### PR TITLE
Make longout record only write on change

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -16,6 +16,13 @@ should also be read to understand what has changed since earlier releases.
 ## Changes made on the 7.0 branch since 7.0.5
 
 <!-- Insert new items immediately below here ... -->
+### Extend longout conditions to write the OUT link (OOPT field)
+
+The longout record has now the capacity to condition its output write operation to
+different options, using the OOPT field (similar to calcout record). This is 
+the first output record to have such feature as a result of the 
+[Make output records only write on change](https://bugs.launchpad.net/epics-base/+bug/1398215)
+issue on Launchpad.
 
 
 -----

--- a/modules/database/src/std/rec/longoutRecord.c
+++ b/modules/database/src/std/rec/longoutRecord.c
@@ -217,9 +217,9 @@ static long special(DBADDR *paddr, int after)
             return(0);
         }
 
-        /* Detect an output link re-direction (change)*/
+        /* Detect an output link re-direction (change) */
         if (dbGetFieldIndex(paddr) == longoutRecordOUT) {
-            if (!after)
+            if (after)
                 prec->outpvt = OUT_LINK_CHANGED;
             return(0);
         }

--- a/modules/database/src/std/rec/longoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/longoutRecord.dbd.pod
@@ -95,8 +95,7 @@ written to. It's a menu field that has six choices:
 C<Every Time> -- write output every time record is processed. (DEFAULT)
 
 =item *
-C<On Change> -- write output every time VAL changes, i.e., every time the
-result of the expression changes.
+C<On Change> -- write output every time VAL changes.
 
 =item *
 C<When Zero> -- when record is processed, write output if VAL is zero.
@@ -117,8 +116,10 @@ VAL is non-zero and last value was zero.
 
 =head4 Changes in OUT field when OOPT = On Change
 
-The OOCH field determines if a change in OUT field should cause a write operation
-even when the value is the same and OOPT = On Change. By default, OOCH is set to YES.
+If OOCH is C<YES> (its default value) and the OOPT field is C<On Change>,
+the record will write to the device support the first time the record gets
+processed after its OUT link is modified, even when the output value has
+not actually changed.
 
 =cut
 

--- a/modules/database/src/std/rec/longoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/longoutRecord.dbd.pod
@@ -27,9 +27,7 @@ menu(longoutOOPT) {
 	choice(longoutOOPT_When_Non_zero,"When Non-zero")
 	choice(longoutOOPT_Transition_To_Zero,"Transition To Zero")
 	choice(longoutOOPT_Transition_To_Non_zero,"Transition To Non-zero")
-	choice(longoutOOPT_Write_Once_Then_On_Change, "Write Once Then On Change")
 }
-
 
 recordtype(longout) {
 
@@ -82,7 +80,45 @@ DTYP field must then specify the C<<< Soft Channel >>> device support routine.
 See L<Address Specification> for information on the format of hardware addresses
 and database links.
 
-=fields OUT, DTYP
+=fields OUT, DTYP, OOPT, OOCH
+
+=head4 Menu longoutOOPT
+
+The OOPT field determines the condition that causes the output link to be
+written to. It's a menu field that has six choices:
+
+=menu longoutOOPT
+
+=over
+
+=item *
+C<Every Time> -- write output every time record is processed. (DEFAULT)
+
+=item *
+C<On Change> -- write output every time VAL changes, i.e., every time the
+result of the expression changes.
+
+=item *
+C<When Zero> -- when record is processed, write output if VAL is zero.
+
+=item *
+C<When Non-zero> -- when record is processed, write output if VAL is
+non-zero.
+
+=item *
+C<Transition To Zero> -- when record is processed, write output only if VAL
+is zero and the last value was non-zero.
+
+=item *
+C<Transition To Non-zero> -- when record is processed, write output only if
+VAL is non-zero and last value was zero.
+
+=back
+
+=head4 Changes in OUT field when OOPT = On Change
+
+The OOCH field determines if a change in OUT field should cause a write operation
+even when the value is the same and OOPT = On Change. By default, OOCH is set to YES.
 
 =cut
 
@@ -372,7 +408,7 @@ for more information on simulation mode and its fields.
 		prompt("Sim. Mode Private")
 		special(SPC_NOMOD)
 		interest(4)
-		extra("epicsCallback            *simpvt")
+		extra("epicsCallback       *simpvt")
 	}
 	field(IVOA,DBF_MENU) {
 		prompt("INVALID output action")
@@ -385,11 +421,21 @@ for more information on simulation mode and its fields.
 		promptgroup("50 - Output")
 		interest(2)
 	}
