### PR TITLE
Restrict charactor set for record names.

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1065,15 +1065,12 @@ int dbRecordNameValidate(const char *name)
     for(; *pos; i++, pos++) {
         char c = *pos;
         if(i==0) {
-            /* first charactor restrictions */
-            if(c >= '0' && c <= '9') {
-                errlogPrintf("Warning: Record name '%s' should not begin with a number\n", name);
-
-            } else if(c=='-' || c=='+' || c=='[' || c=='{') {
+            /* first character restrictions */
+            if(c=='-' || c=='+' || c=='[' || c=='{') {
                 errlogPrintf("Warning: Record name '%s' should not begin with '%c'\n", name, c);
             }
         }
-        /* any charactor restrictions */
+        /* any character restrictions */
         if(c < ' ') {
             errlogPrintf("Warning: Record name '%s' should not contain non-printable 0x%02u\n",
                          name, (unsigned)c);

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -136,12 +136,14 @@ static void allocTemp(void *pvoid)
 static void *popFirstTemp(void)
 {
     tempListNode        *ptempListNode;
-    void                *ptemp;
+    void                *ptemp = NULL;
 
     ptempListNode = (tempListNode *)ellFirst(&tempList);
-    ptemp = ptempListNode->item;
-    ellDelete(&tempList,(ELLNODE *)ptempListNode);
-    freeListFree(freeListPvt,ptempListNode);
+    if(ptempListNode) {
+        ptemp = ptempListNode->item;
+        ellDelete(&tempList,(ELLNODE *)ptempListNode);
+        freeListFree(freeListPvt,ptempListNode);
+    }
     return(ptemp);
 }
 

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1058,7 +1058,7 @@ int dbRecordNameValidate(const char *name)
     const char *pos = name;
 
     if (!*name) {
-        yyerrorAbort("dbRecordHead: Record name can't be empty");
+        yyerrorAbort("Error: Record/Alias name can't be empty");
         return 1;
     }
 
@@ -1067,16 +1067,16 @@ int dbRecordNameValidate(const char *name)
         if(i==0) {
             /* first character restrictions */
             if(c=='-' || c=='+' || c=='[' || c=='{') {
-                errlogPrintf("Warning: Record name '%s' should not begin with '%c'\n", name, c);
+                errlogPrintf("Warning: Record/Alias name '%s' should not begin with '%c'\n", name, c);
             }
         }
         /* any character restrictions */
         if(c < ' ') {
-            errlogPrintf("Warning: Record name '%s' should not contain non-printable 0x%02u\n",
+            errlogPrintf("Warning: Record/Alias name '%s' should not contain non-printable 0x%02u\n",
                          name, (unsigned)c);
 
         } else if(c==' ' || c=='\t' || c=='"' || c=='\'' || c=='.' || c=='$') {
-            epicsPrintf("Error: Bad character '%c' in record name \"%s\"\n",
+            epicsPrintf("Error: Bad character '%c' in Record/Alias name \"%s\"\n",
                 c, name);
             yyerrorAbort(NULL);
             return 1;
@@ -1223,10 +1223,9 @@ static void dbRecordAlias(char *name)
     tempListNode *ptempListNode;
     long status;
 
-    if (!*name) {
-        yyerrorAbort("dbRecordAlias: Alias name can't be empty");
+    if(dbRecordNameValidate(name))
         return;
-    }
+
     if (duplicate) return;
     ptempListNode = (tempListNode *)ellFirst(&tempList);
     pdbentry = ptempListNode->item;
@@ -1244,10 +1243,9 @@ static void dbAlias(char *name, char *alias)
     DBENTRY dbEntry;
     DBENTRY *pdbEntry = &dbEntry;
 
-    if (!*alias) {
-        yyerrorAbort("dbAlias: Alias name can't be empty");
+    if(dbRecordNameValidate(alias))
         return;
-    }
+
     dbInitEntry(pdbbase, pdbEntry);
     if (dbFindRecord(pdbEntry, name)) {
         epicsPrintf("Alias \"%s\" refers to unknown record \"%s\"\n",

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -479,12 +479,16 @@ static void dbMenuBody(void)
         return;
     }
     pnewMenu = (dbMenu *)popFirstTemp();
+    if(!pnewMenu)
+        return;
     pnewMenu->nChoice = nChoice = ellCount(&tempList)/2;
     pnewMenu->papChoiceName = dbCalloc(pnewMenu->nChoice,sizeof(char *));
     pnewMenu->papChoiceValue = dbCalloc(pnewMenu->nChoice,sizeof(char *));
     for(i=0; i<nChoice; i++) {
         pnewMenu->papChoiceName[i] = (char *)popFirstTemp();
         pnewMenu->papChoiceValue[i] = (char *)popFirstTemp();
+        if(!pnewMenu->papChoiceName[i] || !pnewMenu->papChoiceValue[i])
+            return;
     }
     if(ellCount(&tempList)) yyerrorAbort("dbMenuBody: tempList not empty");
     /* Add menu in sorted order */
@@ -705,6 +709,8 @@ static void dbRecordtypeBody(void)
         return;
     }
     pdbRecordType= (dbRecordType *)popFirstTemp();
+    if(!pdbRecordType)
+        return;
     pdbRecordType->no_fields = no_fields = ellCount(&tempList);
     pdbRecordType->papFldDes = dbCalloc(no_fields,sizeof(dbFldDes *));
     pdbRecordType->papsortFldName = dbCalloc(no_fields,sizeof(char *));
@@ -712,6 +718,8 @@ static void dbRecordtypeBody(void)
     no_prompt = no_links = 0;
     for(i=0; i<no_fields; i++) {
         pdbFldDes = (dbFldDes *)popFirstTemp();
+        if(!pdbFldDes)
+            return;
         pdbFldDes->pdbRecordType = pdbRecordType;
         pdbFldDes->indRecordType = i;
         pdbRecordType->papFldDes[i] = pdbFldDes;
@@ -976,6 +984,8 @@ static void dbBreakBody(void)
         return;
     }
     pnewbrkTable = (brkTable *)popFirstTemp();
+    if(!pnewbrkTable)
+        return;
     number = ellCount(&tempList);
     if (number % 2) {
         yyerrorAbort("breaktable: Raw value missing");
@@ -992,10 +1002,14 @@ static void dbBreakBody(void)
         char    *str;
 
         str = (char *)popFirstTemp();
+        if(!str)
+            return;
         (void) epicsScanDouble(str, &paBrkInt[i].raw);
         free(str);
 
         str = (char *)popFirstTemp();
+        if(!str)
+            return;
         (void) epicsScanDouble(str, &paBrkInt[i].eng);
         free(str);
     }

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1045,10 +1045,15 @@ static void dbRecordHead(char *recordType, char *name, int visible)
         yyerrorAbort("dbRecordHead: Record name can't be empty");
         return;
     }
-    badch = strpbrk(name, " \"'.$");
+    badch = strpbrk(name, " \t\"'.$");
     if (badch) {
-        epicsPrintf("Bad character '%c' in record name \"%s\"\n",
+        epicsPrintf("Error: Bad character '%c' in record name \"%s\"\n",
             *badch, name);
+        yyerrorAbort(NULL);
+        return;
+    } else if((*name >= '0' && *name <= '9') || *name=='{') {
+        epicsPrintf("Warning: Bad character '%c' begins record name \"%s\"\n",
+            *name, name);
     }
 
     pdbentry = dbAllocEntry(pdbbase);


### PR DESCRIPTION
This change converts the warning in `dbRecordHead()` added by bdbada28a82ef88a7005653e979ae7bc2eb603be (in 2012) to an error, and also add `'\t'`.

It further adds a new warning for record names which begin with a number or `'{'`.

The bulk of the changeset ensure an error in `dbRecordHead()` doesn't escalate into a crash.