### PR TITLE
Fix seg fault when empty string is passed to caget or cainfo

### DIFF
--- a/src/ca/client/tools/caget.c
+++ b/src/ca/client/tools/caget.c
@@ -159,6 +159,8 @@ static int caget (pv *pvs, int nPvs, RequestT request, OutputT format,
 
     for (n = 0; n < nPvs; n++) {
         unsigned long nElems;
+        if ( pvs[n].chid == 0 )
+            continue;
 
                                 /* Set up pvs structure */
                                 /* -------------------- */

--- a/src/ca/client/tools/cainfo.c
+++ b/src/ca/client/tools/cainfo.c
@@ -80,6 +80,8 @@ int cainfo (pv *pvs, int nPvs)
                                 /* Print the status data */
                                 /* --------------------- */
 
+            if ( pvs[n].chid == 0 )
+				continue;
             state   = ca_state(pvs[n].chid);
             nElems  = ca_element_count(pvs[n].chid);
             dbfType = ca_field_type(pvs[n].chid);


### PR DESCRIPTION

Found this via a scripting error.  
From the cmd line you need to use quotes to pass in an empty string.