-	field(OVAL,DBF_LONG) {
-		prompt("Last Value Written")
-		promptgroup("50 - Output")
-		asl(ASL1)
+	field(PVAL,DBF_LONG) {
+		prompt("Previous Value")
+	}
+	field(OUTPVT,DBF_NOACCESS) {
+		prompt("Output Link Changed Private")
 		special(SPC_NOMOD)
+		interest(4)
+		extra("epicsEnum16         outpvt")
+	}
+	field(OOCH,DBF_MENU) {
+		prompt("Output Execute On Change")
+		promptgroup("50 - Output")
+		interest(1)
+		menu(menuYesNo)
+		initial("1")
 	}
 	field(OOPT,DBF_MENU) {
 		prompt("Output Execute Opt")

--- a/modules/database/src/std/rec/longoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/longoutRecord.dbd.pod
@@ -426,13 +426,13 @@ for more information on simulation mode and its fields.
 		prompt("Previous Value")
 	}
 	field(OUTPVT,DBF_NOACCESS) {
-		prompt("Output Link Changed Private")
+		prompt("Output Write Control Private")
 		special(SPC_NOMOD)
 		interest(4)
 		extra("epicsEnum16         outpvt")
 	}
 	field(OOCH,DBF_MENU) {
-		prompt("Output Execute On Change")
+		prompt("Output Exec. On Change (Opt)")
 		promptgroup("50 - Output")
 		interest(1)
 		menu(menuYesNo)

--- a/modules/database/src/std/rec/longoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/longoutRecord.dbd.pod
@@ -20,6 +20,17 @@ limits.
 
 =cut
 
+menu(longoutOOPT) {
+	choice(longoutOOPT_Every_Time,"Every Time")
+	choice(longoutOOPT_On_Change,"On Change")
+	choice(longoutOOPT_When_Zero,"When Zero")
+	choice(longoutOOPT_When_Non_zero,"When Non-zero")
+	choice(longoutOOPT_Transition_To_Zero,"Transition To Zero")
+	choice(longoutOOPT_Transition_To_Non_zero,"Transition To Non-zero")
+	choice(longoutOOPT_Write_Once_Then_On_Change, "Write Once Then On Change")
+}
+
+
 recordtype(longout) {
 
 =head2 Parameter Fields
@@ -93,6 +104,7 @@ and database links.
 	}
 	field(OUT,DBF_OUTLINK) {
 		prompt("Output Specification")
+		special(SPC_MOD)
 		promptgroup("50 - Output")
 		interest(1)
 	}
@@ -372,6 +384,19 @@ for more information on simulation mode and its fields.
 		prompt("INVALID output value")
 		promptgroup("50 - Output")
 		interest(2)
+	}
+	field(OVAL,DBF_LONG) {
+		prompt("Last Value Written")
+		promptgroup("50 - Output")
+		asl(ASL1)
+		special(SPC_NOMOD)
+	}
+	field(OOPT,DBF_MENU) {
+		prompt("Output Execute Opt")
+		promptgroup("50 - Output")
+		interest(1)
+		menu(longoutOOPT)
+		initial("0")
 	}
 
 

--- a/modules/database/test/std/rec/Makefile
+++ b/modules/database/test/std/rec/Makefile
@@ -87,6 +87,13 @@ testHarness_SRCS += seqTest.c
 TESTFILES += ../seqTest.db
 TESTS += seqTest
 
+TESTPROD_HOST += longoutTest
+longoutTest_SRCS += longoutTest.c
+longoutTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
+testHarness_SRCS += longoutTest.c
+TESTFILES += ../longoutTest.db
+TESTS += longoutTest
+
 TARGETS += $(COMMON_DIR)/asTestIoc.dbd
 DBDDEPENDS_FILES += asTestIoc.dbd$(DEP)
 asTestIoc_DBD += base.dbd

--- a/modules/database/test/std/rec/longoutTest.c
+++ b/modules/database/test/std/rec/longoutTest.c
@@ -222,12 +222,28 @@ static void test_changing_out_field(void){
     /* Test if the counter was processed once */
     testdbGetFieldEqual("counter_a", DBF_DOUBLE, 1.0);
 
-    //number of tests 24
+    /* reset rec processing counters */
+    testdbPutFieldOk("counter_a.VAL", DBF_DOUBLE, 0.0);
+
+    /* test if record with OOPT == On Change will 
+       write to output at its first process */
+    testdbPutFieldOk("longout_rec2.VAL", DBF_LONG, 16);
+
+    /* Test if the counter was processed once */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 1.0);
+
+    /* write the same value */
+    testdbPutFieldOk("longout_rec2.VAL", DBF_LONG, 16);
+
+    /* Test if the counter was not processed again */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 1.0);
+
+    //number of tests 29
 }
 
 MAIN(longoutTest) {
 
-    testPlan(6+8+8+8+9+8+24);
+    testPlan(6+8+8+8+9+8+29);
 
     testdbPrepare();
     testdbReadDatabase("recTestIoc.dbd", NULL, NULL);

--- a/modules/database/test/std/rec/longoutTest.c
+++ b/modules/database/test/std/rec/longoutTest.c
@@ -10,14 +10,15 @@
 #include "errlog.h"
 #include "dbAccess.h"
 #include "epicsMath.h"
+#include "menuYesNo.h"
 
 #include "longoutRecord.h"
 
 void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 static void test_oopt_everytime(void){
-    /* reset rec processing counter */
-    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+    /* reset rec processing counter_a */
+    testdbPutFieldOk("counter_a.VAL", DBF_DOUBLE, 0.0);
 
     /* write the same value two times */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
@@ -27,8 +28,8 @@ static void test_oopt_everytime(void){
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
 
-    /* Test if the counter was processed 4 times */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 4.0);
+    /* Test if the counter_a was processed 4 times */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 4.0);
 
     // number of tests = 6
 }
