### PR TITLE
Bump NUM_TIME_EVENTS to 599 to allow more unused event numbers for TSE timing

### DIFF
--- a/src/ioc/db/dbScan.c
+++ b/src/ioc/db/dbScan.c
@@ -25,6 +25,7 @@
 #include "dbDefs.h"
 #include "ellLib.h"
 #include "epicsEvent.h"
+#include "epicsGeneralTime.h"
 #include "epicsMutex.h"
 #include "epicsPrint.h"
 #include "epicsRingBytes.h"
@@ -112,7 +113,7 @@ typedef struct event_list {
     struct event_list *next;
     char                event_name[MAX_STRING_SIZE];
 } event_list;
-static event_list * volatile pevent_list[256];
+static event_list * volatile pevent_list[NUM_TIME_EVENTS];
 static epicsMutexId event_lock;
 
 /* IO_EVENT*/
@@ -530,7 +531,7 @@ void post_event(int event)
 {
     event_list* pel;
 
-    if (event <= 0 || event > 255) return;
+    if (event <= 0 || event >= NUM_TIME_EVENTS) return;
     do { /* multithreading: make sure pel is consistent */
         pel = pevent_list[event];
     } while (pel != pevent_list[event]);

--- a/src/libCom/osi/epicsGeneralTime.h
+++ b/src/libCom/osi/epicsGeneralTime.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 
-#define NUM_TIME_EVENTS 256
+#define NUM_TIME_EVENTS 599
 /* Time Events are numbered 0 through (NUM_TIME_EVENTS-1) */
 
 epicsShareFunc void generalTime_Init(void);


### PR DESCRIPTION

Allows Timing Pattern Receiver (TPR) channels to map to event numbers:
 TPR 0: 300-399, TPR 1: 400-499, TPR 2: 500-599