### PR TITLE
Add a getter function for field_type

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -1381,6 +1381,14 @@ char * dbGetFieldName(DBENTRY *pdbentry)
     return(pflddes->name);
 }
 
+int dbGetFieldDbfType(DBENTRY *pdbentry)
+{
+    dbFldDes  	*pflddes = pdbentry->pflddes;
+
+    if(!pflddes) return(-1);
+    return(pflddes->field_type);
+}
+
 char * dbGetDefault(DBENTRY *pdbentry)
 {
     dbFldDes  	*pflddes = pdbentry->pflddes;

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.h
@@ -110,6 +110,7 @@ epicsShareFunc long dbFirstField(DBENTRY *pdbentry, int dctonly);
 epicsShareFunc long dbNextField(DBENTRY *pdbentry, int dctonly);
 epicsShareFunc int  dbGetNFields(DBENTRY *pdbentry, int dctonly);
 epicsShareFunc char * dbGetFieldName(DBENTRY *pdbentry);
+epicsShareFunc int dbGetFieldDbfType(DBENTRY *pdbentry);
 epicsShareFunc char * dbGetDefault(DBENTRY *pdbentry);
 epicsShareFunc char * dbGetPrompt(DBENTRY *pdbentry);
 epicsShareFunc int dbGetPromptGroup(DBENTRY *pdbentry);


### PR DESCRIPTION
Some time ago, the DCT  related functions were removed from `dbStaticLib`, leaving no function to retrieve a field type. IIRC the documentation suggests that the fields in DBENTRY and others shouldn't be accessed directly.
In this change, I would like to provide a getter function for a field dbf type, I have 2 comments about it:
- I use a different name for the function to avoid confusion with the deprecated one.
- I don't check pflddes for NULL, as every use of this functions is always done after calling any form of `dbNextField`, which makes access safe.