### PR TITLE
Remove memory leak from epicsEnvSet() on systems that support setenv()

### DIFF
--- a/src/libCom/osi/os/default/osdEnv.c
+++ b/src/libCom/osi/os/default/osdEnv.c
@@ -34,25 +34,28 @@
  */
 epicsShareFunc void epicsShareAPI epicsEnvSet (const char *name, const char *value)
 {
-    char *cp;
-
+#if defined(_BSD_SOURCE) || (_POSIX_C_SOURCE >= 200112L) || (_XOPEN_SOURCE >= 600)
     iocshEnvClear(name);
-    
-	cp = mallocMustSucceed (strlen (name) + strlen (value) + 2, "epicsEnvSet");
-	strcpy (cp, name);
-	strcat (cp, "=");
-	strcat (cp, value);
-	if (putenv (cp) < 0) {
-		errPrintf(
-                -1L,
-                __FILE__,
-                __LINE__,
-                "Failed to set environment parameter \"%s\" to \"%s\": %s\n",
-                name,
-                value,
-                strerror (errno));
+    setenv (name, value, 1);
+#else
+    char *cp;
+    iocshEnvClear(name);
+    cp = mallocMustSucceed (strlen (name) + strlen (value) + 2, "epicsEnvSet");
+    strcpy (cp, name);
+    strcat (cp, "=");
+    strcat (cp, value);
+    if (putenv (cp) < 0) {
+        errPrintf(
+            -1L,
+            __FILE__,
+            __LINE__,
+            "Failed to set environment parameter \"%s\" to \"%s\": %s\n",
+            name,
+            value,
+            strerror (errno));
         free (cp);
-	}
+    }
+#endif
 }
 
 /*


### PR DESCRIPTION
Example valgrind log showing memory leak, fixed by this patch:

    ==11103== 22 bytes in 1 blocks are definitely lost in loss record 39 of 745
    ==11103==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==11103==    by 0x555886E: mallocMustSucceed (cantProceed.c:43)
    ==11103==    by 0x5562082: epicsEnvSet (osdEnv.c:39)
    ==11103==    by 0x52F4347: iocshRegisterCommon (iocshRegisterCommon.c:40)
    ==11103==    by 0x409462: Registration (ScalerLinux_registerRecordDeviceDriver.cpp:296)
    ==11103==    by 0x409462: __static_initialization_and_destruction_0 (ScalerLinux_registerRecordDeviceDriver.cpp:301)
    ==11103==    by 0x409462: _GLOBAL__sub_I_ScalerLinux_registerRecordDeviceDriver (ScalerLinux_registerRecordDeviceDriver.cpp:301)
    ==11103==    by 0x41123C: __libc_csu_init (in /home/ABTLUS/henrique.almeida/code/ScalerLinux/bin/linux-x86_64/ScalerLinux)
    ==11103==    by 0x617A7BE: (below main) (libc-start.c:247)