### PR TITLE
Added Multicast to caRepeater

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -108,6 +108,7 @@
 #  Definitions in configure/os/CONFIG_SITE.<host>.Common
 #  may override this setting.
 CROSS_COMPILER_TARGET_ARCHS=
+CROSS_COMPILER_TARGET_ARCHS+=$(EPICS_HOST_ARCH)-debug
 #CROSS_COMPILER_TARGET_ARCHS=vxWorks-ppc32
 
 # If only some of your host architectures can compile the

--- a/modules/ca/src/client/repeater.cpp
+++ b/modules/ca/src/client/repeater.cpp
@@ -551,18 +551,15 @@ void ca_repeater ()
                     struct ip_mreq mreq;
 
                     memset(&mreq, 0, sizeof(mreq));
+		    mreq.imr_multiaddr = pNode->addr.ia.sin_addr;
                     mreq.imr_interface.s_addr = INADDR_ANY;
 
                     if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP,
                         (char *) &mreq, sizeof(mreq)) != 0) {
-                        struct sockaddr_in temp;
                         char name[40];
                         char sockErrBuf[64];
-                        temp.sin_family = AF_INET;
-                        temp.sin_addr = pNode->addr.ia.sin_addr;
-                        temp.sin_port = htons ( port );
                         epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
-                        ipAddrToDottedIP (&temp, name, sizeof(name));
+                        ipAddrToDottedIP (&pNode->addr.ia, name, sizeof(name));
                         errlogPrintf("caR: Socket mcast join to %s failed: %s\n", name, sockErrBuf );
                     }
                 }

--- a/modules/ca/src/client/repeater.cpp
+++ b/modules/ca/src/client/repeater.cpp
@@ -524,18 +524,18 @@ void ca_repeater ()
      */
     {
         ELLLIST casBeaconAddrList = ELLLIST_INIT;
-        ELLLIST dummy = ELLLIST_INIT;
+        ELLLIST casMergeAddrList = ELLLIST_INIT;
 
         /*
          * collect user specified beacon address list;
          * check BEACON_ADDR_LIST list first; if no result, take CA_ADDR_LIST
         */
-        if(!addAddrToChannelAccessAddressList(&casBeaconAddrList,&EPICS_CAS_BEACON_ADDR_LIST,port,0)) {
-            addAddrToChannelAccessAddressList(&casBeaconAddrList,&EPICS_CA_ADDR_LIST,port,0);
+        if(!addAddrToChannelAccessAddressList(&casMergeAddrList,&EPICS_CAS_BEACON_ADDR_LIST,port,0)) {
+            addAddrToChannelAccessAddressList(&casMergeAddrList,&EPICS_CA_ADDR_LIST,port,0);
         }
 
         /* First clean up */
-        removeDuplicateAddresses(&casBeaconAddrList, &dummy , 0);
+        removeDuplicateAddresses(&casBeaconAddrList, &casMergeAddrList , 0);
 
         osiSockAddrNode *pNode;
         for(pNode = (osiSockAddrNode*)ellFirst(&casBeaconAddrList);
@@ -551,7 +551,6 @@ void ca_repeater ()
                     struct ip_mreq mreq;
 
                     memset(&mreq, 0, sizeof(mreq));
-                    mreq.imr_multiaddr = pNode->addr.ia.sin_addr;
                     mreq.imr_interface.s_addr = INADDR_ANY;
 
                     if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP,
@@ -560,7 +559,7 @@ void ca_repeater ()
                         char name[40];
                         char sockErrBuf[64];
                         temp.sin_family = AF_INET;
-                        temp.sin_addr = mreq.imr_multiaddr;
+                        temp.sin_addr = pNode->addr.ia.sin_addr;
                         temp.sin_port = htons ( port );
                         epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
                         ipAddrToDottedIP (&temp, name, sizeof(name));

--- a/modules/ca/src/client/repeater.cpp
+++ b/modules/ca/src/client/repeater.cpp
@@ -551,7 +551,7 @@ void ca_repeater ()
                     struct ip_mreq mreq;
 
                     memset(&mreq, 0, sizeof(mreq));
-		    mreq.imr_multiaddr = pNode->addr.ia.sin_addr;
+                    mreq.imr_multiaddr = pNode->addr.ia.sin_addr;
                     mreq.imr_interface.s_addr = INADDR_ANY;
 
                     if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP,


### PR DESCRIPTION
Modifications to allow for CA multicast listening by adding multicast address
from EPICS_CA_BEACON_ADDR_LIST (or EPICS_CA_ADDR_LIST if beacon list is empty).
Original modifications from Jim Smedinghoff, with further changes by Pierrick Hanlet.