### PR TITLE
perl 5.8 compatibility fix

### DIFF
--- a/src/error/makeStatTbl.pl
+++ b/src/error/makeStatTbl.pl
@@ -52,7 +52,7 @@ my (@syms, %vals, %msgs);
 while (<>) {
     chomp;
     next unless m/^ \s* \# \s* define \s+ ([SM]_[A-Za-z0-9_]+)
-        \s++ (.*?) \s* \/ \* \s*+ (.*?) \s* \* \/ \s* $/x;
+        \s+ (.*?) \s* \/ \* \s* (.*?) \s* \* \/ \s* $/x;
     push @syms, $1;
     $vals{$1} = $2;
     $msgs{$1} = $3;


### PR DESCRIPTION
Many of our host machines are running perl 5.8.8 and throw an error for the possesive quantifiers in this regex.
Support for the ++ and *+ possesive quantifiers wasn't added till perl 5.10 and the epics docs still say perl 5.8.1 is the requirement.
They don't appear to be needed in this regex and removing them generated the same errSymTbl.c in my tests.