### PR TITLE
Add alarm message and time tag to dbCommon

### DIFF
--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -523,7 +523,7 @@ long dbProcess(dbCommon *precord)
             (precord->lcnt++ < MAX_LOCK) ||
             (precord->sevr >= INVALID_ALARM)) goto all_done;
 
-        recGblSetSevr(precord, SCAN_ALARM, INVALID_ALARM);
+        recGblSetSevrMsg(precord, SCAN_ALARM, INVALID_ALARM, "Async in progress");
         monitor_mask = recGblResetAlarms(precord);
         monitor_mask |= DBE_VALUE|DBE_LOG;
         pdbFldDes = pdbRecordType->papFldDes[pdbRecordType->indvalFlddes];

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -359,6 +359,14 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
             *pushort++ = pcommon->acks;
             *pushort++ = pcommon->ackt;
             pbuffer = (char *)pushort;
+            if (!pfl || pfl->type == dbfl_type_rec) {
+                STATIC_ASSERT(sizeof(pcommon->amsg)==sizeof(pfl->amsg));
+                strncpy(pbuffer, pcommon->amsg, sizeof(pcommon->amsg)-1);
+            } else {
+                strncpy(pbuffer, pfl->amsg,sizeof(pfl->amsg)-1);
+            }
+            pbuffer[sizeof(pcommon->amsg)-1] = '\0';
+            pbuffer += sizeof(pcommon->amsg);
         }
         if( (*options) & DBR_UNITS ) {
             memset(pbuffer,'\0',dbr_units_size);
@@ -386,10 +394,13 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
             if (!pfl) {
                 *ptime++ = pcommon->time.secPastEpoch;
                 *ptime++ = pcommon->time.nsec;
+                *ptime++ = pcommon->utag;
             } else {
                 *ptime++ = pfl->time.secPastEpoch;
                 *ptime++ = pfl->time.nsec;
+                *ptime++ = pfl->utag;
             }
+            *ptime++ = 0; /* padding */
             pbuffer = (char *)ptime;
         }
         if( (*options) & DBR_ENUM_STRS )

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -361,7 +361,7 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
             pbuffer = (char *)pushort;
         }
         if( (*options) & DBR_AMSG ) {
-            if (!pfl || pfl->type == dbfl_type_rec) {
+            if (!pfl) {
                 STATIC_ASSERT(sizeof(pcommon->amsg)==sizeof(pfl->amsg));
                 strncpy(pbuffer, pcommon->amsg, sizeof(pcommon->amsg)-1);
             } else {
@@ -404,7 +404,7 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
         }
         if( (*options) & DBR_UTAG ) {
             epicsUInt64 *ptag = (epicsUInt64*)pbuffer;
-            if (!pfl || pfl->type == dbfl_type_rec) {
+            if (!pfl) {
                 *ptag++ = pcommon->utag;
             } else {
                 *ptag++ = pfl->utag;

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -359,6 +359,8 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
             *pushort++ = pcommon->acks;
             *pushort++ = pcommon->ackt;
             pbuffer = (char *)pushort;
+        }
+        if( (*options) & DBR_AMSG ) {
             if (!pfl || pfl->type == dbfl_type_rec) {
                 STATIC_ASSERT(sizeof(pcommon->amsg)==sizeof(pfl->amsg));
                 strncpy(pbuffer, pcommon->amsg, sizeof(pcommon->amsg)-1);
@@ -390,7 +392,6 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
         }
         if( (*options) & DBR_TIME ) {
             epicsUInt32 *ptime = (epicsUInt32 *)pbuffer;
-            epicsUInt64 *ptime64;
 
             if (!pfl) {
                 *ptime++ = pcommon->time.secPastEpoch;
@@ -399,13 +400,16 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
                 *ptime++ = pfl->time.secPastEpoch;
                 *ptime++ = pfl->time.nsec;
             }
-            ptime64 = (epicsUInt64*)ptime;
+            pbuffer = (char *)ptime;
+        }
+        if( (*options) & DBR_UTAG ) {
+            epicsUInt64 *ptag = (epicsUInt64*)pbuffer;
             if (!pfl || pfl->type == dbfl_type_rec) {
-                *ptime64++ = pcommon->utag;
+                *ptag++ = pcommon->utag;
             } else {
-                *ptime64++ = pfl->utag;
+                *ptag++ = pfl->utag;
             }
-            pbuffer = (char *)ptime64;
+            pbuffer = (char *)ptag;
         }
         if( (*options) & DBR_ENUM_STRS )
             get_enum_strs(paddr, &pbuffer, prset, options);

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -390,18 +390,22 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
         }
         if( (*options) & DBR_TIME ) {
             epicsUInt32 *ptime = (epicsUInt32 *)pbuffer;
+            epicsUInt64 *ptime64;
 
             if (!pfl) {
                 *ptime++ = pcommon->time.secPastEpoch;
                 *ptime++ = pcommon->time.nsec;
-                *ptime++ = pcommon->utag;
             } else {
                 *ptime++ = pfl->time.secPastEpoch;
                 *ptime++ = pfl->time.nsec;
-                *ptime++ = pfl->utag;
             }
-            *ptime++ = 0; /* padding */
-            pbuffer = (char *)ptime;
+            ptime64 = (epicsUInt64*)ptime;
+            if (!pfl || pfl->type == dbfl_type_rec) {
+                *ptime64++ = pcommon->utag;
+            } else {
+                *ptime64++ = pfl->utag;
+            }
+            pbuffer = (char *)ptime64;
         }
         if( (*options) & DBR_ENUM_STRS )
             get_enum_strs(paddr, &pbuffer, prset, options);

--- a/modules/database/src/ioc/db/dbAccessDefs.h
+++ b/modules/database/src/ioc/db/dbAccessDefs.h
@@ -33,16 +33,18 @@ DBCORE_API extern int dbAccessDebugPUTF;
 /*  The database field and request types are defined in dbFldTypes.h*/
 /* Data Base Request Options    */
 #define DBR_STATUS      0x00000001
-#define DBR_UNITS       0x00000002
-#define DBR_PRECISION   0x00000004
-#define DBR_TIME        0x00000008
-#define DBR_ENUM_STRS   0x00000010
-#define DBR_GR_LONG     0x00000020
-#define DBR_GR_DOUBLE   0x00000040
-#define DBR_CTRL_LONG   0x00000080
-#define DBR_CTRL_DOUBLE 0x00000100
-#define DBR_AL_LONG     0x00000200
-#define DBR_AL_DOUBLE   0x00000400
+#define DBR_AMSG        0x00000002
+#define DBR_UNITS       0x00000004
+#define DBR_PRECISION   0x00000008
+#define DBR_TIME        0x00000010
+#define DBR_UTAG        0x00000020
+#define DBR_ENUM_STRS   0x00000040
+#define DBR_GR_LONG     0x00000080
+#define DBR_GR_DOUBLE   0x00000100
+#define DBR_CTRL_LONG   0x00000200
+#define DBR_CTRL_DOUBLE 0x00000400
+#define DBR_AL_LONG     0x00000800
+#define DBR_AL_DOUBLE   0x00001000
 
 /**********************************************************************
  * The next page contains macros for defining requests.
@@ -99,8 +101,10 @@ DBCORE_API extern int dbAccessDebugPUTF;
         epicsUInt16     status;         /* alarm status */\
         epicsUInt16     severity;       /* alarm severity*/\
         epicsUInt16     acks;           /* alarm ack severity*/\
-        epicsUInt16     ackt;           /* Acknowledge transient alarms?*/\
-        char amsg[40];
+        epicsUInt16     ackt;           /* Acknowledge transient alarms?*/
+#define DB_AMSG_SIZE 40
+#define DBRamsg \
+        char amsg[DB_AMSG_SIZE];
 #define DB_UNITS_SIZE   16
 #define DBRunits \
         char            units[DB_UNITS_SIZE];   /* units        */
@@ -113,7 +117,8 @@ DBCORE_API extern int dbAccessDebugPUTF;
          * too late to change now.  DBRprecision must be padded to
          * maintain 8-byte alignment. */
 #define DBRtime \
-        epicsTimeStamp	time;		/* time stamp*/\
+        epicsTimeStamp	time;		/* time stamp*/
+#define DBRutag \
         epicsUTag utag;
 #define DBRenumStrs \
         epicsUInt32     no_str;         /* number of strings*/\

--- a/modules/database/src/ioc/db/dbAccessDefs.h
+++ b/modules/database/src/ioc/db/dbAccessDefs.h
@@ -114,8 +114,7 @@ DBCORE_API extern int dbAccessDebugPUTF;
          * maintain 8-byte alignment. */
 #define DBRtime \
         epicsTimeStamp	time;		/* time stamp*/\
-        epicsInt32 utag;\
-        epicsInt32 padTime;
+        epicsUTag utag;
 #define DBRenumStrs \
         epicsUInt32     no_str;         /* number of strings*/\
         epicsInt32      padenumStrs;    /*padding to force 8 byte align*/\

--- a/modules/database/src/ioc/db/dbAccessDefs.h
+++ b/modules/database/src/ioc/db/dbAccessDefs.h
@@ -99,7 +99,8 @@ DBCORE_API extern int dbAccessDebugPUTF;
         epicsUInt16     status;         /* alarm status */\
         epicsUInt16     severity;       /* alarm severity*/\
         epicsUInt16     acks;           /* alarm ack severity*/\
-        epicsUInt16     ackt;           /* Acknowledge transient alarms?*/
+        epicsUInt16     ackt;           /* Acknowledge transient alarms?*/\
+        char amsg[40];
 #define DB_UNITS_SIZE   16
 #define DBRunits \
         char            units[DB_UNITS_SIZE];   /* units        */
@@ -112,7 +113,9 @@ DBCORE_API extern int dbAccessDebugPUTF;
          * too late to change now.  DBRprecision must be padded to
          * maintain 8-byte alignment. */
 #define DBRtime \
-        epicsTimeStamp  time;           /* time stamp*/
+        epicsTimeStamp	time;		/* time stamp*/\
+        epicsInt32 utag;\
+        epicsInt32 padTime;
 #define DBRenumStrs \
         epicsUInt32     no_str;         /* number of strings*/\
         epicsInt32      padenumStrs;    /*padding to force 8 byte align*/\

--- a/modules/database/src/ioc/db/dbCommon.dbd.pod
+++ b/modules/database/src/ioc/db/dbCommon.dbd.pod
@@ -524,6 +524,11 @@ field which is then used to acquire a timestamp.
 		interest(2)
 		extra("epicsTimeStamp      time")
 	}
+	field(UTAG,DBF_LONG) {
+		prompt("Time Tag")
+		special(SPC_NOMOD)
+		interest(3)
+	}
 	field(FLNK,DBF_FWDLINK) {
 		prompt("Forward Process Link")
 		promptgroup("20 - Scan")

--- a/modules/database/src/ioc/db/dbCommon.dbd.pod
+++ b/modules/database/src/ioc/db/dbCommon.dbd.pod
@@ -279,6 +279,11 @@ support routines which write to the VAL field are responsible for setting UDF.
 		special(SPC_NOMOD)
 		menu(menuAlarmSevr)
 	}
+	field(AMSG,DBF_STRING) {
+		prompt("Alarm Message")
+		special(SPC_NOMOD)
+                size(40)
+	}
 	field(NSTA,DBF_MENU) {
 		prompt("New Alarm Status")
 		special(SPC_NOMOD)
@@ -290,6 +295,11 @@ support routines which write to the VAL field are responsible for setting UDF.
 		special(SPC_NOMOD)
 		interest(2)
 		menu(menuAlarmSevr)
+	}
+	field(NAMSG,DBF_STRING) {
+		prompt("New Alarm Message")
+		special(SPC_NOMOD)
+		size(40)
 	}
 	field(ACKS,DBF_MENU) {
 		prompt("Alarm Ack Severity")

--- a/modules/database/src/ioc/db/dbCommon.dbd.pod
+++ b/modules/database/src/ioc/db/dbCommon.dbd.pod
@@ -524,7 +524,7 @@ field which is then used to acquire a timestamp.
 		interest(2)
 		extra("epicsTimeStamp      time")
 	}
-	field(UTAG,DBF_LONG) {
+        field(UTAG,DBF_UINT64) {
 		prompt("Time Tag")
 		special(SPC_NOMOD)
 		interest(3)

--- a/modules/database/src/ioc/db/dbDbLink.c
+++ b/modules/database/src/ioc/db/dbDbLink.c
@@ -337,8 +337,8 @@ static long dbDbGetUnits(const struct link *plink, char *units, int unitsSize)
     return 0;
 }
 
-static long dbDbGetAlarm(const struct link *plink, epicsEnum16 *status,
-        epicsEnum16 *severity)
+static long dbDbGetAlarmMsg(const struct link *plink, epicsEnum16 *status,
+                            epicsEnum16 *severity, char *msgbuf, size_t msgbuflen)
 {
     dbChannel *chan = linkChannel(plink);
     dbCommon *precord = dbChannelRecord(chan);
@@ -346,7 +346,17 @@ static long dbDbGetAlarm(const struct link *plink, epicsEnum16 *status,
         *status = precord->stat;
     if (severity)
         *severity = precord->sevr;
+    if (msgbuf && msgbuflen) {
+        strncpy(msgbuf, precord->amsg, msgbuflen-1);
+        msgbuf[msgbuflen-1] = '\0';
+    }
     return 0;
+}
+
+static long dbDbGetAlarm(const struct link *plink, epicsEnum16 *status,
+        epicsEnum16 *severity)
+{
+    return dbDbGetAlarmMsg(plink, status, severity, NULL, 0u);
 }
 
 static long dbDbGetTimeStamp(const struct link *plink, epicsTimeStamp *pstamp)
@@ -403,7 +413,8 @@ static lset dbDb_lset = {
     dbDbGetPrecision, dbDbGetUnits,
     dbDbGetAlarm, dbDbGetTimeStamp,
     dbDbPutValue, NULL,
-    dbDbScanFwdLink, doLocked
+    dbDbScanFwdLink, doLocked,
+    dbDbGetAlarmMsg,
 };
 
 

--- a/modules/database/src/ioc/db/dbDbLink.c
+++ b/modules/database/src/ioc/db/dbDbLink.c
@@ -353,12 +353,6 @@ static long dbDbGetAlarmMsg(const struct link *plink, epicsEnum16 *status,
     return 0;
 }
 
-static long dbDbGetAlarm(const struct link *plink, epicsEnum16 *status,
-        epicsEnum16 *severity)
-{
-    return dbDbGetAlarmMsg(plink, status, severity, NULL, 0u);
-}
-
 static long dbDbGetTimeStampTag(const struct link *plink, epicsTimeStamp *pstamp, epicsUTag *ptag)
 {
     dbChannel *chan = linkChannel(plink);
@@ -367,11 +361,6 @@ static long dbDbGetTimeStampTag(const struct link *plink, epicsTimeStamp *pstamp
     if(ptag)
         *ptag = precord->utag;
     return 0;
-}
-
-static long dbDbGetTimeStamp(const struct link *plink, epicsTimeStamp *pstamp)
-{
-    return dbDbGetTimeStampTag(plink, pstamp, NULL);
 }
 
 static long dbDbPutValue(struct link *plink, short dbrType,
@@ -418,7 +407,7 @@ static lset dbDb_lset = {
     dbDbGetValue,
     dbDbGetControlLimits, dbDbGetGraphicLimits, dbDbGetAlarmLimits,
     dbDbGetPrecision, dbDbGetUnits,
-    dbDbGetAlarm, dbDbGetTimeStamp,
+    NULL, NULL,
     dbDbPutValue, NULL,
     dbDbScanFwdLink, doLocked,
     dbDbGetAlarmMsg,

--- a/modules/database/src/ioc/db/dbDbLink.c
+++ b/modules/database/src/ioc/db/dbDbLink.c
@@ -359,12 +359,19 @@ static long dbDbGetAlarm(const struct link *plink, epicsEnum16 *status,
     return dbDbGetAlarmMsg(plink, status, severity, NULL, 0u);
 }
 
-static long dbDbGetTimeStamp(const struct link *plink, epicsTimeStamp *pstamp)
+static long dbDbGetTimeStampTag(const struct link *plink, epicsTimeStamp *pstamp, epicsInt32 *ptag)
 {
     dbChannel *chan = linkChannel(plink);
     dbCommon *precord = dbChannelRecord(chan);
     *pstamp = precord->time;
+    if(ptag)
+        *ptag = precord->utag;
     return 0;
+}
+
+static long dbDbGetTimeStamp(const struct link *plink, epicsTimeStamp *pstamp)
+{
+    return dbDbGetTimeStampTag(plink, pstamp, NULL);
 }
 
 static long dbDbPutValue(struct link *plink, short dbrType,
@@ -415,6 +422,7 @@ static lset dbDb_lset = {
     dbDbPutValue, NULL,
     dbDbScanFwdLink, doLocked,
     dbDbGetAlarmMsg,
+    dbDbGetTimeStampTag,
 };
 
 

--- a/modules/database/src/ioc/db/dbDbLink.c
+++ b/modules/database/src/ioc/db/dbDbLink.c
@@ -359,7 +359,7 @@ static long dbDbGetAlarm(const struct link *plink, epicsEnum16 *status,
     return dbDbGetAlarmMsg(plink, status, severity, NULL, 0u);
 }
 
-static long dbDbGetTimeStampTag(const struct link *plink, epicsTimeStamp *pstamp, epicsInt32 *ptag)
+static long dbDbGetTimeStampTag(const struct link *plink, epicsTimeStamp *pstamp, epicsUTag *ptag)
 {
     dbChannel *chan = linkChannel(plink);
     dbCommon *precord = dbChannelRecord(chan);

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -675,7 +675,10 @@ static db_field_log* db_create_field_log (struct dbChannel *chan, int use_val)
         struct dbCommon  *prec = dbChannelRecord(chan);
         pLog->stat = prec->stat;
         pLog->sevr = prec->sevr;
+        strncpy(pLog->amsg, prec->amsg, sizeof(pLog->amsg)-1);
+        pLog->amsg[sizeof(pLog->amsg)-1] = '\0';
         pLog->time = prec->time;
+        pLog->utag = prec->utag;
         pLog->field_type  = dbChannelFieldType(chan);
         pLog->field_size  = dbChannelFieldSize(chan);
         pLog->no_elements = dbChannelElements(chan);

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -714,6 +714,7 @@ db_field_log* db_create_event_log (struct evSubscrip *pevent)
 {
     db_field_log *pLog = db_create_field_log(pevent->chan, pevent->useValque);
     if (pLog) {
+        pLog->mask = pevent->select;
         pLog->ctx  = dbfl_context_event;
     }
     return pLog;

--- a/modules/database/src/ioc/db/dbLink.c
+++ b/modules/database/src/ioc/db/dbLink.c
@@ -423,12 +423,21 @@ long dbGetAlarmMsg(const struct link *plink, epicsEnum16 *status,
 
 long dbGetTimeStamp(const struct link *plink, epicsTimeStamp *pstamp)
 {
+    return dbGetTimeStampTag(plink, pstamp, NULL);
+}
+
+long dbGetTimeStampTag(const struct link *plink,
+                       epicsTimeStamp *pstamp, epicsInt32 *ptag)
+{
     lset *plset = plink->lset;
 
-    if (!plset || !plset->getTimeStamp)
+    if (plset && plset->getTimeStampTag) {
+        return plset->getTimeStampTag(plink, pstamp, ptag);
+    } else if(plset && plset->getTimeStamp) {
+        return plset->getTimeStamp(plink, pstamp);
+    } else {
         return S_db_noLSET;
-
-    return plset->getTimeStamp(plink, pstamp);
+    }
 }
 
 long dbPutLink(struct link *plink, short dbrType, const void *pbuffer,

--- a/modules/database/src/ioc/db/dbLink.c
+++ b/modules/database/src/ioc/db/dbLink.c
@@ -316,19 +316,8 @@ long dbTryGetLink(struct link *plink, short dbrType, void *pbuffer,
 static
 void setLinkAlarm(struct link* plink)
 {
-    struct dbCommon *precord = plink->precord;
-    dbRecordType *rdes = precord->rdes;
-    const char* amsg = NULL;
-    short i;
-
-    for(i=0; i<rdes->no_links; i++) {
-        dbFldDes *fdes = rdes->papFldDes[rdes->link_ind[i]];
-        if((char*)plink - (char*)precord == fdes->offset) {
-            amsg = fdes->name;
-        }
-    }
-
-    recGblSetSevrMsg(precord, LINK_ALARM, INVALID_ALARM, "field %s", amsg);
+    recGblSetSevrMsg(plink->precord, LINK_ALARM, INVALID_ALARM,
+                     "field %s", dbLinkFieldName(plink));
 }
 
 long dbGetLink(struct link *plink, short dbrType, void *pbuffer,

--- a/modules/database/src/ioc/db/dbLink.c
+++ b/modules/database/src/ioc/db/dbLink.c
@@ -402,14 +402,23 @@ long dbGetUnits(const struct link *plink, char *units, int unitsSize)
 }
 
 long dbGetAlarm(const struct link *plink, epicsEnum16 *status,
-        epicsEnum16 *severity)
+                epicsEnum16 *severity)
+{
+    return dbGetAlarmMsg(plink, status, severity, NULL, 0);
+}
+
+long dbGetAlarmMsg(const struct link *plink, epicsEnum16 *status,
+                   epicsEnum16 *severity, char *msgbuf, size_t msgbuflen)
 {
     lset *plset = plink->lset;
 
-    if (!plset || !plset->getAlarm)
+    if (plset && plset->getAlarmMsg) {
+        return plset->getAlarmMsg(plink, status, severity, msgbuf, msgbuflen);
+    } else if(plset && plset->getAlarm) {
+        return plset->getAlarm(plink, status, severity);
+    } else {
         return S_db_noLSET;
-
-    return plset->getAlarm(plink, status, severity);
+    }
 }
 
 long dbGetTimeStamp(const struct link *plink, epicsTimeStamp *pstamp)

--- a/modules/database/src/ioc/db/dbLink.c
+++ b/modules/database/src/ioc/db/dbLink.c
@@ -427,7 +427,7 @@ long dbGetTimeStamp(const struct link *plink, epicsTimeStamp *pstamp)
 }
 
 long dbGetTimeStampTag(const struct link *plink,
-                       epicsTimeStamp *pstamp, epicsInt32 *ptag)
+                       epicsTimeStamp *pstamp, epicsUTag *ptag)
 {
     lset *plset = plink->lset;
 

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -377,6 +377,15 @@ typedef struct lset {
      */
     long (*getAlarmMsg)(const struct link *plink, epicsEnum16 *status,
                         epicsEnum16 *severity, char *msgbuf, size_t msgbuflen);
+
+    /** @brief Extended version of getTimeStamp
+     *
+     * Equivalent of getTimeStamp() and also copy out time tag.
+     * ptag may be NULL.
+     *
+     * @since Added after UNRELEASED
+     */
+    long (*getTimeStampTag)(const struct link *plink, epicsTimeStamp *pstamp, epicsInt32 *ptag);
 } lset;
 
 #define dbGetSevr(link, sevr) \
@@ -428,6 +437,10 @@ DBCORE_API long dbGetAlarmMsg(const struct link *plink, epicsEnum16 *status,
 #define dbGetAlarmMsg(LINK, STAT, SEVR, BUF, BUFLEN) dbGetAlarmMsg(LINK, STAT, SEVR, BUF, BUFLEN)
 DBCORE_API long dbGetTimeStamp(const struct link *plink,
         epicsTimeStamp *pstamp);
+/** @since UNRELEASED */
+DBCORE_API long dbGetTimeStampTag(const struct link *plink,
+        epicsTimeStamp *pstamp, epicsInt32 *ptag);
+#define dbGetTimeStampTag(LINK, STAMP, TAG) dbGetTimeStampTag(LINK, STAMP, TAG)
 DBCORE_API long dbPutLink(struct link *plink, short dbrType,
         const void *pbuffer, long nRequest);
 DBCORE_API void dbLinkAsyncComplete(struct link *plink);

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -385,7 +385,7 @@ typedef struct lset {
      *
      * @since Added after UNRELEASED
      */
-    long (*getTimeStampTag)(const struct link *plink, epicsTimeStamp *pstamp, epicsInt32 *ptag);
+    long (*getTimeStampTag)(const struct link *plink, epicsTimeStamp *pstamp, epicsUTag *ptag);
 } lset;
 
 #define dbGetSevr(link, sevr) \
@@ -439,7 +439,7 @@ DBCORE_API long dbGetTimeStamp(const struct link *plink,
         epicsTimeStamp *pstamp);
 /** @since UNRELEASED */
 DBCORE_API long dbGetTimeStampTag(const struct link *plink,
-        epicsTimeStamp *pstamp, epicsInt32 *ptag);
+        epicsTimeStamp *pstamp, epicsUTag *ptag);
 #define dbGetTimeStampTag(LINK, STAMP, TAG) dbGetTimeStampTag(LINK, STAMP, TAG)
 DBCORE_API long dbPutLink(struct link *plink, short dbrType,
         const void *pbuffer, long nRequest);

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -282,8 +282,6 @@ typedef struct lset {
      * @param   status      where to put the alarm status (or NULL)
      * @param   severity    where to put the severity (or NULL)
      * @returns status value
-     *
-     * @note Link types which provide getAlarm should also provided getAlarmMsg().
      */
     long (*getAlarm)(const struct link *plink, epicsEnum16 *status,
             epicsEnum16 *severity);
@@ -368,7 +366,7 @@ typedef struct lset {
      *
      * Equivalent of getAlarm() and also copy out alarm message string.
      * The msgbuf argument may be NULL and/or msgbuflen==0, in which case
-     * the call must be the same as a call to getAlarm().
+     * the effect must be the same as a call to getAlarm().
      *
      * Implementations must write a trailing nil to msgbuf whenever
      * @code msgbuf!=NULL && msgbuflen>0 @endcode .

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -282,6 +282,8 @@ typedef struct lset {
      * @param   status      where to put the alarm status (or NULL)
      * @param   severity    where to put the severity (or NULL)
      * @returns status value
+     *
+     * @note Link types which provide getAlarm should also provided getAlarmMsg().
      */
     long (*getAlarm)(const struct link *plink, epicsEnum16 *status,
             epicsEnum16 *severity);
@@ -361,6 +363,20 @@ typedef struct lset {
      * @returns status value
      */
     long (*doLocked)(struct link *plink, dbLinkUserCallback rtn, void *priv);
+
+    /** @brief Extended version of getAlarm
+     *
+     * Equivalent of getAlarm() and also copy out alarm message string.
+     * The msgbuf argument may be NULL and/or msgbuflen==0, in which case
+     * the call must be the same as a call to getAlarm().
+     *
+     * Implementations must write a trailing nil to msgbuf whenever
+     * @code msgbuf!=NULL && msgbuflen>0 @endcode .
+     *
+     * @since UNRELEASED
+     */
+    long (*getAlarmMsg)(const struct link *plink, epicsEnum16 *status,
+                        epicsEnum16 *severity, char *msgbuf, size_t msgbuflen);
 } lset;
 
 #define dbGetSevr(link, sevr) \
@@ -402,6 +418,14 @@ DBCORE_API long dbGetUnits(const struct link *plink, char *units,
         int unitsSize);
 DBCORE_API long dbGetAlarm(const struct link *plink, epicsEnum16 *status,
         epicsEnum16 *severity);
+/** Get link alarm and message string.
+ * To ensure the complete message string is copied, ensure @code msgbuflen >= sizeof (dbCommon::amsg) @endcode .
+ * A trailing nil will be added whenever @code msgbuflen > 0 @endcode .
+ * @since UNRELEASED
+ */
+DBCORE_API long dbGetAlarmMsg(const struct link *plink, epicsEnum16 *status,
+        epicsEnum16 *severity, char *msgbuf, size_t msgbuflen);
+#define dbGetAlarmMsg(LINK, STAT, SEVR, BUF, BUFLEN) dbGetAlarmMsg(LINK, STAT, SEVR, BUF, BUFLEN)
 DBCORE_API long dbGetTimeStamp(const struct link *plink,
         epicsTimeStamp *pstamp);
 DBCORE_API long dbPutLink(struct link *plink, short dbrType,

--- a/modules/database/src/ioc/db/db_field_log.h
+++ b/modules/database/src/ioc/db/db_field_log.h
@@ -109,6 +109,8 @@ typedef struct db_field_log {
     unsigned int     type:1;  /* type (union) selector */
     /* ctx is used for all types */
     unsigned int      ctx:1;  /* context (operation type) */
+    /* only for dbfl_context_event */
+    unsigned char      mask;  /* DBE_* mask */
     /* the following are used for value and reference types */
     epicsTimeStamp     time;  /* Time stamp */
     unsigned short     stat;  /* Alarm Status */

--- a/modules/database/src/ioc/db/db_field_log.h
+++ b/modules/database/src/ioc/db/db_field_log.h
@@ -113,7 +113,7 @@ typedef struct db_field_log {
     unsigned char      mask;  /* DBE_* mask */
     /* the following are used for value and reference types */
     epicsTimeStamp     time;  /* Time stamp */
-    epicsInt32         utag;
+    epicsUTag          utag;
     unsigned short     stat;  /* Alarm Status */
     unsigned short     sevr;  /* Alarm Severity */
     char               amsg[40];

--- a/modules/database/src/ioc/db/db_field_log.h
+++ b/modules/database/src/ioc/db/db_field_log.h
@@ -113,8 +113,10 @@ typedef struct db_field_log {
     unsigned char      mask;  /* DBE_* mask */
     /* the following are used for value and reference types */
     epicsTimeStamp     time;  /* Time stamp */
+    epicsInt32         utag;
     unsigned short     stat;  /* Alarm Status */
     unsigned short     sevr;  /* Alarm Severity */
+    char               amsg[40];
     short        field_type;  /* DBF type of data */
     short        field_size;  /* Size of a single element */
     long        no_elements;  /* No of valid array elements */

--- a/modules/database/src/ioc/db/recGbl.c
+++ b/modules/database/src/ioc/db/recGbl.c
@@ -304,7 +304,7 @@ void recGblGetTimeStampSimm(void *pvoid, const epicsEnum16 simm, struct link *si
 
     if (!dbLinkIsConstant(plink)) {
         if (plink->flags & DBLINK_FLAG_TSELisTIME) {
-            if (dbGetTimeStamp(plink, &prec->time))
+            if (dbGetTimeStampTag(plink, &prec->time, &prec->utag))
                 errlogPrintf("recGblGetTimeStamp: dbGetTimeStamp failed for %s.TSEL\n",
                     prec->name);
             return;

--- a/modules/database/src/ioc/db/recGbl.h
+++ b/modules/database/src/ioc/db/recGbl.h
@@ -15,6 +15,9 @@
 #ifndef INCrecGblh
 #define INCrecGblh 1
 
+#include <stdarg.h>
+
+#include "compilerDependencies.h"
 #include "epicsTypes.h"
 #include "dbCoreAPI.h"
 
@@ -62,6 +65,12 @@ DBCORE_API int recGblSetSevr(void *precord, epicsEnum16 new_stat,
     epicsEnum16 new_sevr);
 DBCORE_API void recGblInheritSevr(int msMode, void *precord, epicsEnum16 stat,
     epicsEnum16 sevr);
+DBCORE_API int recGblSetSevrMsg(void *precord, epicsEnum16 new_stat,
+                                epicsEnum16 new_sevr,
+                                const char *msg, ...) EPICS_PRINTF_STYLE(4,5);
+DBCORE_API int recGblSetSevrVMsg(void *precord, epicsEnum16 new_stat,
+                                 epicsEnum16 new_sevr,
+                                 const char *msg, va_list args);
 DBCORE_API void recGblFwdLink(void *precord);
 DBCORE_API void recGblGetTimeStamp(void *precord);
 DBCORE_API void recGblGetTimeStampSimm(void *prec, const epicsEnum16 simm, struct link *siol);

--- a/modules/database/src/ioc/db/recGbl.h
+++ b/modules/database/src/ioc/db/recGbl.h
@@ -25,6 +25,14 @@
 extern "C" {
 #endif
 
+/** Feature test macro for alarm message (AMSG) field and support
+ *
+ * Covers addition of dbCommon::amsg, recGblSetSevrMsg(), lset::getAlarmMsg()
+ *
+ * @since UNRELEASED
+ */
+#define HAS_ALARM_MESSAGE 1
+
 /*************************************************************************/
 
 /* Structures needed for args */

--- a/modules/database/src/std/dev/devEnviron.c
+++ b/modules/database/src/std/dev/devEnviron.c
@@ -63,7 +63,7 @@ static long read_lsi(lsiRecord *prec)
         prec->val[0] = 0;
         prec->len = 1;
         prec->udf = TRUE;
-        recGblSetSevr(prec, UDF_ALARM, prec->udfs);
+        recGblSetSevrMsg(prec, UDF_ALARM, prec->udfs, "No such ENV");
     }
 
     return 0;
@@ -114,7 +114,7 @@ static long read_stringin(stringinRecord *prec)
     else {
         prec->val[0] = 0;
         prec->udf = TRUE;
-        recGblSetSevr(prec, UDF_ALARM, prec->udfs);
+        recGblSetSevrMsg(prec, UDF_ALARM, prec->udfs, "No such ENV");
     }
 
     return 0;

--- a/modules/database/src/std/filters/Makefile
+++ b/modules/database/src/std/filters/Makefile
@@ -16,6 +16,7 @@ dbRecStd_SRCS += dbnd.c
 dbRecStd_SRCS += arr.c
 dbRecStd_SRCS += sync.c
 dbRecStd_SRCS += decimate.c
+dbRecStd_SRCS += utag.c
 
 HTMLS += filters.html
 

--- a/modules/database/src/std/filters/filters.dbd.pod
+++ b/modules/database/src/std/filters/filters.dbd.pod
@@ -285,3 +285,5 @@ once every minute:
  ...
 
 =cut
+
+registrar(utagInitialize)

--- a/modules/database/src/std/filters/filters.dbd.pod
+++ b/modules/database/src/std/filters/filters.dbd.pod
@@ -16,6 +16,8 @@ The following filters are available in this release:
 
 =item * L<Decimation|/"Decimation Filter dec">
 
+=item * L<UTag|/"UTag Filter utag">
+
 =back
 
 =head2 Using Filters
@@ -287,3 +289,24 @@ once every minute:
 =cut
 
 registrar(utagInitialize)
+
+=head3 UTag Filter C<"utag">
+
+This filter applies a test UTAG&M==V to the value taken from the UTAG record field
+and drops those updates which evaluate as false.
+
+=head4 Parameters
+
+=over
+
+=item Mask C<"M">
+
+Bit mask.
+
+=item Value C<"V">
+
+Required value.
+
+=back
+
+=cut

--- a/modules/database/src/std/filters/utag.c
+++ b/modules/database/src/std/filters/utag.c
@@ -1,0 +1,99 @@
+/*************************************************************************\
+* Copyright (c) 2020 Michael Davidsaver
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include <stdlib.h>
+
+#include <caeventmask.h>
+#include <chfPlugin.h>
+#include <dbCommon.h>
+#include <epicsStdio.h>
+#include <epicsExport.h>
+
+typedef struct {
+    epicsInt32 mask, value;
+    int first;
+} utagPvt;
+
+static const
+chfPluginArgDef opts[] = {
+    chfInt32(utagPvt, mask, "M", 0, 1),
+    chfInt32(utagPvt, value, "V", 0, 1),
+    chfPluginArgEnd
+};
+
+static void * allocPvt(void)
+{
+    utagPvt *pvt;
+    pvt = calloc(1, sizeof(utagPvt));
+    pvt->mask = 0xffffffff;
+    return pvt;
+}
+
+static void freePvt(void *pvt)
+{
+    free(pvt);
+}
+
+static int parse_ok(void *raw)
+{
+    utagPvt *pvt = (utagPvt*)raw;
+    pvt->first = 1;
+    return 0;
+}
+
+static db_field_log* filter(void* raw, dbChannel *chan, db_field_log *pfl)
+{
+    utagPvt *pvt = (utagPvt*)raw;
+    epicsInt32 utag = pfl->type==dbfl_type_rec ? dbChannelRecord(chan)->utag : pfl->utag;
+    int drop = (utag&pvt->mask)!=pvt->value;
+
+    if(pfl->ctx!=dbfl_context_event || pfl->mask&DBE_PROPERTY) {
+        /* never drop for reads, or property events */
+
+    } else if(pvt->first) {
+        /* never drop first */
+        pvt->first = 0;
+
+    } else if(drop) {
+        db_delete_field_log(pfl);
+        pfl = NULL;
+    }
+
+    return pfl;
+}
+
+static void channelRegisterPre(dbChannel *chan, void *pvt,
+                               chPostEventFunc **cb_out, void **arg_out, db_field_log *probe)
+{
+    *cb_out = filter;
+    *arg_out = pvt;
+}
+
+static void channel_report(dbChannel *chan, void *raw, int level, const unsigned short indent)
+{
+    utagPvt *pvt = (utagPvt*)raw;
+    printf("%*sutag : mask=0x%08x value=0x%08x\n", indent, "", (epicsUInt32)pvt->mask, (epicsUInt32)pvt->value);
+}
+
+static const
+chfPluginIf pif = {
+    allocPvt,
+    freePvt,
+    NULL, /* parse_error */
+    parse_ok, /* parse_ok */
+    NULL, /* channel_open */
+    channelRegisterPre,
+    NULL, /* channelRegisterPost */
+    channel_report,
+    NULL, /* channel_close */
+};
+
+static
+void utagInitialize(void)
+{
+    chfPluginRegister("utag", &pif, opts);
+}
+epicsExportRegistrar(utagInitialize);

--- a/modules/database/src/std/filters/utag.c
+++ b/modules/database/src/std/filters/utag.c
@@ -47,7 +47,7 @@ static int parse_ok(void *raw)
 static db_field_log* filter(void* raw, dbChannel *chan, db_field_log *pfl)
 {
     utagPvt *pvt = (utagPvt*)raw;
-    epicsInt32 utag = pfl->type==dbfl_type_rec ? dbChannelRecord(chan)->utag : pfl->utag;
+    epicsUTag utag = pfl->type==dbfl_type_rec ? dbChannelRecord(chan)->utag : pfl->utag;
     int drop = (utag&pvt->mask)!=pvt->value;
 
     if(pfl->ctx!=dbfl_context_event || pfl->mask&DBE_PROPERTY) {

--- a/modules/database/src/std/filters/utag.c
+++ b/modules/database/src/std/filters/utag.c
@@ -47,7 +47,7 @@ static int parse_ok(void *raw)
 static db_field_log* filter(void* raw, dbChannel *chan, db_field_log *pfl)
 {
     utagPvt *pvt = (utagPvt*)raw;
-    epicsUTag utag = pfl->type==dbfl_type_rec ? dbChannelRecord(chan)->utag : pfl->utag;
+    epicsUTag utag = pfl->utag;
     int drop = (utag&pvt->mask)!=pvt->value;
 
     if(pfl->ctx!=dbfl_context_event || pfl->mask&DBE_PROPERTY) {

--- a/modules/database/src/std/link/lnkCalc.c
+++ b/modules/database/src/std/link/lnkCalc.c
@@ -53,6 +53,7 @@ typedef struct calc_link {
     } pstate;
     epicsEnum16 stat;
     epicsEnum16 sevr;
+    char amsg[MAX_STRING_SIZE];
     short prec;
     char *expr;
     char *major;
@@ -385,9 +386,10 @@ static void lnkCalc_report(const jlink *pjlink, int level, int indent)
 
     if (level > 0) {
         if (clink->sevr)
-            printf("%*s  Alarm: %s, %s\n", indent, "",
+            printf("%*s  Alarm: %s, %s, \"%s\"\n", indent, "",
                 epicsAlarmSeverityStrings[clink->sevr],
-                epicsAlarmConditionStrings[clink->stat]);
+                epicsAlarmConditionStrings[clink->stat],
+                clink->amsg);
 
         if (clink->post_major)
             printf("%*s  Major expression: \"%s\"\n", indent, "",
@@ -583,6 +585,7 @@ static long lnkCalc_getValue(struct link *plink, short dbrType, void *pbuffer,
     }
     clink->stat = 0;
     clink->sevr = 0;
+    clink->amsg[0] = '\0';
 
     if (clink->post_expr) {
         status = calcPerform(clink->arg, &clink->val, clink->post_expr);
@@ -604,7 +607,8 @@ static long lnkCalc_getValue(struct link *plink, short dbrType, void *pbuffer,
         if (!status && alval) {
             clink->stat = LINK_ALARM;
             clink->sevr = MAJOR_ALARM;
-            recGblSetSevr(prec, clink->stat, clink->sevr);
+            strcpy(clink->amsg, "post_major error");
+            recGblSetSevrMsg(prec, clink->stat, clink->sevr, "post_major error");
         }
     }
 
@@ -615,7 +619,8 @@ static long lnkCalc_getValue(struct link *plink, short dbrType, void *pbuffer,
         if (!status && alval) {
             clink->stat = LINK_ALARM;
             clink->sevr = MINOR_ALARM;
-            recGblSetSevr(prec, clink->stat, clink->sevr);
+            strcpy(clink->amsg, "post_minor error");
+            recGblSetSevrMsg(prec, clink->stat, clink->sevr, "post_minor error");
         }
     }
 
@@ -659,6 +664,7 @@ static long lnkCalc_putValue(struct link *plink, short dbrType,
     }
     clink->stat = 0;
     clink->sevr = 0;
+    clink->amsg[0] = '\0';
 
     /* Get the value being output as VAL */
     status = conv(pbuffer, &clink->val, NULL);
@@ -673,7 +679,8 @@ static long lnkCalc_putValue(struct link *plink, short dbrType,
         if (!status && alval) {
             clink->stat = LINK_ALARM;
             clink->sevr = MAJOR_ALARM;
-            recGblSetSevr(prec, clink->stat, clink->sevr);
+            strcpy(clink->amsg, "post_major error");
+            recGblSetSevrMsg(prec, clink->stat, clink->sevr, "post_major error");
         }
     }
 
@@ -684,7 +691,8 @@ static long lnkCalc_putValue(struct link *plink, short dbrType,
         if (!status && alval) {
             clink->stat = LINK_ALARM;
             clink->sevr = MINOR_ALARM;
-            recGblSetSevr(prec, clink->stat, clink->sevr);
+            strcpy(clink->amsg, "post_major error");
+            recGblSetSevrMsg(prec, clink->stat, clink->sevr, "post_minor error");
         }
     }
 
@@ -718,8 +726,8 @@ static long lnkCalc_getUnits(const struct link *plink, char *units, int len)
     return 0;
 }
 
-static long lnkCalc_getAlarm(const struct link *plink, epicsEnum16 *status,
-    epicsEnum16 *severity)
+static long lnkCalc_getAlarmMsg(const struct link *plink, epicsEnum16 *status,
+                                epicsEnum16 *severity, char *msgbuf, size_t msgbuflen)
 {
     calc_link *clink = CONTAINER(plink->value.json.jlink,
         struct calc_link, jlink);
@@ -728,8 +736,18 @@ static long lnkCalc_getAlarm(const struct link *plink, epicsEnum16 *status,
         *status = clink->stat;
     if (severity)
         *severity = clink->sevr;
+    if (msgbuf && msgbuflen) {
+        strncpy(msgbuf, clink->amsg, msgbuflen-1);
+        msgbuf[msgbuflen-1] = '\0';
+    }
 
     return 0;
+}
+
+static long lnkCalc_getAlarm(const struct link *plink, epicsEnum16 *status,
+    epicsEnum16 *severity)
+{
+    return lnkCalc_getAlarmMsg(plink, status, severity, NULL, 0u);
 }
 
 static long lnkCalc_getTimestamp(const struct link *plink, epicsTimeStamp *pstamp)
@@ -763,7 +781,8 @@ static lset lnkCalc_lset = {
     lnkCalc_getPrecision, lnkCalc_getUnits,
     lnkCalc_getAlarm, lnkCalc_getTimestamp,
     lnkCalc_putValue, NULL,
-    NULL, doLocked
+    NULL, doLocked,
+    lnkCalc_getAlarmMsg,
 };
 
 static jlif lnkCalcIf = {

--- a/modules/database/src/std/link/lnkCalc.c
+++ b/modules/database/src/std/link/lnkCalc.c
@@ -67,7 +67,7 @@ typedef struct calc_link {
     struct link out;
     double arg[CALCPERFORM_NARGS];
     epicsTimeStamp time;
-    epicsInt32 utag;
+    epicsUTag utag;
     double val;
 } calc_link;
 
@@ -535,7 +535,7 @@ static long lnkCalc_getElements(const struct link *plink, long *nelements)
 struct lcvt {
     double *pval;
     epicsTimeStamp *ptime;
-    epicsInt32 *ptag;
+    epicsUTag *ptag;
 };
 
 static long readLocked(struct link *pinp, void *vvt)
@@ -754,7 +754,7 @@ static long lnkCalc_getAlarm(const struct link *plink, epicsEnum16 *status,
     return lnkCalc_getAlarmMsg(plink, status, severity, NULL, 0u);
 }
 
-static long lnkCalc_getTimestampTag(const struct link *plink, epicsTimeStamp *pstamp, epicsInt32 *ptag)
+static long lnkCalc_getTimestampTag(const struct link *plink, epicsTimeStamp *pstamp, epicsUTag *ptag)
 {
     calc_link *clink = CONTAINER(plink->value.json.jlink,
         struct calc_link, jlink);

--- a/modules/database/src/std/link/lnkCalc.c
+++ b/modules/database/src/std/link/lnkCalc.c
@@ -748,12 +748,6 @@ static long lnkCalc_getAlarmMsg(const struct link *plink, epicsEnum16 *status,
     return 0;
 }
 
-static long lnkCalc_getAlarm(const struct link *plink, epicsEnum16 *status,
-    epicsEnum16 *severity)
-{
-    return lnkCalc_getAlarmMsg(plink, status, severity, NULL, 0u);
-}
-
 static long lnkCalc_getTimestampTag(const struct link *plink, epicsTimeStamp *pstamp, epicsUTag *ptag)
 {
     calc_link *clink = CONTAINER(plink->value.json.jlink,
@@ -767,11 +761,6 @@ static long lnkCalc_getTimestampTag(const struct link *plink, epicsTimeStamp *ps
     }
 
     return -1;
-}
-
-static long lnkCalc_getTimestamp(const struct link *plink, epicsTimeStamp *pstamp)
-{
-    return lnkCalc_getTimestampTag(plink, pstamp, NULL);
 }
 
 static long doLocked(struct link *plink, dbLinkUserCallback rtn, void *priv)
@@ -790,7 +779,7 @@ static lset lnkCalc_lset = {
     lnkCalc_getValue,
     NULL, NULL, NULL,
     lnkCalc_getPrecision, lnkCalc_getUnits,
-    lnkCalc_getAlarm, lnkCalc_getTimestamp,
+    NULL, NULL,
     lnkCalc_putValue, NULL,
     NULL, doLocked,
     lnkCalc_getAlarmMsg,

--- a/modules/database/src/std/rec/aiRecord.c
+++ b/modules/database/src/std/rec/aiRecord.c
@@ -432,7 +432,7 @@ static void convert(aiRecord *prec)
 
         default: /* must use breakpoint table */
             if (cvtRawToEngBpt(&val,prec->linr,prec->init,(void *)&prec->pbrk,&prec->lbrk)!=0) {
-                recGblSetSevr(prec,SOFT_ALARM,MAJOR_ALARM);
+                recGblSetSevrMsg(prec,SOFT_ALARM,MAJOR_ALARM, "BPT Error");
             }
     }
 

--- a/modules/database/src/std/rec/calcoutRecord.c
+++ b/modules/database/src/std/rec/calcoutRecord.c
@@ -236,7 +236,7 @@ static long process(struct dbCommon *pcommon)
         }
         if (fetch_values(prec) == 0) {
             if (calcPerform(&prec->a, &prec->val, prec->rpcl)) {
-                recGblSetSevr(prec, CALC_ALARM, INVALID_ALARM);
+                recGblSetSevrMsg(prec, CALC_ALARM, INVALID_ALARM, "calcPerform");
             } else {
                 prec->udf = isnan(prec->val);
             }
@@ -610,7 +610,7 @@ static void execOutput(calcoutRecord *prec)
         break;
     case calcoutDOPT_Use_OVAL:
         if (calcPerform(&prec->a, &prec->oval, prec->orpc)) {
-            recGblSetSevr(prec, CALC_ALARM, INVALID_ALARM);
+            recGblSetSevrMsg(prec, CALC_ALARM, INVALID_ALARM, "OCAL calcPerform");
         } else {
             prec->udf = isnan(prec->oval);
         }
@@ -770,7 +770,7 @@ static long writeValue(calcoutRecord *prec)
 
     if (!pcalcoutDSET || !pcalcoutDSET->write) {
         errlogPrintf("%s DSET write does not exist\n", prec->name);
-        recGblSetSevr(prec, SOFT_ALARM, INVALID_ALARM);
+        recGblSetSevrMsg(prec, SOFT_ALARM, INVALID_ALARM, "DSET write does not exist");
         prec->pact = TRUE;
         return(-1);
     }

--- a/modules/database/test/ioc/db/Makefile
+++ b/modules/database/test/ioc/db/Makefile
@@ -117,6 +117,13 @@ testHarness_SRCS += dbCACTest.cpp
 TESTS += dbCaLinkTest
 TESTFILES += ../dbCaLinkTest1.db ../dbCaLinkTest2.db ../dbCaLinkTest3.db
 
+TESTPROD_HOST += dbDbLinkTest
+dbDbLinkTest_SRCS += dbDbLinkTest.c
+dbDbLinkTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
+testHarness_SRCS += dbDbLinkTest.c
+TESTS += dbDbLinkTest
+TESTFILES += ../dbDbLinkTest.db
+
 TESTPROD_HOST += scanIoTest
 scanIoTest_SRCS += scanIoTest.c
 scanIoTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
@@ -200,6 +207,7 @@ include $(TOP)/configure/RULES
 
 arrRecord$(DEP): $(COMMON_DIR)/arrRecord.h
 dbCaLinkTest$(DEP): $(COMMON_DIR)/xRecord.h $(COMMON_DIR)/arrRecord.h
+dbDbLinkTest$(DEP): $(COMMON_DIR)/xRecord.h
 dbPutLinkTest$(DEP): $(COMMON_DIR)/xRecord.h
 dbStressLock$(DEP): $(COMMON_DIR)/xRecord.h
 devx$(DEP): $(COMMON_DIR)/xRecord.h

--- a/modules/database/test/ioc/db/dbDbLinkTest.c
+++ b/modules/database/test/ioc/db/dbDbLinkTest.c
@@ -26,7 +26,7 @@ static
 void checkTime(void)
 {
     epicsTimeStamp stamp;
-    epicsInt32 tag;
+    epicsUTag tag;
 
     dbCommon* target = testdbRecordPtr("target");
     dbCommon* src = testdbRecordPtr("src");

--- a/modules/database/test/ioc/db/dbDbLinkTest.c
+++ b/modules/database/test/ioc/db/dbDbLinkTest.c
@@ -1,0 +1,136 @@
+/*************************************************************************\
+ * Copyright (c) 2020 Michael Davidsaver
+ * SPDX-License-Identifier: EPICS
+ * EPICS BASE is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ \*************************************************************************/
+
+#include <string.h>
+
+#include <dbUnitTest.h>
+#include <testMain.h>
+
+#include <errlog.h>
+#include <epicsTime.h>
+
+#include <dbLock.h>
+#include <dbAccess.h>
+#include <recGbl.h>
+#include <alarm.h>
+
+#include "xRecord.h"
+
+void dbTestIoc_registerRecordDeviceDriver(struct dbBase *);
+
+static
+void checkTime(void)
+{
+    epicsTimeStamp stamp;
+    epicsInt32 tag;
+
+    dbCommon* target = testdbRecordPtr("target");
+    dbCommon* src = testdbRecordPtr("src");
+
+    testDiag("checkTime()");
+
+    dbScanLock(target);
+    target->time.secPastEpoch = 0x12345678;
+    target->time.nsec = 0x9abcdef0;
+    target->utag = 0xdeadbeef;
+    dbScanUnlock(target);
+
+    dbScanLock(src);
+    testOk1(0==dbGetTimeStamp(dbGetDevLink(src), &stamp));
+    dbScanUnlock(src);
+
+    testOk1(stamp.secPastEpoch==0x12345678);
+    testOk1(stamp.nsec==0x9abcdef0);
+    stamp.secPastEpoch = 0;
+    stamp.nsec = 0;
+
+    dbScanLock(src);
+    testOk1(0==dbGetTimeStampTag(dbGetDevLink(src), &stamp, &tag));
+    dbScanUnlock(src);
+
+    testOk1(stamp.secPastEpoch==0x12345678);
+    testOk1(stamp.nsec==0x9abcdef0);
+    testOk1(tag==0xdeadbeef);
+}
+
+static
+void alarmProc(xRecord *prec)
+{
+    recGblSetSevrMsg(prec, READ_ALARM, MAJOR_ALARM, "a %s", "message");
+    prec->val = 0;
+}
+
+static
+void checkAlarm(void)
+{
+    epicsEnum16 stat, sevr;
+
+    xRecord* target = (xRecord*)testdbRecordPtr("target");
+    dbCommon* src = testdbRecordPtr("src");
+
+    char amsg[sizeof(src->amsg)];
+
+    testDiag("checkAlarm()");
+
+    dbScanLock((dbCommon*)target);
+    target->clbk = &alarmProc;
+    dbProcess((dbCommon*)target);
+    target->clbk = NULL;
+    dbScanUnlock((dbCommon*)target);
+
+    dbScanLock(src);
+    testOk1(0==dbGetAlarm(dbGetDevLink(src), &stat, &sevr));
+    dbScanUnlock(src);
+
+    testOk1(stat==READ_ALARM);
+    testOk1(sevr==MAJOR_ALARM);
+    stat = sevr = 0;
+
+    dbScanLock(src);
+    testOk1(0==dbGetAlarmMsg(dbGetDevLink(src), &stat, &sevr, amsg, sizeof(amsg)));
+    dbScanUnlock(src);
+
+    testOk1(stat==READ_ALARM);
+    testOk1(sevr==MAJOR_ALARM);
+    testOk1(strcmp(amsg, "a message")==0);
+    stat = sevr = 0;
+    memset(amsg, 0, sizeof(amsg));
+
+    dbScanLock(src);
+    testOk1(0==dbGetAlarmMsg(dbGetDevLink(src), &stat, &sevr, amsg, 5));
+    dbScanUnlock(src);
+
+    testOk1(stat==READ_ALARM);
+    testOk1(sevr==MAJOR_ALARM);
+    testOk1(strcmp(amsg, "a me")==0);
+}
+
+MAIN(dbDbLinkTest)
+{
+    testPlan(18);
+
+    testdbPrepare();
+
+    testdbReadDatabase("dbTestIoc.dbd", NULL, NULL);
+
+    dbTestIoc_registerRecordDeviceDriver(pdbbase);
+
+    testdbReadDatabase("dbDbLinkTest.db", NULL, NULL);
+
+    eltc(0);
+    testIocInitOk();
+    eltc(1);
+
+    checkTime();
+    checkAlarm();
+
+    testIocShutdownOk();
+
+    testdbCleanup();
+
+    return testDone();
+}

--- a/modules/database/test/ioc/db/dbDbLinkTest.db
+++ b/modules/database/test/ioc/db/dbDbLinkTest.db
@@ -1,0 +1,6 @@
+record(x, "target") {
+}
+
+record(x, "src") {
+    field(INP, "target.VAL")
+}

--- a/modules/database/test/ioc/db/dbPutGetTest.c
+++ b/modules/database/test/ioc/db/dbPutGetTest.c
@@ -51,7 +51,6 @@ void testdbMetaDoubleSizes(void)
     testOffset(precision);
     testOffset(time);
     testOffset(utag);
-    testOffset(padTime);
     testOffset(upper_disp_limit);
     testOffset(lower_disp_limit);
     testOffset(upper_ctrl_limit);
@@ -177,7 +176,6 @@ void testdbMetaEnumSizes(void)
     testOffset(amsg);
     testOffset(time);
     testOffset(utag);
-    testOffset(padTime);
     testOffset(no_str);
     testOffset(padenumStrs);
     testOffset(strs);
@@ -315,7 +313,7 @@ void dbTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 MAIN(dbPutGet)
 {
-    testPlan(113);
+    testPlan(111);
     testdbPrepare();
 
     testdbMetaDoubleSizes();

--- a/modules/database/test/ioc/db/dbPutGetTest.c
+++ b/modules/database/test/ioc/db/dbPutGetTest.c
@@ -20,15 +20,17 @@
 
 typedef struct {
     DBRstatus
+    DBRamsg
     DBRunits
     DBRprecision
     DBRtime
+    DBRutag
     DBRgrDouble
     DBRctrlDouble
     DBRalDouble
 } dbMetaDouble;
 
-enum {dbMetaDoubleMask = DBR_STATUS | DBR_UNITS | DBR_PRECISION | DBR_TIME | DBR_GR_DOUBLE | DBR_CTRL_DOUBLE | DBR_AL_DOUBLE};
+enum {dbMetaDoubleMask = DBR_STATUS | DBR_AMSG | DBR_UNITS | DBR_PRECISION | DBR_TIME | DBR_UTAG | DBR_GR_DOUBLE | DBR_CTRL_DOUBLE | DBR_AL_DOUBLE};
 
 static
 void testdbMetaDoubleSizes(void)
@@ -153,7 +155,9 @@ void testdbMetaDoubleGet(void)
 
 typedef struct {
     DBRstatus
+    DBRamsg
     DBRtime
+    DBRutag
     DBRenumStrs
 } dbMetaEnum;
 

--- a/modules/database/test/ioc/db/dbPutGetTest.db
+++ b/modules/database/test/ioc/db/dbPutGetTest.db
@@ -44,3 +44,5 @@ record(arr, "arr") {
     field(FTVL, "ULONG")
     field(NELM, "10")
 }
+
+record(x, "recmeta") {}

--- a/modules/database/test/ioc/db/epicsRunDbTests.c
+++ b/modules/database/test/ioc/db/epicsRunDbTests.c
@@ -30,6 +30,7 @@ int dbLockTest(void);
 int dbPutLinkTest(void);
 int dbStaticTest(void);
 int dbCaLinkTest(void);
+int dbDbLinkTest(void);
 int testDbChannel(void);
 int chfPluginTest(void);
 int arrShorthandTest(void);
@@ -52,6 +53,7 @@ void epicsRunDbTests(void)
     runTest(dbPutLinkTest);
     runTest(dbStaticTest);
     runTest(dbCaLinkTest);
+    runTest(dbDbLinkTest);
     runTest(testDbChannel);
     runTest(arrShorthandTest);
     runTest(recGblCheckDeadbandTest);

--- a/modules/database/test/ioc/db/xRecord.c
+++ b/modules/database/test/ioc/db/xRecord.c
@@ -76,7 +76,82 @@ static long process(struct dbCommon *pcommon)
     return ret;
 }
 
+long get_units(struct dbAddr *paddr, char *units)
+{
+    if(dbGetFieldIndex(paddr)==xRecordOTST) {
+        strncpy(units, "arbitrary", DB_UNITS_SIZE);
+    }
+    return 0;
+}
+
+long get_precision(const struct dbAddr *paddr, long *precision)
+{
+    if(dbGetFieldIndex(paddr)==xRecordOTST) {
+        *precision = 0x12345678;
+    }
+    return 0;
+}
+
+long get_graphic_double(struct dbAddr *paddr, struct dbr_grDouble *p)
+{
+    xRecord *prec = (xRecord *)paddr->precord;
+    if(dbGetFieldIndex(paddr)==xRecordOTST) {
+        p->lower_disp_limit = prec->otst-1.0;
+        p->upper_disp_limit = prec->otst+1.0;
+    }
+    return 0;
+}
+
+long get_control_double(struct dbAddr *paddr, struct dbr_ctrlDouble *p)
+{
+    xRecord *prec = (xRecord *)paddr->precord;
+    if(dbGetFieldIndex(paddr)==xRecordOTST) {
+        p->lower_ctrl_limit = prec->otst-2.0;
+        p->upper_ctrl_limit = prec->otst+2.0;
+    }
+    return 0;
+}
+long get_alarm_double(struct dbAddr *paddr, struct dbr_alDouble *p)
+{
+    xRecord *prec = (xRecord *)paddr->precord;
+    if(dbGetFieldIndex(paddr)==xRecordOTST) {
+        p->lower_alarm_limit = prec->otst-3.0;
+        p->lower_warning_limit = prec->otst-4.0;
+        p->upper_warning_limit = prec->otst+4.0;
+        p->upper_alarm_limit = prec->otst+3.0;
+    }
+    return 0;
+}
+
+#define report NULL
+#define initialize NULL
+#define special NULL
+#define get_value NULL
+#define cvt_dbaddr NULL
+#define get_array_info NULL
+#define put_array_info NULL
+#define get_enum_str NULL
+#define get_enum_strs NULL
+#define put_enum_str NULL
+
 static rset xRSET = {
-    RSETNUMBER, NULL, NULL, init_record, process
+    RSETNUMBER,
+    report,
+    initialize,
+    init_record,
+    process,
+    special,
+    get_value,
+    cvt_dbaddr,
+    get_array_info,
+    put_array_info,
+    get_units,
+    get_precision,
+    get_enum_str,
+    get_enum_strs,
+    put_enum_str,
+    get_graphic_double,
+    get_control_double,
+    get_alarm_double
 };
 epicsExportAddress(rset,xRSET);

--- a/modules/database/test/ioc/db/xRecord.dbd
+++ b/modules/database/test/ioc/db/xRecord.dbd
@@ -46,4 +46,8 @@ recordtype(x) {
     special(SPC_NOMOD)
     extra("void (*clbk)(struct xRecord*)")
   }
+  field(OTST, DBF_DOUBLE) {
+    prompt("dbGet() options test")
+    special(SPC_NOMOD)
+  }
 }

--- a/modules/libcom/src/osi/epicsTime.h
+++ b/modules/libcom/src/osi/epicsTime.h
@@ -36,6 +36,10 @@ typedef struct epicsTimeStamp {
     epicsUInt32    nsec;           /**< \brief nanoseconds within second */
 } epicsTimeStamp;
 
+/** \brief Type of UTAG field (dbCommon::utag)
+ */
+typedef epicsUInt64     epicsUTag;
+
 /** \brief Old time-stamp data type, deprecated.
  * \deprecated TS_STAMP was provided for compatibility with Base-3.13 code.
  * It will be removed in some future release of EPICS 7.


### PR DESCRIPTION
Adding extra meta-data to be transported by PVA.

Starts by adding two (user) fields to dbCommon named: AMSG (`alarm.message` in NTScalar) and UTAG (`timeStamp.userTag`).

AMSG is an alarm message string to go along with SEVR and STAT.  A new function `recGblSetSevrMsg()` for (maybe) raising an alarm with a message string.  Some internal use is made, including in `dbGetLink()` to indicate which link field has caused an alarm (eg. "INPA" in calc).

```c
int recGblSetSevrMsg(void *precord, epicsEnum16 new_stat,
                     epicsEnum16 new_sevr,
                     const char *msg, ...)
```

This alarm message string is added to `db_field_log` to maintain consistency, although I'm not certain that this isn't the right approach.

UTAG is an integer (signed 32-bit atm.) which is treated as part of the timestamp.  It is also added to `db_field_log`, and moved by a DB_LINK to `.TIME` via the new `dbGetTimeStampTag()` link support accessor.  I've also added a new server side filter `utag` which can filter updates based on UTAG.  It applies a filter condition `UTAG&M==V` where `M` and `V` are client specified integers.

My idea is that a knowledgeable driver can fill in UTAG with a bit-mask describing the conditions under which this value was acquired.  For example, an intelligent beam measurement device might fill this in based on information received from a timing system.  The most obvious case is to have one bit for "beam on".  Say bit 0.  Then

> camonitor BPM0:X.VAL{"utag":{"M":1,"V":1}}

will only show updates when beam should be present.

Additionally, two new link support "methods" are added `lset::getAlarmMsg` and `lset::getTimestampTag` which like the existing getAlarm and getTimestamp.  `dbGetTimeStampTag()` is added with usage in `recGblGetTimeStampSimm()` to propagate UTAG along with TIME through supported link types (DB and calc in Base).