@@ -37,22 +38,22 @@ static void test_oopt_onchange(void){
     /* change OOPT to On Change */
     testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_On_Change);
 
-    /* reset rec processing counter */
-    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+    /* reset rec processing counter_a */
+    testdbPutFieldOk("counter_a.VAL", DBF_DOUBLE, 0.0);
 
     /* write the same value two times */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
 
-    /* Test if the counter was processed only once */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 1.0);
+    /* Test if the counter_a was processed only once */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 1.0);
 
     /* write two times with different values*/
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
 
-    /* Test if the counter was processed 1 + 2 times */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 3.0);
+    /* Test if the counter_a was processed 1 + 2 times */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 3.0);
 
     //number of tests 8
 }
@@ -60,22 +61,22 @@ static void test_oopt_onchange(void){
 static void test_oopt_whenzero(void){
     testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_When_Zero);
 
-    /* reset rec processing counter */
-    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+    /* reset rec processing counter_a */
+    testdbPutFieldOk("counter_a.VAL", DBF_DOUBLE, 0.0);
 
     /* write zero two times */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
 
-    /* Test if the counter was processed twice */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 2.0);
+    /* Test if the counter_a was processed twice */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 2.0);
 
     /* write two times with non-zero values*/
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
 
-    /* Test if the counter was still processed 2 times */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 2.0);
+    /* Test if the counter_a was still processed 2 times */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 2.0);
 
     //number of tests 8
 }
