### PR TITLE
Avoid need to save/restore dbAddr::pfield

### DIFF
--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -623,6 +623,7 @@ all_done:
 
 long dbEntryToAddr(const DBENTRY *pdbentry, DBADDR *paddr)
 {
+    long ret = 0;
     dbFldDes *pflddes = pdbentry->pflddes;
     short dbfType = pflddes->field_type;
 
@@ -640,10 +641,11 @@ long dbEntryToAddr(const DBENTRY *pdbentry, DBADDR *paddr)
 
         /* Let record type modify paddr */
         if (prset && prset->cvt_dbaddr) {
-            return prset->cvt_dbaddr(paddr);
+            ret = prset->cvt_dbaddr(paddr);
         }
     }
-    return 0;
+    paddr->compare = paddr->pfield;
+    return ret;
 }
 
 /*
@@ -911,7 +913,6 @@ long dbGet(DBADDR *paddr, short dbrType,
     void *pbuffer, long *options, long *nRequest, void *pflin)
 {
     char *pbuf = pbuffer;
-    void *pfieldsave = paddr->pfield;
     db_field_log *pfl = (db_field_log *)pflin;
     short field_type;
     long capacity, no_elements, offset;
@@ -1044,7 +1045,6 @@ long dbGet(DBADDR *paddr, short dbrType,
         }
     }
 done:
-    paddr->pfield = pfieldsave;
     return status;
 }
 
@@ -1322,7 +1322,6 @@ long dbPut(DBADDR *paddr, short dbrType,
     short field_type  = paddr->field_type;
     long no_elements  = paddr->no_elements;
     long special      = paddr->special;
-    void *pfieldsave  = paddr->pfield;
     rset *prset = dbGetRset(paddr);
     long status = 0;
     dbFldDes *pfldDes;
@@ -1392,7 +1391,7 @@ long dbPut(DBADDR *paddr, short dbrType,
     if (isValueField) precord->udf = FALSE;
     if (precord->mlis.count &&
         !(isValueField && pfldDes->process_passive))
-        db_post_events(precord, pfieldsave, DBE_VALUE | DBE_LOG);
+        db_post_events(precord, paddr->compare, DBE_VALUE | DBE_LOG);
     /* If this field is a property (metadata) field,
      * then post a property change event (even if the field
      * didn't change).
@@ -1400,6 +1399,5 @@ long dbPut(DBADDR *paddr, short dbrType,
     if (precord->mlis.count && pfldDes->prop)
         db_post_events(precord, NULL, DBE_PROPERTY);
 done:
-    paddr->pfield = pfieldsave;
     return status;
 }

--- a/modules/database/src/ioc/db/dbAddr.h
+++ b/modules/database/src/ioc/db/dbAddr.h
@@ -17,6 +17,7 @@ struct dbFldDes;
 typedef struct dbAddr {
         struct dbCommon *precord;   /* address of record                     */
         void    *pfield;            /* address of field                      */
+        void    *compare;           /* use only for equality/order test between instances */
         struct dbFldDes *pfldDes;   /* address of struct fldDes              */
         long    no_elements;        /* number of elements (arrays)           */
         short   field_type;         /* type of database field                */

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -895,7 +895,7 @@ unsigned int    caEventMask
          * Only send event msg if they are waiting on the field which
          * changed or pval==NULL, and are waiting on matching event
          */
-        if ( (dbChannelField(pevent->chan) == (void *)pField || pField==NULL) &&
+        if ( (pevent->chan->addr.compare == (void *)pField || pField==NULL) &&
             (caEventMask & pevent->select)) {
             db_field_log *pLog = db_create_event_log(pevent);
             if(pLog)

--- a/modules/database/test/std/rec/arrayOpTest.c
+++ b/modules/database/test/std/rec/arrayOpTest.c
@@ -23,7 +23,7 @@ void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
 static void testGetPutArray(void)
 {
     double data[4] = {11, 12, 13, 14};
-    DBADDR addr, save;
+    DBADDR addr;
     long nreq;
     epicsInt32 *pbtr;
     waveformRecord *prec;
@@ -45,7 +45,6 @@ static void testGetPutArray(void)
     prec = (waveformRecord*)testdbRecordPtr("wfrec");
     if(!prec || dbNameToAddr("wfrec", &addr))
         testAbort("Failed to find record wfrec");
-    memcpy(&save, &addr, sizeof(save));
 
     testDiag("Fetch initial value of %s", prec->name);
 
@@ -62,9 +61,6 @@ static void testGetPutArray(void)
     }
     dbScanUnlock(addr.precord);
 
-    testOk1(memcmp(&addr, &save, sizeof(save))==0);
-    addr=save;
-
     testDiag("Write a new value");
 
     data[0] = 4.0;
@@ -78,9 +74,6 @@ static void testGetPutArray(void)
     testOk(prec->nord==4, "prec->nord==4 (got %u)", prec->nord);
     testOk1(pbtr[0]==4 && pbtr[1]==5 && pbtr[2]==6 && pbtr[3]==7);
     dbScanUnlock(addr.precord);
-
-    testOk1(memcmp(&addr, &save, sizeof(save))==0);
-    addr=save;
 
     memset(&data, 0, sizeof(data));
 
@@ -96,14 +89,11 @@ static void testGetPutArray(void)
     }
     dbScanUnlock(addr.precord);
 
-    testOk1(memcmp(&addr, &save, sizeof(save))==0);
-
     testDiag("Test dbGet() and dbPut() from/to an array of size 1");
 
     prec = (waveformRecord*)testdbRecordPtr("wfrec1");
     if(!prec || dbNameToAddr("wfrec1", &addr))
         testAbort("Failed to find record wfrec1");
-    memcpy(&save, &addr, sizeof(save));
 
     testDiag("Fetch initial value of %s", prec->name);
 
@@ -117,9 +107,6 @@ static void testGetPutArray(void)
         testOk(nreq==0, "nreq==0 (got %ld)", nreq);
     }
     dbScanUnlock(addr.precord);
-
-    testOk1(memcmp(&addr, &save, sizeof(save))==0);
-    addr=save;
 
     testDiag("Write a new value");
 
@@ -135,9 +122,6 @@ static void testGetPutArray(void)
     testOk1(pbtr[0]==4);
     dbScanUnlock(addr.precord);
 
-    testOk1(memcmp(&addr, &save, sizeof(save))==0);
-    addr=save;
-
     memset(&data, 0, sizeof(data));
 
     testDiag("Reread the value");
@@ -152,7 +136,6 @@ static void testGetPutArray(void)
     }
     dbScanUnlock(addr.precord);
 
-    testOk1(memcmp(&addr, &save, sizeof(save))==0);
 
     testIocShutdownOk();
 
@@ -161,7 +144,7 @@ static void testGetPutArray(void)
 
 MAIN(arrayOpTest)
 {
-    testPlan(21);
+    testPlan(15);
     testGetPutArray();
     return testDone();
 }


### PR DESCRIPTION
Avoid need for callers of `rset::get_array_info` to save/restore `dbAddr::pfield` by adding a new member for use in `db_post_events()`.