### PR TITLE
Added initialization of alarm severity on probe. This value is not us…

### DIFF
--- a/modules/database/src/ioc/db/dbChannel.c
+++ b/modules/database/src/ioc/db/dbChannel.c
@@ -37,6 +37,7 @@
 #include "link.h"
 #include "recSup.h"
 #include "special.h"
+#include "alarm.h"
 
 typedef struct parseContext {
     dbChannel *chan;
@@ -601,6 +602,7 @@ long dbChannelOpen(dbChannel *chan)
     probe.field_type  = dbChannelExportType(chan);
     probe.no_elements = dbChannelElements(chan);
     probe.field_size  = dbChannelFieldSize(chan);
+    probe.sevr = NO_ALARM;
     p = probe;
 
     /*


### PR DESCRIPTION
…ed, but should be initialized regardless. This was flagged as an error by the Codacy static code analysis.

Codacy link: https://app.codacy.com/gh/epics-base/epics-base/file/42103575016/issues/source?bid=16430872&fileBranchId=16430872#l604
Launchpad bug: https://bugs.launchpad.net/epics-base/+bug/1862918