@@ -83,22 +84,22 @@ static void test_oopt_whenzero(void){
 static void test_oopt_whennonzero(void){
     testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_When_Non_zero);
 
-    /* reset rec processing counter */
-    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+    /* reset rec processing counter_a */
+    testdbPutFieldOk("counter_a.VAL", DBF_DOUBLE, 0.0);
 
     /* write zero two times */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
 
-    /* Test if the counter was never processed */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 0.0);
+    /* Test if the counter_a was never processed */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 0.0);
 
     /* write two times with non-zero values*/
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
 
-    /* Test if the counter was still processed 2 times */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 2.0);
+    /* Test if the counter_a was still processed 2 times */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 2.0);
 
     //number of tests 8
 }
@@ -106,23 +107,23 @@ static void test_oopt_whennonzero(void){
 static void test_oopt_when_transition_zero(void){
     testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_Transition_To_Zero);
 
-    /* reset rec processing counter */
-    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+    /* reset rec processing counter_a */
+    testdbPutFieldOk("counter_a.VAL", DBF_DOUBLE, 0.0);
 
     /* write non-zero then zero */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
 
-    /* Test if the counter was processed */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 1.0);
+    /* Test if the counter_a was processed */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 1.0);
 
     /* write another transition to zero */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
 
-    /* Test if the counter was processed once more */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 2.0);
+    /* Test if the counter_a was processed once more */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 2.0);
 
     //number of tests 9
 }
@@ -133,21 +134,21 @@ static void test_oopt_when_transition_nonzero(void){
     /* write non-zero to start fresh */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
 
-    /* reset rec processing counter */
-    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+    /* reset rec processing counter_a */
+    testdbPutFieldOk("counter_a.VAL", DBF_DOUBLE, 0.0);
 
     /* write non-zero then zero */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
 
-    /* Test if the counter was never processed */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 0.0);
+    /* Test if the counter_a was never processed */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 0.0);
 
     /* write a transition to non-zero */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
     
-    /* Test if the counter was processed */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 1.0);
+    /* Test if the counter_a was processed */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 1.0);
 
     //number of tests 8
 }
@@ -159,35 +160,74 @@ static void test_changing_out_field(void){
     /* write an initial value */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
 
-    /* reset rec processing counter */
-    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
-    testdbPutFieldOk("counter2.VAL", DBF_DOUBLE, 0.0);
+    /* reset rec processing counters */
+    testdbPutFieldOk("counter_a.VAL", DBF_DOUBLE, 0.0);
+    testdbPutFieldOk("counter_b.VAL", DBF_DOUBLE, 0.0);
 
     /* write the same value */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
 
     /* Test if the counter was never processed */
-    testdbGetFieldEqual("counter", DBF_DOUBLE, 0.0);
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 0.0);
 
     /* change the OUT link to another counter */
-    testdbPutFieldOk("longout_rec.OUT", DBF_STRING, "counter2.B PP");
+    testdbPutFieldOk("longout_rec.OUT", DBF_STRING, "counter_b.B PP");
 
     /* write the same value */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
 
     /* Test if the counter was processed once */
-    testdbGetFieldEqual("counter2", DBF_DOUBLE, 1.0);
+    testdbGetFieldEqual("counter_b", DBF_DOUBLE, 1.0);
 
     /* write the same value */
     testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
 
     /* Test if the counter was not processed again */
