### PR TITLE
DB include w/ macros

### DIFF
--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -273,11 +273,9 @@ YACCOPT ?= $($*_YACCOPT)
 # are creating it
 #
 %.c: %.y
-	@$(RM) $*.tab.c
-	@$(RM) $*.tab.h
+	@$(RM) $*.c
+	@$(RM) $*.h
 	$(YACC) -b$* $(YACCOPT) $<
-	$(MV) $*.tab.c $*.c
-	$(if $(findstring -d, $(YACCOPT)),$(MV) $*.tab.h $*.h,)
 
 # must be a separate rule since when not using '-d' the
 # prefix for .h will be different then .c

--- a/modules/database/src/ioc/dbStatic/RULES
+++ b/modules/database/src/ioc/dbStatic/RULES
@@ -11,3 +11,11 @@
 
 # dbLexRoutines.c is included in dbYacc.c
 dbYacc.c: dbLex.c $(IOCDIR)/dbStatic/dbLexRoutines.c
+
+# Parser debugging hints:
+# set dbStaticDebug global (in dbStaticLib.c)
+# Emit dbYacc.output with parser state info
+#dbYacc_YACCOPT = -v
+# Enable conditional debug prints.
+# at runtime set $YYDEBUG=9
+#dbYacc_CPPFLAGS = -DYYDEBUG

--- a/modules/database/src/ioc/dbStatic/dbYacc.y
+++ b/modules/database/src/ioc/dbStatic/dbYacc.y
@@ -62,11 +62,24 @@ database_item:  include
     |   alias
     ;
 
-include:    tokenINCLUDE tokenSTRING
+include:    tokenINCLUDE tokenSTRING include_mac_list
 {
-    if(dbStaticDebug>2) printf("include : %s\n",$2);
+    if(dbStaticDebug>2) printf("including : %s\n",$2);
     dbIncludeNew($2); dbmfFree($2);
-};
+}
+    | tokenINCLUDE '(' tokenSTRING include_mac_list ')'
+{
+    if(dbStaticDebug>2) printf("including : %s\n",$3);
+    dbIncludeNew($3); dbmfFree($3);
+}
+    ;
+
+include_mac_list: /* empty */
+    | include_mac_list ',' tokenSTRING
+{
+    if(dbStaticDebug>2) printf("  with %s\n",$3);
+    dbIncludeMacro($3); dbmfFree($3);
+}
 
 path:   tokenPATH tokenSTRING
 {

--- a/modules/libcom/src/flex/flex.skel
+++ b/modules/libcom/src/flex/flex.skel
@@ -89,7 +89,9 @@ void free( void* );
         while ( 0 )
 
 /* default yywrap function - always treat EOF as an EOF */
-#define yywrap() 1
+#ifndef yywrap
+#  define yywrap() 1
+#endif
 
 /* enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less

--- a/modules/libcom/src/flex/flex.skel.static
+++ b/modules/libcom/src/flex/flex.skel.static
@@ -749,6 +749,7 @@ static void yy_init_buffer( YY_BUFFER_STATE b, FILE *file )
 static int yyterminate_internal( void )
 {
         /* jbk fix - buffer created by yy_create_buffer needs to be freed */
+    if(yy_current_buffer)
         yy_delete_buffer(yy_current_buffer);
         yy_current_buffer=NULL;
         return YY_NULL;

--- a/modules/libcom/src/flex/flex.skel.static
+++ b/modules/libcom/src/flex/flex.skel.static
@@ -68,7 +68,9 @@ static int yyterminate_internal( void );
         while ( 0 )
 
 /* default yywrap function - always treat EOF as an EOF */
-#define yywrap() 1
+#ifndef yywrap
+#  define yywrap() 1
+#endif
 
 /* enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less

--- a/modules/libcom/src/yacc/defs.h
+++ b/modules/libcom/src/yacc/defs.h
@@ -46,8 +46,8 @@
 /* defines for constructing filenames */
 
 #define CODE_SUFFIX     ".code.c"
-#define DEFINES_SUFFIX  ".tab.h"
-#define OUTPUT_SUFFIX   ".tab.c"
+#define DEFINES_SUFFIX  ".h"
+#define OUTPUT_SUFFIX   ".c"
 #define VERBOSE_SUFFIX  ".output"
 
 


### PR DESCRIPTION
An idea I'm trying out.  Partly an excuse for cleanup in the DBD parser code.  Enables a .db files include w/o additional macro (re)definitions.  A sort of hierarchical alternative to MSI.

```
include "other.db"   # current syntax
include("other.db")
include("other.db", "MAC=one")
include("other.db", "MAC=two,OTHER=foo")
include("other.db", "MAC=two", "OTHER=foo")
```

This PR also closes a corner case bug in the parser which requires that an include be at the end of a line (through re-use of line buffer and parser state).  eg.

```
include "other.db" record(ai, "x") {
```

Currently fails to parse with the rather contradictory error

```
Error: syntax error
 at or before "record" in path "."  file "other.db" line 1
```

Where the "record" in question is actually the remainder of the line in the enclosing .db file.