### PR TITLE
Add "extern C" for many C headers

### DIFF
--- a/modules/database/src/ioc/db/dbLockPvt.h
+++ b/modules/database/src/ioc/db/dbLockPvt.h
@@ -86,6 +86,10 @@ struct dbLocker {
     lockRecordRef refs[DBLOCKER_NALLOC]; /* actual length is maxrefs */
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* These are exported for testing only */
 epicsShareFunc lockSet* dbLockGetRef(lockRecord *lr); /* lookup lockset and increment ref count */
 epicsShareFunc void dbLockIncRef(lockSet* ls);
@@ -106,5 +110,9 @@ void dbLockSetMerge(struct dbLocker *locker,
 void dbLockSetSplit(struct dbLocker *locker,
                     struct dbCommon *psource,
                     struct dbCommon *psecond);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* DBLOCKPVT_H */

--- a/modules/database/src/ioc/rsrv/server.h
+++ b/modules/database/src/ioc/rsrv/server.h
@@ -223,6 +223,10 @@ GLBLTYPE unsigned int       threadPrios[5];
 #define LOCK_CLIENTQ    epicsMutexMustLock (clientQlock);
 #define UNLOCK_CLIENTQ  epicsMutexUnlock (clientQlock);
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void camsgtask (void *client);
 void cas_send_bs_msg ( struct client *pclient, int lock_needed );
 void cas_send_dg_msg ( struct client *pclient );
@@ -258,5 +262,9 @@ int cas_copy_in_header (
 void cas_set_header_cid ( struct client *pClient, ca_uint32_t );
 void cas_set_header_count (struct client *pClient, ca_uint32_t count);
 void cas_commit_msg ( struct client *pClient, ca_uint32_t size );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*INCLserverh*/

--- a/modules/libcom/RTEMS/epicsMemFs.h
+++ b/modules/libcom/RTEMS/epicsMemFs.h
@@ -19,6 +19,14 @@ typedef struct {
     const epicsMemFile * const *files;
 } epicsMemFS;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int epicsMemFsLoad(const epicsMemFS *fs);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // EPICSMEMFS_H

--- a/modules/libcom/RTEMS/epicsRtemsInitHooks.h
+++ b/modules/libcom/RTEMS/epicsRtemsInitHooks.h
@@ -16,6 +16,10 @@ extern char *env_nfsServer;
 extern char *env_nfsPath;
 extern char *env_nfsMountPoint;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Return 0 for success, non-zero for failure (will cause panic)
  */
@@ -23,3 +27,8 @@ int epicsRtemsInitPreSetBootConfigFromNVRAM(struct rtems_bsdnet_config *config);
 int epicsRtemsInitPostSetBootConfigFromNVRAM(struct rtems_bsdnet_config *config);
 /* Return 0 if local file system was setup, or non-zero (will fall back to network */
 int epicsRtemsMountLocalFilesystem(char **argv);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/modules/libcom/src/osi/os/RTEMS/osdVME.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdVME.h
@@ -19,4 +19,12 @@
 #endif
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void bcopyLongs(char *source, char *destination, int nlongs);
+
+#ifdef __cplusplus
+}
+#endif

--- a/modules/libcom/src/osi/os/WIN32/osdSock.h
+++ b/modules/libcom/src/osi/os/WIN32/osdSock.h
@@ -75,6 +75,14 @@ typedef DWORD osiSockOptMcastTTL_t;
  */
 #define FD_IN_FDSET(FD) (1)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 epicsShareFunc unsigned epicsShareAPI wsaMajorVersion ();
+
+#ifdef __cplusplus
+}
+#endif /*__cplusplus*/
 
 #endif /*osdSockH*/

--- a/modules/libcom/src/osi/os/vxWorks/camacLib.h
+++ b/modules/libcom/src/osi/os/vxWorks/camacLib.h
@@ -32,6 +32,9 @@ extern	struct	glob_dat {
 /********************************/
 /* FUNCTION PROTOTYPES		*/
 /********************************/
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 void	cdreg(int *ext, int b, int c, int n, int a);
 void	cfsa(int f, int ext, int *dat, int *q);
@@ -55,3 +58,6 @@ void	csubc(int f, int ext, unsigned short *intc, int cb[4]);
 void	csubr(int f, int ext, int intc[], int cb[4]);
 void	print_reg(int ext);
 
+#ifdef __cplusplus
+}
+#endif

--- a/modules/libcom/src/pool/poolPriv.h
+++ b/modules/libcom/src/pool/poolPriv.h
@@ -94,6 +94,14 @@ struct epicsJob {
     unsigned int dead:1; /* flag to catch use of freed objects */
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int createPoolThread(epicsThreadPool *pool);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // POOLPRIV_H

--- a/modules/libcom/src/yajl/yajl_alloc.h
+++ b/modules/libcom/src/yajl/yajl_alloc.h
@@ -29,6 +29,14 @@
 #define YA_FREE(afs, ptr) (afs)->free((afs)->ctx, (ptr))
 #define YA_REALLOC(afs, ptr, sz) (afs)->realloc((afs)->ctx, (ptr), (sz))
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 YAJL_API void yajl_set_default_alloc_funcs(yajl_alloc_funcs * yaf);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/modules/libcom/src/yajl/yajl_buf.h
+++ b/modules/libcom/src/yajl/yajl_buf.h
@@ -33,6 +33,10 @@
  */
 typedef struct yajl_buf_t * yajl_buf;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* allocate a new buffer */
 yajl_buf yajl_buf_alloc(yajl_alloc_funcs * alloc);
 
@@ -53,5 +57,9 @@ size_t yajl_buf_len(yajl_buf buf);
 
 /* truncate the buffer */
 void yajl_buf_truncate(yajl_buf buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/modules/libcom/src/yajl/yajl_encode.h
+++ b/modules/libcom/src/yajl/yajl_encode.h
@@ -20,6 +20,10 @@
 #include "yajl_buf.h"
 #include "yajl_gen.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void yajl_string_encode(const yajl_print_t printer,
                         void * ctx,
                         const unsigned char * str,
@@ -30,5 +34,9 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                         size_t length);
 
 int yajl_string_validate_utf8(const unsigned char * s, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/modules/libcom/src/yajl/yajl_lex.h
+++ b/modules/libcom/src/yajl/yajl_lex.h
@@ -47,6 +47,10 @@ typedef enum {
 
 typedef struct yajl_lexer_t * yajl_lexer;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 yajl_lexer yajl_lex_alloc(yajl_alloc_funcs * alloc,
                           unsigned int allowComments,
                           unsigned int validateUTF8);
@@ -113,5 +117,9 @@ size_t yajl_lex_current_line(yajl_lexer lexer);
 /** get the number of chars lexed by this lexer instance since the last
  *  \n or \r */
 size_t yajl_lex_current_char(yajl_lexer lexer);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/modules/libcom/src/yajl/yajl_parser.h
+++ b/modules/libcom/src/yajl/yajl_parser.h
@@ -58,6 +58,10 @@ struct yajl_handle_t {
     unsigned int flags;
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 yajl_status
 yajl_do_parse(yajl_handle handle, const unsigned char * jsonText,
               size_t jsonTextLen);
@@ -74,5 +78,8 @@ yajl_render_error_string(yajl_handle hand, const unsigned char * jsonText,
 long long
 yajl_parse_integer(const unsigned char *number, size_t length);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
I've tried to cover all C headers without extern C.
This allow that these files could be imported to C++ correctly.