-    testdbGetFieldEqual("counter2", DBF_DOUBLE, 1.0);
+    testdbGetFieldEqual("counter_b", DBF_DOUBLE, 1.0);
+
+    /* Set option to write ON CHANGE even when the OUT link was changed */
+    testdbPutFieldOk("longout_rec.OOCH", DBF_ENUM, menuYesNoNO);
+
+    /* write an initial value */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* reset rec processing counters */
+    testdbPutFieldOk("counter_a.VAL", DBF_DOUBLE, 0.0);
+    testdbPutFieldOk("counter_b.VAL", DBF_DOUBLE, 0.0);
+
+    /* write the same value */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* Test if the counter_b was never processed */
+    testdbGetFieldEqual("counter_b", DBF_DOUBLE, 0.0);
+
+    /* change back the OUT link to counter_a */
+    testdbPutFieldOk("longout_rec.OUT", DBF_STRING, "counter_a.B PP");
+
+    /* write the same value */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* Test if the counter was never processed */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 0.0);
+
+    /* write the same value */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* Test if the counter was not processed again */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 0.0);
+
+    /* write new value */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
+
+    /* Test if the counter was processed once */
+    testdbGetFieldEqual("counter_a", DBF_DOUBLE, 1.0);
+
+    //number of tests 24
 }
 
 MAIN(longoutTest) {
 
-    testPlan(6+8+8+8+9+8+11);
+    testPlan(6+8+8+8+9+8+24);
 
     testdbPrepare();
     testdbReadDatabase("recTestIoc.dbd", NULL, NULL);

--- a/modules/database/test/std/rec/longoutTest.c
+++ b/modules/database/test/std/rec/longoutTest.c
@@ -1,0 +1,214 @@
+/*************************************************************************\
+* Copyright (c) 2020 Joao Paulo Martins
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include "dbUnitTest.h"
+#include "testMain.h"
+#include "dbLock.h"
+#include "errlog.h"
+#include "dbAccess.h"
+#include "epicsMath.h"
+
+#include "longoutRecord.h"
+
+void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
+
+static void test_oopt_everytime(void){
+    /* reset rec processing counter */
+    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+
+    /* write the same value two times */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* write two times with different values*/
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
+
+    /* Test if the counter was processed 4 times */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 4.0);
+
+    // number of tests = 6
+}
+
+static void test_oopt_onchange(void){
+    /* change OOPT to On Change */
+    testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_On_Change);
+
+    /* reset rec processing counter */
+    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+
+    /* write the same value two times */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* Test if the counter was processed only once */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 1.0);
+
+    /* write two times with different values*/
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
+
+    /* Test if the counter was processed 1 + 2 times */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 3.0);
+
+    //number of tests 8
+}
+
+static void test_oopt_whenzero(void){
+    testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_When_Zero);
+
+    /* reset rec processing counter */
+    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+
+    /* write zero two times */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
+
+    /* Test if the counter was processed twice */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 2.0);
+
+    /* write two times with non-zero values*/
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
+
+    /* Test if the counter was still processed 2 times */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 2.0);
+
+    //number of tests 8
+}
+
+static void test_oopt_whennonzero(void){
+    testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_When_Non_zero);
+
+    /* reset rec processing counter */
+    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+
+    /* write zero two times */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
+
+    /* Test if the counter was never processed */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 0.0);
+
+    /* write two times with non-zero values*/
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
+
+    /* Test if the counter was still processed 2 times */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 2.0);
+
+    //number of tests 8
+}
+
+static void test_oopt_when_transition_zero(void){
+    testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_Transition_To_Zero);
+
+    /* reset rec processing counter */
+    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+
+    /* write non-zero then zero */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
+
+    /* Test if the counter was processed */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 1.0);
+
+    /* write another transition to zero */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
+
+    /* Test if the counter was processed once more */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 2.0);
+
+    //number of tests 9
+}
+
+static void test_oopt_when_transition_nonzero(void){
+    testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_Transition_To_Non_zero);
+
+    /* write non-zero to start fresh */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* reset rec processing counter */
+    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+
+    /* write non-zero then zero */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 17);
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 0);
+
+    /* Test if the counter was never processed */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 0.0);
+
+    /* write a transition to non-zero */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 18);
+    
+    /* Test if the counter was processed */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 1.0);
+
+    //number of tests 8
+}
+
+static void test_changing_out_field(void){
+    /* change OOPT to On Change */
+    testdbPutFieldOk("longout_rec.OOPT", DBF_ENUM, longoutOOPT_On_Change);
+    
+    /* write an initial value */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* reset rec processing counter */
+    testdbPutFieldOk("counter.VAL", DBF_DOUBLE, 0.0);
+    testdbPutFieldOk("counter2.VAL", DBF_DOUBLE, 0.0);
+
+    /* write the same value */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* Test if the counter was never processed */
+    testdbGetFieldEqual("counter", DBF_DOUBLE, 0.0);
+
+    /* change the OUT link to another counter */
+    testdbPutFieldOk("longout_rec.OUT", DBF_STRING, "counter2.B PP");
+
+    /* write the same value */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* Test if the counter was processed once */
+    testdbGetFieldEqual("counter2", DBF_DOUBLE, 1.0);
+
+    /* write the same value */
+    testdbPutFieldOk("longout_rec.VAL", DBF_LONG, 16);
+
+    /* Test if the counter was not processed again */
+    testdbGetFieldEqual("counter2", DBF_DOUBLE, 1.0);
+}
+
+MAIN(longoutTest) {
+
+    testPlan(6+8+8+8+9+8+11);
+
+    testdbPrepare();
+    testdbReadDatabase("recTestIoc.dbd", NULL, NULL);
+    recTestIoc_registerRecordDeviceDriver(pdbbase);
+
+    testdbReadDatabase("longoutTest.db", NULL, NULL);
+    
+    eltc(0);
+    testIocInitOk();
+    eltc(1);
+
+    test_oopt_everytime();
+    test_oopt_onchange();
+    test_oopt_whenzero();
+    test_oopt_whennonzero();
+    test_oopt_when_transition_zero();
+    test_oopt_when_transition_nonzero();
+    test_changing_out_field();
+
+    testIocShutdownOk();
+    testdbCleanup();
+
+    return testDone();
+}

