### PR TITLE
Rework module dependency conflict error message for easier debugging.

### DIFF
--- a/src/tools/convertRelease.pl
+++ b/src/tools/convertRelease.pl
@@ -230,11 +230,11 @@ sub checkRelease {
             if (exists $macros{$parent} &&
                 AbsPath($macros{$parent}) ne AbsPath($ppath)) {
                 print "\n" unless ($status);
-                print "Definition of $parent conflicts with $app support.\n";
-                print "In this application a RELEASE file defines\n";
-                print "\t$parent = $macros{$parent}\n";
-                print "but $app at $path defines\n";
-                print "\t$parent = $ppath\n";
+                print "Definition of $parent conflict between this app and $app.\n";
+                print "In this application a RELEASE file\n";
+                print "conflicts with $app at $path\n";
+                print "  This App: $parent = $macros{$parent}\n";
+                print "  $app: $parent = $ppath\n";
                 $status = 1;
             }
         }


### PR DESCRIPTION
Now a simply grep for asyn in the build log will show you line by
line which modules depend on which asyn versions.