### PR TITLE
Debugging travis-prepare.sh

### DIFF
--- a/.ci/travis-prepare.sh
+++ b/.ci/travis-prepare.sh
@@ -35,7 +35,7 @@ fi
 install -d "$HOME/configure"
 cd "$HOME/configure"
 
-cat << EOF > RULES_USER
+cat <<'EOF' > RULES_USER
 SHOW_MAKEFILES = $(MAKEFILE_LIST:%=show-makefile.%)
 show-makefiles: $(SHOW_MAKEFILES)
 

--- a/.ci/travis-prepare.sh
+++ b/.ci/travis-prepare.sh
@@ -129,6 +129,15 @@ EOF
   EXTRA=RTEMS_QEMU_FIXUPS=YES
 fi
 
-make -C epics-base $EXTRA
+make -C epics-base configure src
+
+make -C epics-base/modules RELEASE.$EPICS_HOST_ARCH.local
 
 cat epics-base/modules/RELEASE.$EPICS_HOST_ARCH.local
+cat epics-base/modules/CONFIG_SITE.local
+
+ls epics-base/modules/libcom/configure
+cat epics-base/modules/libcom/configure/RELEASE
+
+make -C epics-base/modules/libcom
+

--- a/.ci/travis-prepare.sh
+++ b/.ci/travis-prepare.sh
@@ -71,7 +71,7 @@ git clone --quiet --depth 5 --branch core/"${BRCORE:-master}" https://github.com
 ( cd epics-base && git log -n1 )
 add_base_module libcom "${BRLIBCOM:-master}"
 
-EPICS_HOST_ARCH=`sh epics-base/startup/EpicsHostArch`
+export EPICS_HOST_ARCH=`sh epics-base/startup/EpicsHostArch`
 
 # requires wine and g++-mingw-w64-i686
 if [ "$WINE" = "32" ]

--- a/.ci/travis-prepare.sh
+++ b/.ci/travis-prepare.sh
@@ -129,4 +129,6 @@ EOF
   EXTRA=RTEMS_QEMU_FIXUPS=YES
 fi
 
-make -j2 -C epics-base $EXTRA
+make -C epics-base $EXTRA
+
+cat epics-base/modules/RELEASE.$EPICS_HOST_ARCH.local

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,9 @@ addons:
     - libreadline6-dev
     - libncurses5-dev
     - perl
-    - clang
-    - g++-mingw-w64-i686
 install:
  - ./.ci/travis-prepare.sh
 script:
  - ./.ci/travis-build.sh
 env:
  - BRCORE=master BRLIBCOM=master TEST=NO
- - CMPLR=clang TEST=NO
- - USR_CXXFLAGS=-std=c++11 TEST=NO
- - CMPLR=clang USR_CXXFLAGS=-std=c++11 TEST=NO
- - WINE=32 TEST=NO STATIC=YES
- - WINE=32 TEST=NO STATIC=NO
- - RTEMS=4.10 TEST=NO
- - RTEMS=4.9 TEST=NO


### PR DESCRIPTION
I'm trying to work out why Travis isn't creating the `modules/RELEASE.$EPICS_HOST_ARCH.local` file in its `$HOME/.source/epics-base` tree.

This pull request is for triggering Travis builds only and will not be merged.
