### PR TITLE
Simplify epicsTempFile handling

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,10 +90,10 @@ build_script:
 
 test_script:
   - cmd: .ci/appveyor-make.bat tapfiles
-  - cmd: .ci/appveyor-make.bat test-results
 
 on_finish:
   - ps: Get-ChildItem *.tap -Recurse -Force | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - cmd: .ci/appveyor-make.bat -s test-results
 
 
 #---------------------------------#

--- a/modules/libcom/src/osi/Makefile
+++ b/modules/libcom/src/osi/Makefile
@@ -104,7 +104,7 @@ epicsReadline_INCLUDES += $(INCLUDES_$(COMMANDLINE_LIBRARY))
 
 Com_SRCS += epicsReadline.c
 
-Com_SRCS += epicsTempFile.cpp
+Com_SRCS += epicsTempFile.c
 Com_SRCS += epicsStdio.c
 Com_SRCS += osdStdio.c
 

--- a/modules/libcom/src/osi/os/WIN32/epicsTempFile.c
+++ b/modules/libcom/src/osi/os/WIN32/epicsTempFile.c
@@ -27,7 +27,6 @@
 // allow the teporary file directory to be set with the 
 // TMP environment varianble
 //
-extern "C"
 epicsShareFunc FILE * epicsShareAPI epicsTempFile ()
 {
     char * pName = _tempnam ( "c:\\tmp", "epics" );

--- a/modules/libcom/src/osi/os/WIN32/epicsTempFile.c
+++ b/modules/libcom/src/osi/os/WIN32/epicsTempFile.c
@@ -45,7 +45,7 @@ epicsShareFunc FILE * epicsShareAPI epicsTempFile ()
     // _O_BINARY no translation 
     // _O_SHORT_LIVED avoid flush to disk
     //
-    const int openFlag = _O_CREAT | _O_EXCL | _O_RDWR | 
+    int openFlag = _O_CREAT | _O_EXCL | _O_RDWR |
         _O_SHORT_LIVED | _O_BINARY | _O_TEMPORARY;
     int fd = open ( pName, openFlag, _S_IWRITE );
     FILE * pNewFile = 0;

--- a/modules/libcom/src/osi/os/posix/epicsTempFile.c
+++ b/modules/libcom/src/osi/os/posix/epicsTempFile.c
@@ -13,7 +13,6 @@
 #define epicsExportSharedSymbols
 #include "epicsTempFile.h"
 
-extern "C"
 epicsShareFunc FILE * epicsShareAPI epicsTempFile ( void )
 {
     return tmpfile ();

--- a/modules/libcom/src/yacc/Makefile
+++ b/modules/libcom/src/yacc/Makefile
@@ -23,7 +23,6 @@ antelope_SRCS += skeleton.c
 antelope_SRCS += symtab.c
 antelope_SRCS += verbose.c
 antelope_SRCS += warshall.c
-antelope_OBJS += epicsTempFile$(OBJ)
 
 PROD_HOST += antelope
 

--- a/modules/libcom/src/yacc/antelope.c
+++ b/modules/libcom/src/yacc/antelope.c
@@ -8,9 +8,9 @@
 \*************************************************************************/
 #include <signal.h>
 #include "defs.h"
-#define epicsExportSharedSymbols
-#include "epicsTempFile.h"
-#undef epicsExportSharedSymbols
+
+/* Need this before the Com library can build it */
+#include "epicsTempFile.c"
 
 char dflag;
 char lflag;


### PR DESCRIPTION
By making it a `.c` file the antelope.c file can include it directly and avoid separate compilation.

See my comments on @mdavidsaver's [libcom-api merge request](https://code.launchpad.net/~epics-core/epics-base/+git/Com/+merge/375942), which Launchpad doesn't seem to be forwarding to core-talk.