### PR TITLE
Fix multiple-IOC start race condition on TCP listen

### DIFF
--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -69,15 +69,7 @@ static void req_server (void *pParm)
     IOC_sock = conf->tcp;
 
     /* listen and accept new connections */
-    if ( listen ( IOC_sock, 20 ) < 0 ) {
-        char sockErrBuf[64];
-        epicsSocketConvertErrnoToString (
-            sockErrBuf, sizeof ( sockErrBuf ) );
-        errlogPrintf ( "CAS: Listen error: %s\n",
-            sockErrBuf );
-        epicsSocketDestroy (IOC_sock);
-        epicsThreadSuspendSelf ();
-    }
+    /*    moved into rsrv_grab_tcp()     */
 
     epicsEventSignal(castcp_startStopEvent);
 
@@ -247,6 +239,21 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
                         sockErrBuf, sizeof ( sockErrBuf ) );
                     ipAddrToDottedIP(&scratch.ia, name, sizeof(name));
                     cantProceed( "CAS: Socket bind %s error: %s\n",
+                        name, sockErrBuf );
+                }
+                ok = 0;
+                break;
+            }
+            if ( listen ( tcpsock, 20 ) < 0 ) {
+                int errcode = SOCKERRNO;
+                if (errcode != SOCK_EADDRINUSE) {
+                    char name[40];
+                    char sockErrBuf[64];
+                    epicsSocketConvertErrnoToString (
+                    sockErrBuf, sizeof ( sockErrBuf ) );
+                    ipAddrToDottedIP(&scratch.ia, name, sizeof(name));
+
+                    cantProceed( "CAS: Socket Listen %s error: %s\n",
                         name, sockErrBuf );
                 }
                 ok = 0;

--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -68,9 +68,6 @@ static void req_server (void *pParm)
 
     IOC_sock = conf->tcp;
 
-    /* listen and accept new connections */
-    /*    moved into rsrv_grab_tcp()     */
-
     epicsEventSignal(castcp_startStopEvent);
 
     while (TRUE) {
@@ -190,7 +187,7 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
 
             epicsSocketEnableAddressReuseDuringTimeWaitState ( tcpsock );
 
-            if(bind(tcpsock, &scratch.sa, sizeof(scratch))==0) {
+            if(bind(tcpsock, &scratch.sa, sizeof(scratch))==0 && listen(tcpsock, 20)==0) {
                 if(scratch.ia.sin_port==0) {
                     /* use first socket to pick a random port */
                     osiSocklen_t alen = sizeof(ifaceAddr);
@@ -239,21 +236,6 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
                         sockErrBuf, sizeof ( sockErrBuf ) );
                     ipAddrToDottedIP(&scratch.ia, name, sizeof(name));
                     cantProceed( "CAS: Socket bind %s error: %s\n",
-                        name, sockErrBuf );
-                }
-                ok = 0;
-                break;
-            }
-            if ( listen ( tcpsock, 20 ) < 0 ) {
-                int errcode = SOCKERRNO;
-                if (errcode != SOCK_EADDRINUSE) {
-                    char name[40];
-                    char sockErrBuf[64];
-                    epicsSocketConvertErrnoToString (
-                    sockErrBuf, sizeof ( sockErrBuf ) );
-                    ipAddrToDottedIP(&scratch.ia, name, sizeof(name));
-
-                    cantProceed( "CAS: Socket Listen %s error: %s\n",
                         name, sockErrBuf );
                 }
                 ok = 0;


### PR DESCRIPTION
caservertask.c: Moved listen into rsrv_grab_tcp to allow retry if failed (race condition with multiple IOCs starting simultaneously). Fix for bug https://bugs.launchpad.net/epics-base/+bug/1862328