### PR TITLE
Fix event record device support with constant INP

### DIFF
--- a/src/std/rec/eventRecord.c
+++ b/src/std/rec/eventRecord.c
@@ -106,10 +106,11 @@ static long init_record(eventRecord *prec, int pass)
 	recGblInitConstantLink(&prec->siol,DBF_STRING,&prec->sval);
     }
 
-    prec->epvt = eventNameToHandle(prec->val);
-
     if( (pdset=(struct eventdset *)(prec->dset)) && (pdset->init_record) ) 
 		status=(*pdset->init_record)(prec);
+
+    prec->epvt = eventNameToHandle(prec->val);
+
     return(status);
 }
 


### PR DESCRIPTION
This fix apply to event record device with constant INP.
Now when the event record is processed the associated records with the
same SCAN setup get triggered correctly, it is not more necessary to set
VAL on event record.

Fixes lp: #1829770