### PR TITLE
Add de-initHooks

### DIFF
--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -710,20 +710,27 @@ int iocShutdown(void)
 {
     if (iocState == iocVoid) return 0;
 
+    initHookAnnounce(initHookAtShutdown);
+
     iterateRecords(doCloseLinks, NULL);
+    initHookAnnounce(initHookAfterCloseLinks);
 
     if (iocBuildMode == buildIsolated) {
         /* stop and "join" threads */
         scanStop();
+        initHookAnnounce(initHookAfterStopScan);
         callbackStop();
-    }
-    else
+        initHookAnnounce(initHookAfterStopCallback);
+    } else {
         dbStopServers();
+    }
 
     dbCaShutdown(); /* must be before dbFreeRecord and dbChannelExit */
+    initHookAnnounce(initHookAfterStopLinks);
 
     if (iocBuildMode == buildIsolated) {
         /* free resources */
+        initHookAnnounce(initHookBeforeFree);
         scanCleanup();
         callbackCleanup();
 
@@ -738,6 +745,8 @@ int iocShutdown(void)
 
     iocState = iocVoid;
     iocBuildMode = buildServers;
+
+    initHookAnnounce(initHookAfterShutdown);
     return 0;
 }
 

--- a/modules/libcom/src/iocsh/initHooks.h
+++ b/modules/libcom/src/iocsh/initHooks.h
@@ -47,6 +47,14 @@ typedef enum {
     initHookAfterDatabasePaused,
     initHookAfterIocPaused,         /* End of iocPause command */
 
+    initHookAtShutdown,             /* Start of iocShutdown commands */
+    initHookAfterCloseLinks,
+    initHookAfterStopScan,          /* triggered only by unittest code.   testIocShutdownOk() */
+    initHookAfterStopCallback,      /* triggered only by unittest code.   testIocShutdownOk() */
+    initHookAfterStopLinks,
+    initHookBeforeFree,             /* triggered only by unittest code.   testIocShutdownOk() */
+    initHookAfterShutdown,          /* End of iocShutdown commands */
+
 /* Deprecated states, provided for backwards compatibility.
  * These states are announced at the same point they were before,
  * but will not be repeated if the IOC gets paused and restarted.


### PR DESCRIPTION
Extend the initHook idea to `exitDatabase()`.