### PR TITLE
Added a null check in epicsWin32ThreadEntry to prevent dereferencing …

### DIFF
--- a/modules/libcom/src/osi/os/WIN32/osdThread.c
+++ b/modules/libcom/src/osi/os/WIN32/osdThread.c
@@ -473,7 +473,11 @@ static unsigned WINAPI epicsWin32ThreadEntry ( LPVOID lpParameter )
     /*
      * CAUTION: !!!! the thread id might continue to be used after this thread exits !!!!
      */
-    TlsSetValue ( pGbl->tlsIndexThreadLibraryEPICS, (void*)0xdeadbeef );
+    
+    if ( pGbl )  {
+        TlsSetValue ( pGbl->tlsIndexThreadLibraryEPICS, (void*)0xdeadbeef );
+    }
+
     epicsParmCleanupWIN32 ( pParm );
 
     return retStat; /* this indirectly closes the thread handle */


### PR DESCRIPTION
…a null pointer in case fetchWin32ThreadGlobal fails.

LP: #1863118