--- a/modules/database/test/std/rec/longoutTest.db
+++ b/modules/database/test/std/rec/longoutTest.db
@@ -15,3 +15,11 @@ record(longout, "longout_rec") {
     field(OUT, "counter_a.B PP")
     field(PINI, "YES")
 }
+
+record(longout, "longout_rec2") {
+    field(VAL,  "16")
+    field(OUT, "counter_a.B PP")
+    field(PINI, "NO")
+    field(OOPT, "On Change")
+}
+

--- a/modules/database/test/std/rec/longoutTest.db
+++ b/modules/database/test/std/rec/longoutTest.db
@@ -1,17 +1,17 @@
-record(calc, "counter") {
-    field(INPA, "counter")
+record(calc, "counter_a") {
+    field(INPA, "counter_a")
     field(CALC, "A+1")
     field(SCAN, "Passive")
 }
 
-record(calc, "counter2") {
-    field(INPA, "counter2")
+record(calc, "counter_b") {
+    field(INPA, "counter_b")
     field(CALC, "A+1")
     field(SCAN, "Passive")
 }
 
 record(longout, "longout_rec") {
     field(VAL,  "0")
-    field(OUT, "counter.B PP")
+    field(OUT, "counter_a.B PP")
     field(PINI, "YES")
 }

--- a/modules/database/test/std/rec/longoutTest.db
+++ b/modules/database/test/std/rec/longoutTest.db
@@ -1,0 +1,17 @@
+record(calc, "counter") {
+    field(INPA, "counter")
+    field(CALC, "A+1")
+    field(SCAN, "Passive")
+}
+
+record(calc, "counter2") {
+    field(INPA, "counter2")
+    field(CALC, "A+1")
+    field(SCAN, "Passive")
+}
+
+record(longout, "longout_rec") {
+    field(VAL,  "0")
+    field(OUT, "counter.B PP")
+    field(PINI, "YES")
+}


### PR DESCRIPTION
This pull request refers to bug 1398215 on Launchpad (https://bugs.launchpad.net/epics-base/+bug/1398215), which is **"Make output records only write on change"**. The first record to have this feature implemented is the longout record.

Two fields were added to the record: OOPT and OVAL. The first one is a menu field with usual options from other records, the second holds the last value written and its used for the comparison during the record process routine.

OOPT can assume the following options:
- Every Time (default)
- On Change
- When Zero
- When non-zero
- When Transition to Zero
- When Transition to non-zero
- Write Once then On Change (*)

If the OUT field is changed during runtime and OOPT is "On Change", the record special function will force OOPT to be "Write Once then On Change". This will cause output record write to new destination even if the value is equal the previous one. 

The second commit refers to test routines of the feature that was implemented. 