### PR TITLE
Thread priorities rework

### DIFF
--- a/modules/libcom/src/osi/os/Linux/osdThread.h
+++ b/modules/libcom/src/osi/os/Linux/osdThread.h
@@ -31,7 +31,6 @@ typedef struct epicsThreadOSD {
     epicsEventId       suspendEvent;
     int                isSuspended;
     int                isEpicsThread;
-    int                isRealTimeScheduled;
     int                isOnThreadList;
     unsigned int       osiPriority;
     char               name[1];     /* actually larger */

--- a/modules/libcom/src/osi/os/Linux/osdThread.h
+++ b/modules/libcom/src/osi/os/Linux/osdThread.h
@@ -24,8 +24,6 @@ typedef struct epicsThreadOSD {
     ELLNODE            node;
     pthread_t          tid;
     pid_t              lwpId;
-    struct sched_param schedParam;
-    int                schedPolicy;
     EPICSTHREADFUNC    createFunc;
     void              *createArg;
     epicsEventId       suspendEvent;

--- a/modules/libcom/src/osi/os/Linux/osdThread.h
+++ b/modules/libcom/src/osi/os/Linux/osdThread.h
@@ -24,7 +24,6 @@ typedef struct epicsThreadOSD {
     ELLNODE            node;
     pthread_t          tid;
     pid_t              lwpId;
-    pthread_attr_t     attr;
     struct sched_param schedParam;
     int                schedPolicy;
     EPICSTHREADFUNC    createFunc;

--- a/modules/libcom/src/osi/os/Linux/osdThread.h
+++ b/modules/libcom/src/osi/os/Linux/osdThread.h
@@ -30,7 +30,6 @@ typedef struct epicsThreadOSD {
     void              *createArg;
     epicsEventId       suspendEvent;
     int                isSuspended;
-    int                isEpicsThread;
     int                isOnThreadList;
     unsigned int       osiPriority;
     char               name[1];     /* actually larger */

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -272,19 +272,25 @@ int           low, try;
      * by resource limitations (but that is ignored
      * by sched_get_priority_max() [linux]).
      */
-    low = min;
 
-    while ( low < max ) {
+    low = min + 1;
+
+    /*
+     * At this point, low-1 is known to be a good
+	 * priority. Keep that a loop invariant
+     */
+
+    while ( low <= max ) {
         try = (max+low)/2;
         if ( try_pri(try, prm->policy) ) {
-            max = try;
+            max = try - 1;
         } else {
             low = try + 1;
         }
     }
 
     prm->min_pri = min;
-    prm->max_pri = try_pri(max, prm->policy) ? max-1 : max;
+    prm->max_pri = low - 1;
     prm->ok = 1;
 
     return 0;

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -5,7 +5,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 ITER Organization.
 * EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution. 
+* in file LICENSE that is included with this distribution.
 \*************************************************************************/
 
 /* Author:  Marty Kraimer Date:    18JAN2000 */
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <sched.h>
 #include <unistd.h>
+#include <math.h>
 
 #if defined(_POSIX_MEMLOCK) && _POSIX_MEMLOCK > 0
 #include <sys/mman.h>
@@ -64,7 +65,7 @@ typedef struct commonAttr{
     int                maxPriority;
     int                minPriority;
     int                schedPolicy;
-    int                usePolicy;
+    int                valid;
 } commonAttr;
 
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
@@ -111,19 +112,71 @@ if(status) { \
     exit(-1);\
 }
 
+static int osi2posixPriority(unsigned osiPriority)
+{
+#if defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
+    double maxPriority,minPriority,slope;
+    int    oss;
+
+    if (!pcommonAttr->valid)
+        return 0; /* assume SCHED_OTHER is in effect */
+
+    if(pcommonAttr->maxPriority==pcommonAttr->minPriority)
+        return(pcommonAttr->minPriority);
+
+    maxPriority = (double)pcommonAttr->maxPriority;
+    minPriority = (double)pcommonAttr->minPriority;
+    slope = (double)(maxPriority - minPriority)/(double)(epicsThreadPriorityMax - epicsThreadPriorityMin);
+    oss   = (int)round( (double)(osiPriority - epicsThreadPriorityMin) * slope + minPriority );
+    if ( oss < pcommonAttr->minPriority )
+        oss = pcommonAttr->minPriority;
+    if ( oss > pcommonAttr->maxPriority )
+        oss = pcommonAttr->maxPriority;
+    return oss;
+#else
+    return 0;
+#endif /* _POSIX_THREAD_PRIORITY_SCHEDULING */
+}
+
+static unsigned posix2osiPriority(int posixPriority)
+{
+#if defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
+double   slope, osid;
+unsigned osi;
+
+    if ( ! pcommonAttr->valid )
+        return epicsThreadPriorityMedium;
+
+    if ( pcommonAttr->maxPriority == pcommonAttr->minPriority )
+        return epicsThreadPriorityMedium;
+
+    slope =   (double)(epicsThreadPriorityMax   - epicsThreadPriorityMin)
+            / (double)(pcommonAttr->maxPriority - pcommonAttr->minPriority);
+
+    osid  = round( (double)(posixPriority - pcommonAttr->minPriority) * slope + epicsThreadPriorityMin );
+	if ( osid < (double) epicsThreadPriorityMin ) {
+		/* may be negative! */
+		return epicsThreadPriorityMin;
+	}
+	osi = (unsigned)osid;
+
+    if ( osi > epicsThreadPriorityMax )
+        osi = epicsThreadPriorityMax;
+
+    return osi;
+#else
+    return epicsThreadPriorityMedium;
+#endif
+}
+
 
 epicsShareFunc int epicsThreadGetPosixPriority(epicsThreadId pthreadInfo)
 {
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
-    double maxPriority,minPriority,slope,oss;
+    if (pcommonAttr->schedPolicy != pthreadInfo->schedPolicy)
+        return 0; // assume SCHED_OTHER
 
-    if(pcommonAttr->maxPriority==pcommonAttr->minPriority)
-        return(pcommonAttr->maxPriority);
-    maxPriority = (double)pcommonAttr->maxPriority;
-    minPriority = (double)pcommonAttr->minPriority;
-    slope = (maxPriority - minPriority)/100.0;
-    oss = (double)pthreadInfo->osiPriority * slope + minPriority;
-    return((int)oss);
+    return osi2posixPriority( pthreadInfo->osiPriority );
 #else
     return 0;
 #endif /* _POSIX_THREAD_PRIORITY_SCHEDULING */
@@ -134,13 +187,14 @@ static void setSchedulingPolicy(pthread_attr_t *pattr, epicsThreadOSD *pthreadIn
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
     int status;
 
-    if(!pcommonAttr->usePolicy) return;
+    if(!pcommonAttr->valid) return;
 
     status = pthread_attr_getschedparam(
         pattr,&pthreadInfo->schedParam);
     checkStatusOnce(status,"pthread_attr_getschedparam");
-    pthreadInfo->schedParam.sched_priority = epicsThreadGetPosixPriority(pthreadInfo);
+	/* Must set schedPolicy first because epicsThreadGetPosixPriority inspects it */
     pthreadInfo->schedPolicy = policy;
+    pthreadInfo->schedParam.sched_priority = epicsThreadGetPosixPriority(pthreadInfo);
     status = pthread_attr_setschedpolicy(
         pattr,policy);
     checkStatusOnce(status,"pthread_attr_setschedpolicy");
@@ -187,7 +241,7 @@ int status;
 #endif /*_POSIX_THREAD_ATTR_STACKSIZE*/
     status = pthread_attr_setscope(pattr,PTHREAD_SCOPE_PROCESS);
     if(errVerbose) checkStatusOnce(status,"pthread_attr_setscope");
-	return status;
+    return status;
 }
 
 static void attr_destroy(pthread_attr_t *pattr)
@@ -287,7 +341,7 @@ int           low, try;
 
     /*
      * At this point, low-1 is known to be a good
-	 * priority. Keep that a loop invariant
+     * priority. Keep that a loop invariant
      */
 
     while ( low <= max ) {
@@ -324,7 +378,7 @@ int          status;
 
     a_p->minPriority = arg.min_pri;
     a_p->maxPriority = arg.max_pri;
-    a_p->usePolicy = arg.ok;
+    a_p->valid       = arg.ok;
 }
 #endif
 
@@ -384,6 +438,8 @@ static void once(void)
 
     pthreadInfo = init_threadInfo("_main_",0,0,0);
     assert(pthreadInfo!=NULL);
+    status = pthread_getschedparam(pthread_self(),&pthreadInfo->schedPolicy,&pthreadInfo->schedParam);
+    checkStatusOnceQuit(status,"pthread_getschedparam","epicsThreadInit");
     status = pthread_setspecific(getpthreadInfo,(void *)pthreadInfo);
     checkStatusOnceQuit(status,"pthread_setspecific","epicsThreadInit");
     status = mutexLock(&listLock);
@@ -434,7 +490,7 @@ epicsShareFunc
 void epicsThreadRealtimeLock(void)
 {
 #if defined(_POSIX_MEMLOCK) && _POSIX_MEMLOCK > 0
-    if (pcommonAttr->maxPriority > pcommonAttr->minPriority) {
+    if (pcommonAttr->valid && pcommonAttr->maxPriority > pcommonAttr->minPriority) {
         int status = mlockall(MCL_CURRENT | MCL_FUTURE);
 
         if (status) {
@@ -534,7 +590,7 @@ epicsShareFunc epicsThreadId epicsShareAPI epicsThreadCreate(const char *name,
     epicsThreadOSD *pthreadInfo;
     int status;
     sigset_t blockAllSig, oldSig;
-	pthread_attr_t        attr;
+    pthread_attr_t        attr;
 
     epicsThreadInit();
     assert(pcommonAttr);
@@ -545,10 +601,9 @@ epicsShareFunc epicsThreadId epicsShareAPI epicsThreadCreate(const char *name,
     pthreadInfo->isEpicsThread = 1;
     attr_init( &attr, stackSize );
     setSchedulingPolicy( &attr, pthreadInfo,SCHED_FIFO);
-    pthreadInfo->isRealTimeScheduled = 1;
     status = pthread_create(&pthreadInfo->tid,&attr,
                 start_routine,pthreadInfo);
-	attr_destroy(&attr);
+    attr_destroy(&attr);
     if(status==EPERM){
         /* Try again without SCHED_FIFO*/
         free_threadInfo(pthreadInfo);
@@ -558,7 +613,7 @@ epicsShareFunc epicsThreadId epicsShareAPI epicsThreadCreate(const char *name,
         pthreadInfo->isEpicsThread = 1;
         status = pthread_create(&pthreadInfo->tid,&attr,
                 start_routine,pthreadInfo);
-		attr_destroy(&attr);
+        attr_destroy(&attr);
     }
     checkStatusOnce(status,"pthread_create");
     if(status) {
@@ -588,12 +643,11 @@ static epicsThreadOSD *createImplicit(void)
     pthreadInfo->osiPriority = 0;
 
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
-    {
-    struct sched_param param;
-    int policy;
-    if(pthread_getschedparam(tid,&policy,&param) == 0)
+    status = pthread_getschedparam(tid,&pthreadInfo->schedPolicy,&pthreadInfo->schedParam);
+    checkStatus(status,"pthread_getschedparam createImplicit");
+    if ( 0 == status && pcommonAttr->valid && pcommonAttr->schedPolicy == pthreadInfo->schedPolicy ) {
         pthreadInfo->osiPriority =
-                 (param.sched_priority - pcommonAttr->minPriority) * 100.0 /
+                 (pthreadInfo->schedParam.sched_priority - pcommonAttr->minPriority) * 100.0 /
                     (pcommonAttr->maxPriority - pcommonAttr->minPriority + 1);
     }
 #endif /* _POSIX_THREAD_PRIORITY_SCHEDULING */
@@ -664,15 +718,19 @@ epicsShareFunc void epicsShareAPI epicsThreadSetPriority(epicsThreadId pthreadIn
 
     assert(epicsThreadOnceCalled);
     assert(pthreadInfo);
+    /* T.S.: There is in principle no problem with changing the priority of
+     * a non-EPICS thread -- as long as it uses the same scheduling policy.
+     * For sake of backwards compatibility I leave this test for now but
+     * it could as well be removed (and the 'isEpicsThread' member as well).
+     */
     if(!pthreadInfo->isEpicsThread) {
         fprintf(stderr,"epicsThreadSetPriority called by non epics thread\n");
         return;
     }
     pthreadInfo->osiPriority = priority;
-    if(!pthreadInfo->isRealTimeScheduled) return;
 
 #if defined (_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
-    if(!pcommonAttr->usePolicy) return;
+    if( !pcommonAttr->valid || pcommonAttr->schedPolicy != pthreadInfo->schedPolicy) return;
     pthreadInfo->schedParam.sched_priority = epicsThreadGetPosixPriority(pthreadInfo);
     status = pthread_setschedparam(
         pthreadInfo->tid, pthreadInfo->schedPolicy, &pthreadInfo->schedParam);
@@ -685,12 +743,28 @@ epicsShareFunc epicsThreadBooleanStatus epicsShareAPI epicsThreadHighestPriority
 {
     unsigned newPriority = priority - 1;
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
-    int diff;
-    diff = pcommonAttr->maxPriority - pcommonAttr->minPriority;
-    if(diff<0) diff = -diff;
-    if(diff>1 && diff <100) newPriority -=  100/(diff+1);
+    if ( pcommonAttr->valid ) {
+        int newOss;
+        if ( epicsThreadPriorityMax - epicsThreadPriorityMin > pcommonAttr->maxPriority - pcommonAttr->minPriority ) {
+            newOss = osi2posixPriority( priority ) - 1;
+            if ( newOss < pcommonAttr->minPriority ) {
+                return epicsThreadBooleanStatusFail;
+            }
+        } else {
+            /* test against Max necessary because priorities are unsigned; this discovers wrap-around */
+            if ( newPriority > epicsThreadPriorityMax || newPriority < epicsThreadPriorityMin ) {
+                return epicsThreadBooleanStatusFail;
+            }
+            newOss = osi2posixPriority( newPriority );
+        }
+        newPriority = posix2osiPriority( newOss );
+        if ( newPriority >= priority ) {
+            return epicsThreadBooleanStatusFail;
+        }
+    }
 #endif /* _POSIX_THREAD_PRIORITY_SCHEDULING */
-    if (newPriority <= 99) {
+    /* test against Max necessary because priorities are unsigned; this discovers wrap-around */
+    if ( newPriority <= epicsThreadPriorityMax && newPriority >= epicsThreadPriorityMin ) {
         *pPriorityJustBelow = newPriority;
         return epicsThreadBooleanStatusSuccess;
     }
@@ -701,15 +775,27 @@ epicsShareFunc epicsThreadBooleanStatus epicsShareAPI epicsThreadLowestPriorityL
     unsigned int priority, unsigned *pPriorityJustAbove)
 {
     unsigned newPriority = priority + 1;
-
 #if defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && _POSIX_THREAD_PRIORITY_SCHEDULING > 0
-    int diff;
-    diff = pcommonAttr->maxPriority - pcommonAttr->minPriority;
-    if(diff<0) diff = -diff;
-    if(diff>1 && diff <100) newPriority += 100/(diff+1);
+    if ( pcommonAttr->valid ) {
+        int newOss;
+        if ( epicsThreadPriorityMax - epicsThreadPriorityMin > pcommonAttr->maxPriority - pcommonAttr->minPriority ) {
+            newOss = osi2posixPriority( priority ) + 1;
+            if ( newOss > pcommonAttr->maxPriority ) {
+                return epicsThreadBooleanStatusFail;
+            }
+        } else {
+            if ( newPriority > epicsThreadPriorityMax ) {
+                return epicsThreadBooleanStatusFail;
+            }
+            newOss = osi2posixPriority( newPriority );
+        }
+        newPriority = posix2osiPriority( newOss );
+        if ( newPriority <= priority ) {
+            return epicsThreadBooleanStatusFail;
+        }
+    }
 #endif /* _POSIX_THREAD_PRIORITY_SCHEDULING */
-
-    if (newPriority <= 99) {
+    if ( newPriority <= epicsThreadPriorityMax ) {
         *pPriorityJustAbove = newPriority;
         return epicsThreadBooleanStatusSuccess;
     }

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -154,11 +154,11 @@ unsigned osi;
             / (double)(pcommonAttr->maxPriority - pcommonAttr->minPriority);
 
     osid  = round( (double)(posixPriority - pcommonAttr->minPriority) * slope + epicsThreadPriorityMin );
-	if ( osid < (double) epicsThreadPriorityMin ) {
-		/* may be negative! */
-		return epicsThreadPriorityMin;
-	}
-	osi = (unsigned)osid;
+    if ( osid < (double) epicsThreadPriorityMin ) {
+        /* may be negative! */
+        return epicsThreadPriorityMin;
+    }
+    osi = (unsigned)osid;
 
     if ( osi > epicsThreadPriorityMax )
         osi = epicsThreadPriorityMax;
@@ -192,7 +192,7 @@ static void setSchedulingPolicy(pthread_attr_t *pattr, epicsThreadOSD *pthreadIn
     status = pthread_attr_getschedparam(
         pattr,&pthreadInfo->schedParam);
     checkStatusOnce(status,"pthread_attr_getschedparam");
-	/* Must set schedPolicy first because epicsThreadGetPosixPriority inspects it */
+    /* Must set schedPolicy first because epicsThreadGetPosixPriority inspects it */
     pthreadInfo->schedPolicy = policy;
     pthreadInfo->schedParam.sched_priority = epicsThreadGetPosixPriority(pthreadInfo);
     status = pthread_attr_setschedpolicy(

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -137,8 +137,8 @@ static int osi2posixPriority(unsigned osiPriority)
 
 static unsigned posix2osiPriority(int posixPriority)
 {
-double   slope, osid;
-unsigned osi;
+    double   slope, osid;
+    unsigned osi;
 
     if ( ! pcommonAttr->valid )
         return epicsThreadPriorityMedium;
@@ -220,7 +220,7 @@ static epicsThreadOSD * create_threadInfo(const char *name)
 
 static int attr_init(pthread_attr_t *pattr, size_t stackSize)
 {
-int status;
+    int status;
 
     status = pthread_attr_init(pattr);
     checkStatusOnce(status,"pthread_attr_init");
@@ -240,7 +240,7 @@ int status;
 
 static void attr_destroy(pthread_attr_t *pattr)
 {
-int status;
+    int status;
     status = pthread_attr_destroy(pattr);
     checkStatusQuit(status,"pthread_attr_destroy","free_threadInfo");
 }
@@ -283,7 +283,7 @@ static void free_threadInfo(epicsThreadOSD *pthreadInfo)
 
 static int try_pri(int pri, int policy)
 {
-struct sched_param  schedp;
+    struct sched_param  schedp;
 
     schedp.sched_priority = pri;
     return pthread_setschedparam(pthread_self(), policy, &schedp);
@@ -292,10 +292,10 @@ struct sched_param  schedp;
 static void*
 find_pri_range(void *arg)
 {
-priAvailable *prm = arg;
-int           min = sched_get_priority_min(prm->policy);
-int           max = sched_get_priority_max(prm->policy);
-int           low, try;
+    priAvailable *prm = arg;
+    int           min = sched_get_priority_min(prm->policy);
+    int           max = sched_get_priority_max(prm->policy);
+    int           low, try;
 
     if ( -1 == min || -1 == max ) {
         /* something is very wrong; maintain old behavior
@@ -356,10 +356,10 @@ int           low, try;
 
 static void findPriorityRange(commonAttr *a_p)
 {
-priAvailable arg;
-pthread_t    id;
-void         *dummy;
-int          status;
+    priAvailable arg;
+    pthread_t    id;
+    void         *dummy;
+    int          status;
 
     arg.policy = a_p->schedPolicy;
     arg.ok = 0;

--- a/modules/libcom/src/osi/os/posix/osdThread.h
+++ b/modules/libcom/src/osi/os/posix/osdThread.h
@@ -23,8 +23,6 @@ extern "C" {
 typedef struct epicsThreadOSD {
     ELLNODE            node;
     pthread_t          tid;
-    struct sched_param schedParam;
-    int                schedPolicy;
     EPICSTHREADFUNC    createFunc;
     void              *createArg;
     epicsEventId       suspendEvent;

--- a/modules/libcom/src/osi/os/posix/osdThread.h
+++ b/modules/libcom/src/osi/os/posix/osdThread.h
@@ -30,7 +30,6 @@ typedef struct epicsThreadOSD {
     epicsEventId       suspendEvent;
     int                isSuspended;
     int                isEpicsThread;
-    int                isRealTimeScheduled;
     int                isOnThreadList;
     unsigned int       osiPriority;
     char               name[1];     /* actually larger */

--- a/modules/libcom/src/osi/os/posix/osdThread.h
+++ b/modules/libcom/src/osi/os/posix/osdThread.h
@@ -23,7 +23,6 @@ extern "C" {
 typedef struct epicsThreadOSD {
     ELLNODE            node;
     pthread_t          tid;
-    pthread_attr_t     attr;
     struct sched_param schedParam;
     int                schedPolicy;
     EPICSTHREADFUNC    createFunc;

--- a/modules/libcom/src/osi/os/posix/osdThread.h
+++ b/modules/libcom/src/osi/os/posix/osdThread.h
@@ -29,7 +29,6 @@ typedef struct epicsThreadOSD {
     void              *createArg;
     epicsEventId       suspendEvent;
     int                isSuspended;
-    int                isEpicsThread;
     int                isOnThreadList;
     unsigned int       osiPriority;
     char               name[1];     /* actually larger */

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -288,9 +288,6 @@ TESTPROD_HOST += cvtFastPerform
 cvtFastPerform_SRCS += cvtFastPerform.cpp
 testHarness_SRCS += cvtFastPerform.cpp
 
-THREAD_CPPFLAGS_NO += -DDONT_USE_POSIX_THREAD_PRIORITY_SCHEDULING
-nonEpicsThreadPriorityTest_CPPFLAGS += $(THREAD_CPPFLAGS_$(USE_POSIX_THREAD_PRIORITY_SCHEDULING))
-
 ifeq ($(POSIX),YES)
 ifeq ($(USE_POSIX_THREAD_PRIORITY_SCHEDULING),YES)
 TESTPROD_HOST += nonEpicsThreadPriorityTest

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -291,7 +291,7 @@ testHarness_SRCS += cvtFastPerform.cpp
 THREAD_CPPFLAGS_NO += -DDONT_USE_POSIX_THREAD_PRIORITY_SCHEDULING
 nonEpicsThreadPriorityTest_CPPFLAGS += $(THREAD_CPPFLAGS_$(USE_POSIX_THREAD_PRIORITY_SCHEDULING))
 
-TESTPROD_Linux += nonEpicsThreadPriorityTest
+TESTPROD_HOST += nonEpicsThreadPriorityTest
 nonEpicsThreadPriorityTest_SRCS += nonEpicsThreadPriorityTest.cpp
 testHarness_SRCS += nonEpicsThreadPriorityTest.cpp
 TESTS += nonEpicsThreadPriorityTest

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -288,4 +288,9 @@ TESTPROD_HOST += cvtFastPerform
 cvtFastPerform_SRCS += cvtFastPerform.cpp
 testHarness_SRCS += cvtFastPerform.cpp
 
+TESTPROD_HOST += nonEpicsThreadPriorityTest
+nonEpicsThreadPriorityTest_SRCS += nonEpicsThreadPriorityTest.cpp
+nonEpicsThreadPriorityTest_LIBS += Com
+nonEpicsThreadPriorityTest_SYS_LIBS += pthread rt
+
 include $(TOP)/configure/RULES

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -288,9 +288,10 @@ TESTPROD_HOST += cvtFastPerform
 cvtFastPerform_SRCS += cvtFastPerform.cpp
 testHarness_SRCS += cvtFastPerform.cpp
 
-TESTPROD_HOST += nonEpicsThreadPriorityTest
+TESTPROD_Linux += nonEpicsThreadPriorityTest
 nonEpicsThreadPriorityTest_SRCS += nonEpicsThreadPriorityTest.cpp
 nonEpicsThreadPriorityTest_LIBS += Com
 nonEpicsThreadPriorityTest_SYS_LIBS += pthread rt
+TESTS += nonEpicsThreadPriorityTest
 
 include $(TOP)/configure/RULES

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -288,10 +288,12 @@ TESTPROD_HOST += cvtFastPerform
 cvtFastPerform_SRCS += cvtFastPerform.cpp
 testHarness_SRCS += cvtFastPerform.cpp
 
+THREAD_CPPFLAGS_NO += -DDONT_USE_POSIX_THREAD_PRIORITY_SCHEDULING
+nonEpicsThreadPriorityTest_CPPFLAGS += $(THREAD_CPPFLAGS_$(USE_POSIX_THREAD_PRIORITY_SCHEDULING))
+
 TESTPROD_Linux += nonEpicsThreadPriorityTest
 nonEpicsThreadPriorityTest_SRCS += nonEpicsThreadPriorityTest.cpp
-nonEpicsThreadPriorityTest_LIBS += Com
-nonEpicsThreadPriorityTest_SYS_LIBS += pthread rt
+testHarness_SRCS += nonEpicsThreadPriorityTest.cpp
 TESTS += nonEpicsThreadPriorityTest
 
 include $(TOP)/configure/RULES

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -292,6 +292,7 @@ ifeq ($(POSIX),YES)
 ifeq ($(USE_POSIX_THREAD_PRIORITY_SCHEDULING),YES)
 TESTPROD_HOST += nonEpicsThreadPriorityTest
 nonEpicsThreadPriorityTest_SRCS += nonEpicsThreadPriorityTest.cpp
+nonEpicsThreadPriorityTest_SYS_LIBS += pthread rt
 testHarness_SRCS += nonEpicsThreadPriorityTest.cpp
 epicsRunLibComTests_CFLAGS += -DHAVE_PTHREAD_PRIORITY_SCHEDULING
 TESTS += nonEpicsThreadPriorityTest

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -291,9 +291,14 @@ testHarness_SRCS += cvtFastPerform.cpp
 THREAD_CPPFLAGS_NO += -DDONT_USE_POSIX_THREAD_PRIORITY_SCHEDULING
 nonEpicsThreadPriorityTest_CPPFLAGS += $(THREAD_CPPFLAGS_$(USE_POSIX_THREAD_PRIORITY_SCHEDULING))
 
+ifeq ($(POSIX),YES)
+ifeq ($(USE_POSIX_THREAD_PRIORITY_SCHEDULING),YES)
 TESTPROD_HOST += nonEpicsThreadPriorityTest
 nonEpicsThreadPriorityTest_SRCS += nonEpicsThreadPriorityTest.cpp
 testHarness_SRCS += nonEpicsThreadPriorityTest.cpp
+epicsRunLibComTests_CFLAGS += -DHAVE_PTHREAD_PRIORITY_SCHEDULING
 TESTS += nonEpicsThreadPriorityTest
+endif
+endif
 
 include $(TOP)/configure/RULES

--- a/modules/libcom/test/epicsRunLibComTests.c
+++ b/modules/libcom/test/epicsRunLibComTests.c
@@ -52,6 +52,7 @@ int epicsInlineTest(void);
 int ipAddrToAsciiTest(void);
 int macDefExpandTest(void);
 int macLibTest(void);
+int nonEpicsThreadPriorityTest(void);
 int osiSockTest(void);
 int ringBytesTest(void);
 int ringPointerTest(void);
@@ -107,6 +108,7 @@ void epicsRunLibComTests(void)
     runTest(ipAddrToAsciiTest);
     runTest(macDefExpandTest);
     runTest(macLibTest);
+    runTest(nonEpicsThreadPriorityTest);
     runTest(osiSockTest);
     runTest(ringBytesTest);
     runTest(ringPointerTest);

--- a/modules/libcom/test/epicsRunLibComTests.c
+++ b/modules/libcom/test/epicsRunLibComTests.c
@@ -52,7 +52,9 @@ int epicsInlineTest(void);
 int ipAddrToAsciiTest(void);
 int macDefExpandTest(void);
 int macLibTest(void);
+#ifdef HAVE_PTHREAD_PRIORITY_SCHEDULING
 int nonEpicsThreadPriorityTest(void);
+#endif
 int osiSockTest(void);
 int ringBytesTest(void);
 int ringPointerTest(void);
@@ -108,7 +110,9 @@ void epicsRunLibComTests(void)
     runTest(ipAddrToAsciiTest);
     runTest(macDefExpandTest);
     runTest(macLibTest);
+#ifdef HAVE_PTHREAD_PRIORITY_SCHEDULING
     runTest(nonEpicsThreadPriorityTest);
+#endif
     runTest(osiSockTest);
     runTest(ringBytesTest);
     runTest(ringPointerTest);

--- a/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
+++ b/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
@@ -1,13 +1,25 @@
-#include <pthread.h>
 #include <epicsThread.h>
 #include "epicsUnitTest.h"
 #include "testMain.h"
 #include <stdio.h>
 #include <string.h>
 
+#if defined(DONT_USE_POSIX_THREAD_PRIORITY_SCHEDULING) || \
+   !defined(_POSIX_THREAD_PRIORITY_SCHEDULING)         || \
+   (_POSIX_THREAD_PRIORITY_SCHEDULING <= 0)
+
+MAIN(nonEpicsThreadPriorityTest)
+{
+    testPlan(1);
+    testSkip(1, "Not using POSIX RT-scheduler");
+    return testDone();
+}
+
+#else
+
 static void *nonEpicsTestFunc(void *arg)
 {
-unsigned int pri;
+    unsigned int pri;
     // epicsThreadGetIdSelf()  creates an EPICS context
     // verify that the priority computed by epics context
     // is OK
@@ -22,13 +34,13 @@ unsigned int pri;
 
 static void testFunc(void *arg)
 {
-epicsEventId        ev = (epicsEventId)arg;
-int                 policy;
-struct sched_param  param;
-int                 status;
-pthread_t           tid;
-void               *rval;
-pthread_attr_t      attr;
+    epicsEventId        ev = (epicsEventId)arg;
+    int                 policy;
+    struct sched_param  param;
+    int                 status;
+    pthread_t           tid;
+    void               *rval;
+    pthread_attr_t      attr;
 
     status = pthread_getschedparam(pthread_self(), &policy,&param);
     if ( status ) {
@@ -76,7 +88,7 @@ done:
 
 MAIN(nonEpicsThreadPriorityTest)
 {
-unsigned int pri;
+    unsigned int pri;
     testPlan(4);
     epicsEventId testComplete = epicsEventMustCreate(epicsEventEmpty);
     epicsThreadMustCreate("nonEpicsThreadPriorityTest", epicsThreadPriorityLow,
@@ -93,6 +105,7 @@ unsigned int pri;
         testFail("epicsThreadLowestPriorityLevelAbove failed");
     }
     testOk(48 == pri, "epicsThreadLowestPriorityLevelAbove(47) = %d (!= 48)", pri);
- return testDone();
+    return testDone();
 }
 
+#endif

--- a/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
+++ b/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
@@ -8,15 +8,15 @@
 static void *nonEpicsTestFunc(void *arg)
 {
 unsigned int pri;
-	// epicsThreadGetIdSelf()  creates an EPICS context
-	// verify that the priority computed by epics context
-	// is OK
-	pri = epicsThreadGetPriority( epicsThreadGetIdSelf() );
-	if ( ! testOk( 0 == pri, "'createImplicit' assigned correct priority (%d) to non-EPICS thread", pri) ) {
-		return 0;
-	}
+    // epicsThreadGetIdSelf()  creates an EPICS context
+    // verify that the priority computed by epics context
+    // is OK
+    pri = epicsThreadGetPriority( epicsThreadGetIdSelf() );
+    if ( ! testOk( 0 == pri, "'createImplicit' assigned correct priority (%d) to non-EPICS thread", pri) ) {
+        return 0;
+    }
 
-	return (void*)1;
+    return (void*)1;
 }
 
 
@@ -36,42 +36,42 @@ pthread_attr_t      attr;
         goto done;
     }
 
-	if ( SCHED_FIFO != policy ) {
-		testSkip(1, "nonEpicsThreadPriorityTest must be executed with privileges to use SCHED_FIFO");
-		goto done;
-	}
+    if ( SCHED_FIFO != policy ) {
+        testSkip(1, "nonEpicsThreadPriorityTest must be executed with privileges to use SCHED_FIFO");
+        goto done;
+    }
 
-	if ( pthread_attr_init( &attr ) ) {
-		testSkip(1, "pthread_attr_init failed");
-		goto done;
-	}
+    if ( pthread_attr_init( &attr ) ) {
+        testSkip(1, "pthread_attr_init failed");
+        goto done;
+    }
     if ( pthread_attr_setinheritsched( &attr, PTHREAD_EXPLICIT_SCHED ) ) {
-		testSkip(1, "pthread_attr_setinheritsched failed");
-		goto done;
-	}
+        testSkip(1, "pthread_attr_setinheritsched failed");
+        goto done;
+    }
     if ( pthread_attr_setschedpolicy ( &attr, SCHED_OTHER            ) ) {
-		testSkip(1, "pthread_attr_setschedpolicy failed");
-		goto done;
-	}
-	param.sched_priority = 0;
+        testSkip(1, "pthread_attr_setschedpolicy failed");
+        goto done;
+    }
+    param.sched_priority = 0;
     if ( pthread_attr_setschedparam  ( &attr, &param                 ) ) {
-		testSkip(1, "pthread_attr_setschedparam failed");
-		goto done;
-	}
+        testSkip(1, "pthread_attr_setschedparam failed");
+        goto done;
+    }
 
-	if ( pthread_create( &tid, &attr, nonEpicsTestFunc, 0 ) ) {
-		testSkip(1, "pthread_create failed");
-		goto done;
-	}
+    if ( pthread_create( &tid, &attr, nonEpicsTestFunc, 0 ) ) {
+        testSkip(1, "pthread_create failed");
+        goto done;
+    }
 
-	if ( pthread_join( tid, &rval ) ) {
-		testSkip(1, "pthread_join failed");
-		goto done;
-	}
+    if ( pthread_join( tid, &rval ) ) {
+        testSkip(1, "pthread_join failed");
+        goto done;
+    }
 
 done:
 
-	epicsEventSignal( ev );
+    epicsEventSignal( ev );
 }
 
 MAIN(nonEpicsThreadPriorityTest)
@@ -85,14 +85,14 @@ unsigned int pri;
     epicsEventWaitStatus status = epicsEventWait(testComplete);
     testOk(status == epicsEventWaitOK,
         "epicsEventWait returned %d", status);
-	if ( epicsThreadBooleanStatusSuccess != epicsThreadHighestPriorityLevelBelow(48, &pri) ) {
-		testFail("epicsThreadHighestPriorityLevelBelow failed");
-	}
-	testOk(47 == pri, "epicsThreadHighestPriorityLevelBelow(48) = %d (!= 47)", pri);
+    if ( epicsThreadBooleanStatusSuccess != epicsThreadHighestPriorityLevelBelow(48, &pri) ) {
+        testFail("epicsThreadHighestPriorityLevelBelow failed");
+    }
+    testOk(47 == pri, "epicsThreadHighestPriorityLevelBelow(48) = %d (!= 47)", pri);
    	if ( epicsThreadBooleanStatusSuccess != epicsThreadLowestPriorityLevelAbove(47, &pri) ) {
-		testFail("epicsThreadLowestPriorityLevelAbove failed");
-	}
-	testOk(48 == pri, "epicsThreadLowestPriorityLevelAbove(47) = %d (!= 48)", pri);
+        testFail("epicsThreadLowestPriorityLevelAbove failed");
+    }
+    testOk(48 == pri, "epicsThreadLowestPriorityLevelAbove(47) = %d (!= 48)", pri);
  return testDone();
 }
 

--- a/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
+++ b/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
@@ -1,0 +1,98 @@
+#include <pthread.h>
+#include <epicsThread.h>
+#include "epicsUnitTest.h"
+#include "testMain.h"
+#include <stdio.h>
+#include <string.h>
+
+static void *nonEpicsTestFunc(void *arg)
+{
+unsigned int pri;
+	// epicsThreadGetIdSelf()  creates an EPICS context
+	// verify that the priority computed by epics context
+	// is OK
+	pri = epicsThreadGetPriority( epicsThreadGetIdSelf() );
+	if ( ! testOk( 0 == pri, "'createImplicit' assigned correct priority (%d) to non-EPICS thread", pri) ) {
+		return 0;
+	}
+
+	return (void*)1;
+}
+
+
+static void testFunc(void *arg)
+{
+epicsEventId        ev = (epicsEventId)arg;
+int                 policy;
+struct sched_param  param;
+int                 status;
+pthread_t           tid;
+void               *rval;
+pthread_attr_t      attr;
+
+    status = pthread_getschedparam(pthread_self(), &policy,&param);
+    if ( status ) {
+        testSkip(1, "pthread_getschedparam failed");
+        goto done;
+    }
+
+	if ( SCHED_FIFO != policy ) {
+		testSkip(1, "nonEpicsThreadPriorityTest must be executed with privileges to use SCHED_FIFO");
+		goto done;
+	}
+
+	if ( pthread_attr_init( &attr ) ) {
+		testSkip(1, "pthread_attr_init failed");
+		goto done;
+	}
+    if ( pthread_attr_setinheritsched( &attr, PTHREAD_EXPLICIT_SCHED ) ) {
+		testSkip(1, "pthread_attr_setinheritsched failed");
+		goto done;
+	}
+    if ( pthread_attr_setschedpolicy ( &attr, SCHED_OTHER            ) ) {
+		testSkip(1, "pthread_attr_setschedpolicy failed");
+		goto done;
+	}
+	param.sched_priority = 0;
+    if ( pthread_attr_setschedparam  ( &attr, &param                 ) ) {
+		testSkip(1, "pthread_attr_setschedparam failed");
+		goto done;
+	}
+
+	if ( pthread_create( &tid, &attr, nonEpicsTestFunc, 0 ) ) {
+		testSkip(1, "pthread_create failed");
+		goto done;
+	}
+
+	if ( pthread_join( tid, &rval ) ) {
+		testSkip(1, "pthread_join failed");
+		goto done;
+	}
+
+done:
+
+	epicsEventSignal( ev );
+}
+
+MAIN(nonEpicsThreadPriorityTest)
+{
+unsigned int pri;
+    testPlan(4);
+    epicsEventId testComplete = epicsEventMustCreate(epicsEventEmpty);
+    epicsThreadMustCreate("nonEpicsThreadPriorityTest", epicsThreadPriorityLow,
+        epicsThreadGetStackSize(epicsThreadStackMedium),
+        testFunc, testComplete);
+    epicsEventWaitStatus status = epicsEventWait(testComplete);
+    testOk(status == epicsEventWaitOK,
+        "epicsEventWait returned %d", status);
+	if ( epicsThreadBooleanStatusSuccess != epicsThreadHighestPriorityLevelBelow(48, &pri) ) {
+		testFail("epicsThreadHighestPriorityLevelBelow failed");
+	}
+	testOk(47 == pri, "epicsThreadHighestPriorityLevelBelow(48) = %d (!= 47)", pri);
+   	if ( epicsThreadBooleanStatusSuccess != epicsThreadLowestPriorityLevelAbove(47, &pri) ) {
+		testFail("epicsThreadLowestPriorityLevelAbove failed");
+	}
+	testOk(48 == pri, "epicsThreadLowestPriorityLevelAbove(47) = %d (!= 48)", pri);
+ return testDone();
+}
+

--- a/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
+++ b/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
@@ -99,11 +99,11 @@ MAIN(nonEpicsThreadPriorityTest)
     if ( epicsThreadBooleanStatusSuccess != epicsThreadHighestPriorityLevelBelow(48, &pri) ) {
         testFail("epicsThreadHighestPriorityLevelBelow failed");
     }
-    testOk(47 == pri, "epicsThreadHighestPriorityLevelBelow(48) = %d (!= 47)", pri);
+    testOk(47 == pri, "epicsThreadHighestPriorityLevelBelow(48) = %d (expected: 47)", pri);
    	if ( epicsThreadBooleanStatusSuccess != epicsThreadLowestPriorityLevelAbove(47, &pri) ) {
         testFail("epicsThreadLowestPriorityLevelAbove failed");
     }
-    testOk(48 == pri, "epicsThreadLowestPriorityLevelAbove(47) = %d (!= 48)", pri);
+    testOk(48 == pri, "epicsThreadLowestPriorityLevelAbove(47) = %d (expected: 48)", pri);
     return testDone();
 }
 

--- a/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
+++ b/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
@@ -4,16 +4,10 @@
 #include <stdio.h>
 #include <string.h>
 
-#if defined(DONT_USE_POSIX_THREAD_PRIORITY_SCHEDULING) || \
-   !defined(_POSIX_THREAD_PRIORITY_SCHEDULING)         || \
+#if !defined(_POSIX_THREAD_PRIORITY_SCHEDULING)         || \
    (_POSIX_THREAD_PRIORITY_SCHEDULING <= 0)
 
-MAIN(nonEpicsThreadPriorityTest)
-{
-    testPlan(1);
-    testSkip(1, "Not using POSIX RT-scheduler");
-    return testDone();
-}
+#error "Should not try to build this test!"
 
 #else
 

--- a/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
+++ b/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
@@ -4,13 +4,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#if !defined(_POSIX_THREAD_PRIORITY_SCHEDULING)         || \
-   (_POSIX_THREAD_PRIORITY_SCHEDULING <= 0)
-
-#error "Should not try to build this test!"
-
-#else
-
 static void *nonEpicsTestFunc(void *arg)
 {
     unsigned int pri;
@@ -101,5 +94,3 @@ MAIN(nonEpicsThreadPriorityTest)
     testOk(48 == pri, "epicsThreadLowestPriorityLevelAbove(47) = %d (!= 48)", pri);
     return testDone();
 }
-
-#endif


### PR DESCRIPTION
I added recent modifications by Heinz Junkes to my original patch (in essence: remove the 'isEpicsThread' member as proposed earlier).