### PR TITLE
Add spdx license tags

### DIFF
--- a/configure/CONFIG.gnuCommon
+++ b/configure/CONFIG.gnuCommon
@@ -3,8 +3,7 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
+# EPICS Base is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution. 
 #*************************************************************************
 

--- a/configure/Sample.Makefile
+++ b/configure/Sample.Makefile
@@ -3,8 +3,8 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution. 
 #*************************************************************************
 #	Makefile  for  base/src/sample

--- a/modules/ca/src/client/CASG.cpp
+++ b/modules/ca/src/client/CASG.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/SearchDest.h
+++ b/modules/ca/src/client/SearchDest.h
@@ -3,8 +3,8 @@
  *     National Laboratory.
  * Copyright (c) 2002 The Regents of the University of California, as
  *     Operator of Los Alamos National Laboratory.
- * EPICS BASE Versions 3.13.7
- * and higher are distributed subject to a Software License Agreement found
+ * SPDX-License-Identifier: EPICS
+ * EPICS Base is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/ca/src/client/access.cpp
+++ b/modules/ca/src/client/access.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/acctst.c
+++ b/modules/ca/src/client/acctst.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/ca/src/client/acctstMain.c
+++ b/modules/ca/src/client/acctstMain.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/ca/src/client/acctstRegister.cpp
+++ b/modules/ca/src/client/acctstRegister.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/addrList.h
+++ b/modules/ca/src/client/addrList.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/autoPtrFreeList.h
+++ b/modules/ca/src/client/autoPtrFreeList.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/autoPtrRecycle.h
+++ b/modules/ca/src/client/autoPtrRecycle.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/ca/src/client/baseNMIU.cpp
+++ b/modules/ca/src/client/baseNMIU.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/bhe.cpp
+++ b/modules/ca/src/client/bhe.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/bhe.h
+++ b/modules/ca/src/client/bhe.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caConnTest.cpp
+++ b/modules/ca/src/client/caConnTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caConnTestMain.cpp
+++ b/modules/ca/src/client/caConnTestMain.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caDiagnostics.h
+++ b/modules/ca/src/client/caDiagnostics.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caEventRate.cpp
+++ b/modules/ca/src/client/caEventRate.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caEventRateMain.cpp
+++ b/modules/ca/src/client/caEventRateMain.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caProto.h
+++ b/modules/ca/src/client/caProto.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caRepeater.cpp
+++ b/modules/ca/src/client/caRepeater.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caServerID.h
+++ b/modules/ca/src/client/caServerID.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caVersion.h@
+++ b/modules/ca/src/client/caVersion.h@
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2017 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/ca_client_context.cpp
+++ b/modules/ca/src/client/ca_client_context.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cac.cpp
+++ b/modules/ca/src/client/cac.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cac.h
+++ b/modules/ca/src/client/cac.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cacChannel.cpp
+++ b/modules/ca/src/client/cacChannel.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cacChannelNotify.cpp
+++ b/modules/ca/src/client/cacChannelNotify.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cacContextNotify.cpp
+++ b/modules/ca/src/client/cacContextNotify.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cacIO.h
+++ b/modules/ca/src/client/cacIO.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cacReadNotify.cpp
+++ b/modules/ca/src/client/cacReadNotify.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cacStateNotify.cpp
+++ b/modules/ca/src/client/cacStateNotify.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cacWriteNotify.cpp
+++ b/modules/ca/src/client/cacWriteNotify.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/cadef.h
+++ b/modules/ca/src/client/cadef.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caerr.h
+++ b/modules/ca/src/client/caerr.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/caeventmask.h
+++ b/modules/ca/src/client/caeventmask.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/ca/src/client/casw.cpp
+++ b/modules/ca/src/client/casw.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/catime.c
+++ b/modules/ca/src/client/catime.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/ca/src/client/catimeMain.c
+++ b/modules/ca/src/client/catimeMain.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/ca/src/client/comBuf.cpp
+++ b/modules/ca/src/client/comBuf.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/comBuf.h
+++ b/modules/ca/src/client/comBuf.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/comQueRecv.cpp
+++ b/modules/ca/src/client/comQueRecv.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/comQueRecv.h
+++ b/modules/ca/src/client/comQueRecv.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/comQueSend.cpp
+++ b/modules/ca/src/client/comQueSend.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/comQueSend.h
+++ b/modules/ca/src/client/comQueSend.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/convert.cpp
+++ b/modules/ca/src/client/convert.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/db_access.h
+++ b/modules/ca/src/client/db_access.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/disconnectGovernorTimer.cpp
+++ b/modules/ca/src/client/disconnectGovernorTimer.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/disconnectGovernorTimer.h
+++ b/modules/ca/src/client/disconnectGovernorTimer.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/evtime.c
+++ b/modules/ca/src/client/evtime.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/ca/src/client/getCallback.cpp
+++ b/modules/ca/src/client/getCallback.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/getCopy.cpp
+++ b/modules/ca/src/client/getCopy.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/hostNameCache.cpp
+++ b/modules/ca/src/client/hostNameCache.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/hostNameCache.h
+++ b/modules/ca/src/client/hostNameCache.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/inetAddrID.h
+++ b/modules/ca/src/client/inetAddrID.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/iocinf.cpp
+++ b/modules/ca/src/client/iocinf.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/iocinf.h
+++ b/modules/ca/src/client/iocinf.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/localHostName.cpp
+++ b/modules/ca/src/client/localHostName.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/localHostName.h
+++ b/modules/ca/src/client/localHostName.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/msgForMultiplyDefinedPV.cpp
+++ b/modules/ca/src/client/msgForMultiplyDefinedPV.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/msgForMultiplyDefinedPV.h
+++ b/modules/ca/src/client/msgForMultiplyDefinedPV.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/nciu.cpp
+++ b/modules/ca/src/client/nciu.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/nciu.h
+++ b/modules/ca/src/client/nciu.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/netIO.h
+++ b/modules/ca/src/client/netIO.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/netReadNotifyIO.cpp
+++ b/modules/ca/src/client/netReadNotifyIO.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/netSubscription.cpp
+++ b/modules/ca/src/client/netSubscription.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/netWriteNotifyIO.cpp
+++ b/modules/ca/src/client/netWriteNotifyIO.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/net_convert.h
+++ b/modules/ca/src/client/net_convert.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/netiiu.cpp
+++ b/modules/ca/src/client/netiiu.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/netiiu.h
+++ b/modules/ca/src/client/netiiu.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/noopiiu.cpp
+++ b/modules/ca/src/client/noopiiu.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/noopiiu.h
+++ b/modules/ca/src/client/noopiiu.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/oldAccess.h
+++ b/modules/ca/src/client/oldAccess.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/oldChannelNotify.cpp
+++ b/modules/ca/src/client/oldChannelNotify.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/oldSubscription.cpp
+++ b/modules/ca/src/client/oldSubscription.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/putCallback.cpp
+++ b/modules/ca/src/client/putCallback.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/repeater.cpp
+++ b/modules/ca/src/client/repeater.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/repeaterClient.h
+++ b/modules/ca/src/client/repeaterClient.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/repeaterSubscribeTimer.cpp
+++ b/modules/ca/src/client/repeaterSubscribeTimer.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/repeaterSubscribeTimer.h
+++ b/modules/ca/src/client/repeaterSubscribeTimer.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/searchTimer.cpp
+++ b/modules/ca/src/client/searchTimer.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/searchTimer.h
+++ b/modules/ca/src/client/searchTimer.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/sgAutoPtr.h
+++ b/modules/ca/src/client/sgAutoPtr.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/syncGroup.h
+++ b/modules/ca/src/client/syncGroup.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/syncGroupNotify.cpp
+++ b/modules/ca/src/client/syncGroupNotify.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/syncGroupReadNotify.cpp
+++ b/modules/ca/src/client/syncGroupReadNotify.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/syncGroupWriteNotify.cpp
+++ b/modules/ca/src/client/syncGroupWriteNotify.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/syncgrp.cpp
+++ b/modules/ca/src/client/syncgrp.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/tcpRecvWatchdog.cpp
+++ b/modules/ca/src/client/tcpRecvWatchdog.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/tcpRecvWatchdog.h
+++ b/modules/ca/src/client/tcpRecvWatchdog.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/tcpSendWatchdog.cpp
+++ b/modules/ca/src/client/tcpSendWatchdog.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/tcpSendWatchdog.h
+++ b/modules/ca/src/client/tcpSendWatchdog.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/tcpiiu.cpp
+++ b/modules/ca/src/client/tcpiiu.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/test/ca_test.c
+++ b/modules/ca/src/client/test/ca_test.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/ca/src/client/test/ca_test.h
+++ b/modules/ca/src/client/test/ca_test.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/ca/src/client/test/ca_test_main.c
+++ b/modules/ca/src/client/test/ca_test_main.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/ca/src/client/test_event.cpp
+++ b/modules/ca/src/client/test_event.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/udpiiu.h
+++ b/modules/ca/src/client/udpiiu.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/client/virtualCircuit.h
+++ b/modules/ca/src/client/virtualCircuit.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/perl/CA.pm
+++ b/modules/ca/src/perl/CA.pm
@@ -1,3 +1,11 @@
+#*************************************************************************
+# Copyright (c) 2014 UChicago Argonne LLC, as Operator of Argonne
+#     National Laboratory.
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
+
 # Bootstrap wrapper for the Perl 5 Channel Access client module.
 # This wrapper also contains the POD documentation for the module.
 

--- a/modules/ca/src/perl/Cap5.xs
+++ b/modules/ca/src/perl/Cap5.xs
@@ -1,3 +1,11 @@
+/*************************************************************************\
+* Copyright (c) 2005 UChicago Argonne LLC, as Operator of Argonne
+*     National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
 /* Provides an EPICS Channel Access client interface for Perl5. */
 
 /* This macro disables perl's reentr.inc file, which we don't need

--- a/modules/ca/src/perl/capr.pl
+++ b/modules/ca/src/perl/capr.pl
@@ -1,4 +1,11 @@
 #!/usr/bin/env perl
+#*************************************************************************
+# Copyright (c) 2005 UChicago Argonne LLC, as Operator of Argonne
+#     National Laboratory.
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
 
 #######################################################################
 #

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -7,6 +7,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2002 Berliner Elektronenspeicherringgesellschaft fuer
 *     Synchrotronstrahlung.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/tools/cainfo.c
+++ b/modules/ca/src/tools/cainfo.c
@@ -6,6 +6,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2002 Berliner Elektronenspeicherringgesellschaft fuer
 *     Synchrotronstrahlung.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/tools/camonitor.c
+++ b/modules/ca/src/tools/camonitor.c
@@ -6,6 +6,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2002 Berliner Elektronenspeicherringgesellschaft fuer
 *     Synchrotronstrahlung.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/tools/caput.c
+++ b/modules/ca/src/tools/caput.c
@@ -7,6 +7,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2002 Berliner Elektronenspeicherringgesellschaft fuer
 *     Synchrotronstrahlung.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/tools/tool_lib.c
+++ b/modules/ca/src/tools/tool_lib.c
@@ -6,6 +6,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2002 Berliner Elektronenspeicherringgesellschaft fuer
 *     Synchrotronstrahlung.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/ca/src/tools/tool_lib.h
+++ b/modules/ca/src/tools/tool_lib.h
@@ -5,6 +5,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2002 Berliner Elektronenspeicherringgesellschaft fuer
 *     Synchrotronstrahlung.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/as/asCa.c
+++ b/modules/database/src/ioc/as/asCa.c
@@ -4,6 +4,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/as/asCa.h
+++ b/modules/database/src/ioc/as/asCa.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/as/asDbLib.c
+++ b/modules/database/src/ioc/as/asDbLib.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/as/asDbLib.h
+++ b/modules/database/src/ioc/as/asDbLib.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* Author:  Marty Kraimer Date:    02-23-94*/

--- a/modules/database/src/ioc/as/asIocRegister.c
+++ b/modules/database/src/ioc/as/asIocRegister.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/as/asIocRegister.h
+++ b/modules/database/src/ioc/as/asIocRegister.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/as/ascheck.c
+++ b/modules/database/src/ioc/as/ascheck.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/bpt/cvtTable.h
+++ b/modules/database/src/ioc/bpt/cvtTable.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/database/src/ioc/bpt/makeBpt.c
+++ b/modules/database/src/ioc/bpt/makeBpt.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/database/src/ioc/databaseVersion.h@
+++ b/modules/database/src/ioc/databaseVersion.h@
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2017 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/callback.c
+++ b/modules/database/src/ioc/db/callback.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/callback.h
+++ b/modules/database/src/ioc/db/callback.h
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/chfPlugin.c
+++ b/modules/database/src/ioc/db/chfPlugin.c
@@ -3,6 +3,7 @@
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     für Materialien und Energie GmbH.
 * Copyright (c) 2014 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/chfPlugin.h
+++ b/modules/database/src/ioc/db/chfPlugin.h
@@ -3,6 +3,7 @@
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     für Materialien und Energie GmbH.
 * Copyright (c) 2014 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/cvtBpt.c
+++ b/modules/database/src/ioc/db/cvtBpt.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbAccess.h
+++ b/modules/database/src/ioc/db/dbAccess.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbAccessDefs.h
+++ b/modules/database/src/ioc/db/dbAccessDefs.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbAddr.h
+++ b/modules/database/src/ioc/db/dbAddr.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbBkpt.c
+++ b/modules/database/src/ioc/db/dbBkpt.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* dbBkpt.c */

--- a/modules/database/src/ioc/db/dbBkpt.h
+++ b/modules/database/src/ioc/db/dbBkpt.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* dbBkpt.h                     */

--- a/modules/database/src/ioc/db/dbCAC.h
+++ b/modules/database/src/ioc/db/dbCAC.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/database/src/ioc/db/dbCa.c
+++ b/modules/database/src/ioc/db/dbCa.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbCa.h
+++ b/modules/database/src/ioc/db/dbCa.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbCaPvt.h
+++ b/modules/database/src/ioc/db/dbCaPvt.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbCaTest.c
+++ b/modules/database/src/ioc/db/dbCaTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbCaTest.h
+++ b/modules/database/src/ioc/db/dbCaTest.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbChannel.c
+++ b/modules/database/src/ioc/db/dbChannel.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbChannel.h
+++ b/modules/database/src/ioc/db/dbChannel.h
@@ -4,6 +4,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbChannelIO.cpp
+++ b/modules/database/src/ioc/db/dbChannelIO.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbChannelIO.h
+++ b/modules/database/src/ioc/db/dbChannelIO.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/database/src/ioc/db/dbConstLink.c
+++ b/modules/database/src/ioc/db/dbConstLink.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbConstLink.h
+++ b/modules/database/src/ioc/db/dbConstLink.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbContext.cpp
+++ b/modules/database/src/ioc/db/dbContext.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbContextReadNotifyCache.cpp
+++ b/modules/database/src/ioc/db/dbContextReadNotifyCache.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/database/src/ioc/db/dbConvert.c
+++ b/modules/database/src/ioc/db/dbConvert.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbConvert.h
+++ b/modules/database/src/ioc/db/dbConvert.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbConvertFast.h
+++ b/modules/database/src/ioc/db/dbConvertFast.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* dbConvertFast.h */

--- a/modules/database/src/ioc/db/dbConvertJSON.c
+++ b/modules/database/src/ioc/db/dbConvertJSON.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2016 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbConvertJSON.h
+++ b/modules/database/src/ioc/db/dbConvertJSON.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2016 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbDbLink.c
+++ b/modules/database/src/ioc/db/dbDbLink.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbDbLink.h
+++ b/modules/database/src/ioc/db/dbDbLink.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbEvent.h
+++ b/modules/database/src/ioc/db/dbEvent.h
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbExtractArray.c
+++ b/modules/database/src/ioc/db/dbExtractArray.c
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbExtractArray.h
+++ b/modules/database/src/ioc/db/dbExtractArray.h
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbFastLinkConv.c
+++ b/modules/database/src/ioc/db/dbFastLinkConv.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbIocRegister.c
+++ b/modules/database/src/ioc/db/dbIocRegister.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbIocRegister.h
+++ b/modules/database/src/ioc/db/dbIocRegister.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbJLink.c
+++ b/modules/database/src/ioc/db/dbJLink.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2016 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbJLink.h
+++ b/modules/database/src/ioc/db/dbJLink.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2016 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbLink.c
+++ b/modules/database/src/ioc/db/dbLink.c
@@ -3,6 +3,7 @@
  *     National Laboratory.
  * Copyright (c) 2002 The Regents of the University of California, as
  *     Operator of Los Alamos National Laboratory.
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbLock.c
+++ b/modules/database/src/ioc/db/dbLock.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/database/src/ioc/db/dbLock.h
+++ b/modules/database/src/ioc/db/dbLock.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* dbLock.h */

--- a/modules/database/src/ioc/db/dbLockPvt.h
+++ b/modules/database/src/ioc/db/dbLockPvt.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Assoc., as Operator of Brookhaven
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbNotify.c
+++ b/modules/database/src/ioc/db/dbNotify.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbNotify.h
+++ b/modules/database/src/ioc/db/dbNotify.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbPutNotifyBlocker.cpp
+++ b/modules/database/src/ioc/db/dbPutNotifyBlocker.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbPutNotifyBlocker.h
+++ b/modules/database/src/ioc/db/dbPutNotifyBlocker.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/database/src/ioc/db/dbScan.c
+++ b/modules/database/src/ioc/db/dbScan.c
@@ -5,6 +5,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 Helmholtz-Zentrum Berlin
 *     für Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbScan.h
+++ b/modules/database/src/ioc/db/dbScan.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbServer.c
+++ b/modules/database/src/ioc/db/dbServer.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbServer.h
+++ b/modules/database/src/ioc/db/dbServer.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbState.c
+++ b/modules/database/src/ioc/db/dbState.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbState.h
+++ b/modules/database/src/ioc/db/dbState.h
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbSubscriptionIO.cpp
+++ b/modules/database/src/ioc/db/dbSubscriptionIO.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbTest.c
+++ b/modules/database/src/ioc/db/dbTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbTest.h
+++ b/modules/database/src/ioc/db/dbTest.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/dbUnitTest.c
+++ b/modules/database/src/ioc/db/dbUnitTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2013 Brookhaven National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/src/ioc/db/dbUnitTest.h
+++ b/modules/database/src/ioc/db/dbUnitTest.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2013 Brookhaven National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/src/ioc/db/db_access.c
+++ b/modules/database/src/ioc/db/db_access.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/db_access_routines.h
+++ b/modules/database/src/ioc/db/db_access_routines.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/db_convert.h
+++ b/modules/database/src/ioc/db/db_convert.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* db_convert.h */

--- a/modules/database/src/ioc/db/db_field_log.h
+++ b/modules/database/src/ioc/db/db_field_log.h
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/db_test.c
+++ b/modules/database/src/ioc/db/db_test.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/db_test.h
+++ b/modules/database/src/ioc/db/db_test.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/menuAlarmStat.dbd.pod
+++ b/modules/database/src/ioc/db/menuAlarmStat.dbd.pod
@@ -3,8 +3,8 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution. 
 #*************************************************************************
 

--- a/modules/database/src/ioc/db/menuPriority.dbd
+++ b/modules/database/src/ioc/db/menuPriority.dbd
@@ -3,8 +3,8 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution. 
 #*************************************************************************
 menu(menuPriority) {

--- a/modules/database/src/ioc/db/recGbl.c
+++ b/modules/database/src/ioc/db/recGbl.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/db/recGbl.h
+++ b/modules/database/src/ioc/db/recGbl.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/dbBase.h
+++ b/modules/database/src/ioc/dbStatic/dbBase.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/dbFldTypes.h
+++ b/modules/database/src/ioc/dbStatic/dbFldTypes.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/database/src/ioc/dbStatic/dbLex.l
+++ b/modules/database/src/ioc/dbStatic/dbLex.l
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/dbPvdLib.c
+++ b/modules/database/src/ioc/dbStatic/dbPvdLib.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/dbStaticIocRegister.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticIocRegister.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/dbStaticIocRegister.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticIocRegister.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*  dbStaticPvt.h */

--- a/modules/database/src/ioc/dbStatic/dbStaticRun.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticRun.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*dbStaticLibRun.c*/

--- a/modules/database/src/ioc/dbStatic/dbYacc.y
+++ b/modules/database/src/ioc/dbStatic/dbYacc.y
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/devSup.h
+++ b/modules/database/src/ioc/dbStatic/devSup.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/drvSup.h
+++ b/modules/database/src/ioc/dbStatic/drvSup.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/guigroup.h
+++ b/modules/database/src/ioc/dbStatic/guigroup.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/database/src/ioc/dbStatic/link.h
+++ b/modules/database/src/ioc/dbStatic/link.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/recSup.h
+++ b/modules/database/src/ioc/dbStatic/recSup.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbStatic/special.h
+++ b/modules/database/src/ioc/dbStatic/special.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* special.h */

--- a/modules/database/src/ioc/dbtemplate/dbLoadTemplate.h
+++ b/modules/database/src/ioc/dbtemplate/dbLoadTemplate.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbtemplate/dbLoadTemplate.y
+++ b/modules/database/src/ioc/dbtemplate/dbLoadTemplate.y
@@ -3,6 +3,7 @@
 /*************************************************************************\
 * Copyright (c) 2006 UChicago, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbtemplate/dbLoadTemplate_lex.l
+++ b/modules/database/src/ioc/dbtemplate/dbLoadTemplate_lex.l
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2006 UChicago, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbtemplate/dbtoolsIocRegister.c
+++ b/modules/database/src/ioc/dbtemplate/dbtoolsIocRegister.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2007 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbtemplate/dbtoolsIocRegister.h
+++ b/modules/database/src/ioc/dbtemplate/dbtoolsIocRegister.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2007 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/dbtemplate/msi.cpp
+++ b/modules/database/src/ioc/dbtemplate/msi.cpp
@@ -3,6 +3,7 @@
 * National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 * Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS Base is distributed subject to a Software License Agreement found
 * in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/misc/dlload.c
+++ b/modules/database/src/ioc/misc/dlload.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2009 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/misc/epicsRelease.c
+++ b/modules/database/src/ioc/misc/epicsRelease.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/misc/epicsRelease.h
+++ b/modules/database/src/ioc/misc/epicsRelease.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* epicsRelease.h */

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -5,6 +5,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 Helmholtz-Zentrum Berlin
 *     für Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/misc/iocInit.h
+++ b/modules/database/src/ioc/misc/iocInit.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/misc/iocshRegisterCommon.c
+++ b/modules/database/src/ioc/misc/iocshRegisterCommon.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/misc/iocshRegisterCommon.h
+++ b/modules/database/src/ioc/misc/iocshRegisterCommon.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/misc/miscIocRegister.c
+++ b/modules/database/src/ioc/misc/miscIocRegister.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/misc/miscIocRegister.h
+++ b/modules/database/src/ioc/misc/miscIocRegister.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryCommon.c
+++ b/modules/database/src/ioc/registry/registryCommon.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryCommon.h
+++ b/modules/database/src/ioc/registry/registryCommon.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryDeviceSupport.c
+++ b/modules/database/src/ioc/registry/registryDeviceSupport.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryDeviceSupport.h
+++ b/modules/database/src/ioc/registry/registryDeviceSupport.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryDriverSupport.c
+++ b/modules/database/src/ioc/registry/registryDriverSupport.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryDriverSupport.h
+++ b/modules/database/src/ioc/registry/registryDriverSupport.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryFunction.c
+++ b/modules/database/src/ioc/registry/registryFunction.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryFunction.h
+++ b/modules/database/src/ioc/registry/registryFunction.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryIocRegister.c
+++ b/modules/database/src/ioc/registry/registryIocRegister.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryIocRegister.h
+++ b/modules/database/src/ioc/registry/registryIocRegister.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryJLinks.c
+++ b/modules/database/src/ioc/registry/registryJLinks.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2016 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryJLinks.h
+++ b/modules/database/src/ioc/registry/registryJLinks.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryRecordType.c
+++ b/modules/database/src/ioc/registry/registryRecordType.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/registry/registryRecordType.h
+++ b/modules/database/src/ioc/registry/registryRecordType.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/rsrv/camsgtask.c
+++ b/modules/database/src/ioc/rsrv/camsgtask.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/database/src/ioc/rsrv/caserverio.c
+++ b/modules/database/src/ioc/rsrv/caserverio.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/rsrv/cast_server.c
+++ b/modules/database/src/ioc/rsrv/cast_server.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/rsrv/online_notify.c
+++ b/modules/database/src/ioc/rsrv/online_notify.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/database/src/ioc/rsrv/rsrv.h
+++ b/modules/database/src/ioc/rsrv/rsrv.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/rsrv/rsrvIocRegister.c
+++ b/modules/database/src/ioc/rsrv/rsrvIocRegister.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/ioc/rsrv/server.h
+++ b/modules/database/src/ioc/rsrv/server.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/asSubRecordFunctions.c
+++ b/modules/database/src/std/dev/asSubRecordFunctions.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* asSubRecordFunctions.c */

--- a/modules/database/src/std/dev/devAaiSoft.c
+++ b/modules/database/src/std/dev/devAaiSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devAaoSoft.c
+++ b/modules/database/src/std/dev/devAaoSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devAiSoft.c
+++ b/modules/database/src/std/dev/devAiSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devAiSoftCallback.c
+++ b/modules/database/src/std/dev/devAiSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devAiSoftRaw.c
+++ b/modules/database/src/std/dev/devAiSoftRaw.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devAoSoft.c
+++ b/modules/database/src/std/dev/devAoSoft.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* devAoSoft.c */

--- a/modules/database/src/std/dev/devAoSoftCallback.c
+++ b/modules/database/src/std/dev/devAoSoftCallback.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* devAoSoftCallbackCallback.c */

--- a/modules/database/src/std/dev/devAoSoftRaw.c
+++ b/modules/database/src/std/dev/devAoSoftRaw.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* devAoSoftRaw.c */

--- a/modules/database/src/std/dev/devBiDbState.c
+++ b/modules/database/src/std/dev/devBiDbState.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devBiSoft.c
+++ b/modules/database/src/std/dev/devBiSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devBiSoftCallback.c
+++ b/modules/database/src/std/dev/devBiSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devBiSoftRaw.c
+++ b/modules/database/src/std/dev/devBiSoftRaw.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devBoDbState.c
+++ b/modules/database/src/std/dev/devBoDbState.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devBoSoft.c
+++ b/modules/database/src/std/dev/devBoSoft.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/database/src/std/dev/devBoSoftCallback.c
+++ b/modules/database/src/std/dev/devBoSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devBoSoftRaw.c
+++ b/modules/database/src/std/dev/devBoSoftRaw.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/database/src/std/dev/devCalcoutSoft.c
+++ b/modules/database/src/std/dev/devCalcoutSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devCalcoutSoftCallback.c
+++ b/modules/database/src/std/dev/devCalcoutSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devEnviron.c
+++ b/modules/database/src/std/dev/devEnviron.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2016 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devEventSoft.c
+++ b/modules/database/src/std/dev/devEventSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devGeneralTime.c
+++ b/modules/database/src/std/dev/devGeneralTime.c
@@ -1,4 +1,5 @@
 /*************************************************************************\
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devHistogramSoft.c
+++ b/modules/database/src/std/dev/devHistogramSoft.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* devHistogramSoft.c */

--- a/modules/database/src/std/dev/devI64inSoft.c
+++ b/modules/database/src/std/dev/devI64inSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devI64inSoftCallback.c
+++ b/modules/database/src/std/dev/devI64inSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devI64outSoft.c
+++ b/modules/database/src/std/dev/devI64outSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devI64outSoftCallback.c
+++ b/modules/database/src/std/dev/devI64outSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devLiSoft.c
+++ b/modules/database/src/std/dev/devLiSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devLiSoftCallback.c
+++ b/modules/database/src/std/dev/devLiSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devLoSoft.c
+++ b/modules/database/src/std/dev/devLoSoft.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* devLoSoft.c */

--- a/modules/database/src/std/dev/devLoSoftCallback.c
+++ b/modules/database/src/std/dev/devLoSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devLsiSoft.c
+++ b/modules/database/src/std/dev/devLsiSoft.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devLsoSoft.c
+++ b/modules/database/src/std/dev/devLsoSoft.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devLsoSoftCallback.c
+++ b/modules/database/src/std/dev/devLsoSoftCallback.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbbiDirectSoft.c
+++ b/modules/database/src/std/dev/devMbbiDirectSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbbiDirectSoftCallback.c
+++ b/modules/database/src/std/dev/devMbbiDirectSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbbiDirectSoftRaw.c
+++ b/modules/database/src/std/dev/devMbbiDirectSoftRaw.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbbiSoft.c
+++ b/modules/database/src/std/dev/devMbbiSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbbiSoftCallback.c
+++ b/modules/database/src/std/dev/devMbbiSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbbiSoftRaw.c
+++ b/modules/database/src/std/dev/devMbbiSoftRaw.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbboDirectSoft.c
+++ b/modules/database/src/std/dev/devMbboDirectSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbboDirectSoftCallback.c
+++ b/modules/database/src/std/dev/devMbboDirectSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbboDirectSoftRaw.c
+++ b/modules/database/src/std/dev/devMbboDirectSoftRaw.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbboSoft.c
+++ b/modules/database/src/std/dev/devMbboSoft.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* devMbboSoft.c */

--- a/modules/database/src/std/dev/devMbboSoftCallback.c
+++ b/modules/database/src/std/dev/devMbboSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devMbboSoftRaw.c
+++ b/modules/database/src/std/dev/devMbboSoftRaw.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devPrintfSoft.c
+++ b/modules/database/src/std/dev/devPrintfSoft.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devPrintfSoftCallback.c
+++ b/modules/database/src/std/dev/devPrintfSoftCallback.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devSASoft.c
+++ b/modules/database/src/std/dev/devSASoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 Lawrence Berkeley Laboratory,The Control Systems
 *     Group, Systems Engineering Department
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devSiSoft.c
+++ b/modules/database/src/std/dev/devSiSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devSiSoftCallback.c
+++ b/modules/database/src/std/dev/devSiSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devSoSoft.c
+++ b/modules/database/src/std/dev/devSoSoft.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/database/src/std/dev/devSoSoftCallback.c
+++ b/modules/database/src/std/dev/devSoSoftCallback.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devStdio.c
+++ b/modules/database/src/std/dev/devStdio.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devTimestamp.c
+++ b/modules/database/src/std/dev/devTimestamp.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/dev/devWfSoft.c
+++ b/modules/database/src/std/dev/devWfSoft.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/filters/arr.c
+++ b/modules/database/src/std/filters/arr.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/filters/dbnd.c
+++ b/modules/database/src/std/filters/dbnd.c
@@ -3,6 +3,7 @@
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     für Materialien und Energie GmbH.
 * Copyright (c) 2014 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/filters/decimate.c
+++ b/modules/database/src/std/filters/decimate.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/filters/sync.c
+++ b/modules/database/src/std/filters/sync.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/filters/ts.c
+++ b/modules/database/src/std/filters/ts.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/link/lnkCalc.c
+++ b/modules/database/src/std/link/lnkCalc.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2016 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/link/lnkConst.c
+++ b/modules/database/src/std/link/lnkConst.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2016 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/link/lnkDebug.c
+++ b/modules/database/src/std/link/lnkDebug.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2018 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/link/lnkState.c
+++ b/modules/database/src/std/link/lnkState.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2017 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/aSubRecord.c
+++ b/modules/database/src/std/rec/aSubRecord.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/aaiRecord.c
+++ b/modules/database/src/std/rec/aaiRecord.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 Southeastern Universities Research Association, as
 *     Operator of Thomas Jefferson National Accelerator Facility.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/aaoRecord.c
+++ b/modules/database/src/std/rec/aaoRecord.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 Southeastern Universities Research Association, as
 *     Operator of Thomas Jefferson National Accelerator Facility.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/aiRecord.c
+++ b/modules/database/src/std/rec/aiRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/aoRecord.c
+++ b/modules/database/src/std/rec/aoRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/biRecord.c
+++ b/modules/database/src/std/rec/biRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/boRecord.c
+++ b/modules/database/src/std/rec/boRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/calcRecord.c
+++ b/modules/database/src/std/rec/calcRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/calcoutRecord.c
+++ b/modules/database/src/std/rec/calcoutRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/compressRecord.c
+++ b/modules/database/src/std/rec/compressRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/dfanoutRecord.c
+++ b/modules/database/src/std/rec/dfanoutRecord.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 Southeastern Universities Research Association, as
 *     Operator of Thomas Jefferson National Accelerator Facility.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/eventRecord.c
+++ b/modules/database/src/std/rec/eventRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/fanoutRecord.c
+++ b/modules/database/src/std/rec/fanoutRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/histogramRecord.c
+++ b/modules/database/src/std/rec/histogramRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/int64inRecord.c
+++ b/modules/database/src/std/rec/int64inRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/int64outRecord.c
+++ b/modules/database/src/std/rec/int64outRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/longinRecord.c
+++ b/modules/database/src/std/rec/longinRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/longoutRecord.c
+++ b/modules/database/src/std/rec/longoutRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/lsiRecord.c
+++ b/modules/database/src/std/rec/lsiRecord.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/lsoRecord.c
+++ b/modules/database/src/std/rec/lsoRecord.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/mbbiDirectRecord.c
+++ b/modules/database/src/std/rec/mbbiDirectRecord.c
@@ -5,6 +5,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2002 Southeastern Universities Research Association, as
 *     Operator of Thomas Jefferson National Accelerator Facility.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/mbbiRecord.c
+++ b/modules/database/src/std/rec/mbbiRecord.c
@@ -4,6 +4,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/mbboDirectRecord.c
+++ b/modules/database/src/std/rec/mbboDirectRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/mbboRecord.c
+++ b/modules/database/src/std/rec/mbboRecord.c
@@ -4,6 +4,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/permissiveRecord.c
+++ b/modules/database/src/std/rec/permissiveRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/printfRecord.c
+++ b/modules/database/src/std/rec/printfRecord.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/selRecord.c
+++ b/modules/database/src/std/rec/selRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/seqRecord.c
+++ b/modules/database/src/std/rec/seqRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/stateRecord.c
+++ b/modules/database/src/std/rec/stateRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/stringinRecord.c
+++ b/modules/database/src/std/rec/stringinRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/stringoutRecord.c
+++ b/modules/database/src/std/rec/stringoutRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/subArrayRecord.c
+++ b/modules/database/src/std/rec/subArrayRecord.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 Lawrence Berkeley Laboratory,The Control Systems
 *     Group, Systems Engineering Department
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/subRecord.c
+++ b/modules/database/src/std/rec/subRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/rec/waveformRecord.c
+++ b/modules/database/src/std/rec/waveformRecord.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/std/softIoc/makeInstallDir.pl
+++ b/modules/database/src/std/softIoc/makeInstallDir.pl
@@ -2,6 +2,7 @@
 #*************************************************************************
 # Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/src/std/softIoc/softMain.cpp
+++ b/modules/database/src/std/softIoc/softMain.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2003 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to the Software License Agreement
 * found in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/src/tools/DBD.pm
+++ b/modules/database/src/tools/DBD.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD;
 
 use strict;

--- a/modules/database/src/tools/DBD/Base.pm
+++ b/modules/database/src/tools/DBD/Base.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 # Common utility functions used by the DBD components
 
 package DBD::Base;

--- a/modules/database/src/tools/DBD/Breaktable.pm
+++ b/modules/database/src/tools/DBD/Breaktable.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Breaktable;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/DBD/Device.pm
+++ b/modules/database/src/tools/DBD/Device.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Device;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/DBD/Driver.pm
+++ b/modules/database/src/tools/DBD/Driver.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Driver;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/DBD/Function.pm
+++ b/modules/database/src/tools/DBD/Function.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Function;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/DBD/Link.pm
+++ b/modules/database/src/tools/DBD/Link.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Link;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/DBD/Menu.pm
+++ b/modules/database/src/tools/DBD/Menu.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Menu;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/DBD/Output.pm
+++ b/modules/database/src/tools/DBD/Output.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Output;
 
 use strict;

--- a/modules/database/src/tools/DBD/Parser.pm
+++ b/modules/database/src/tools/DBD/Parser.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Parser;
 
 use strict;

--- a/modules/database/src/tools/DBD/Recfield.pm
+++ b/modules/database/src/tools/DBD/Recfield.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Recfield;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/DBD/Record.pm
+++ b/modules/database/src/tools/DBD/Record.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Record;
 
 use strict;

--- a/modules/database/src/tools/DBD/Recordtype.pm
+++ b/modules/database/src/tools/DBD/Recordtype.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Recordtype;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/DBD/Registrar.pm
+++ b/modules/database/src/tools/DBD/Registrar.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Registrar;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/DBD/Variable.pm
+++ b/modules/database/src/tools/DBD/Variable.pm
@@ -1,3 +1,9 @@
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
+
 package DBD::Variable;
 use DBD::Base;
 our @ISA = qw(DBD::Base);

--- a/modules/database/src/tools/EPICS/IOC.pm
+++ b/modules/database/src/tools/EPICS/IOC.pm
@@ -1,4 +1,5 @@
 ######################################################################
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement
 # found in file LICENSE that is included with this distribution.
 #

--- a/modules/database/src/tools/dbExpand.pl
+++ b/modules/database/src/tools/dbExpand.pl
@@ -3,6 +3,7 @@
 #*************************************************************************
 # Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/src/tools/dbdExpand.pl
+++ b/modules/database/src/tools/dbdExpand.pl
@@ -3,6 +3,7 @@
 #*************************************************************************
 # Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/src/tools/dbdReport.pl
+++ b/modules/database/src/tools/dbdReport.pl
@@ -3,6 +3,7 @@
 #*************************************************************************
 # Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/src/tools/dbdToHtml.pl
+++ b/modules/database/src/tools/dbdToHtml.pl
@@ -3,6 +3,7 @@
 #*************************************************************************
 # Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/src/tools/dbdToMenuH.pl
+++ b/modules/database/src/tools/dbdToMenuH.pl
@@ -3,6 +3,7 @@
 #*************************************************************************
 # Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/src/tools/dbdToRecordtypeH.pl
+++ b/modules/database/src/tools/dbdToRecordtypeH.pl
@@ -3,6 +3,7 @@
 #*************************************************************************
 # Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/src/tools/makeIncludeDbd.pl
+++ b/modules/database/src/tools/makeIncludeDbd.pl
@@ -3,6 +3,7 @@
 #*************************************************************************
 # Copyright (c) 2014 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/src/tools/registerRecordDeviceDriver.pl
+++ b/modules/database/src/tools/registerRecordDeviceDriver.pl
@@ -5,6 +5,7 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/test/ioc/db/arrRecord.c
+++ b/modules/database/test/ioc/db/arrRecord.c
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/arrShorthandTest.c
+++ b/modules/database/test/ioc/db/arrShorthandTest.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/benchdbConvert.c
+++ b/modules/database/test/ioc/db/benchdbConvert.c
@@ -1,6 +1,9 @@
 /*************************************************************************\
 * Copyright (c) 2013 Brookhaven Science Assoc, as Operator of Brookhaven
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
 \*************************************************************************/
 #include "string.h"
 

--- a/modules/database/test/ioc/db/callbackParallelTest.c
+++ b/modules/database/test/ioc/db/callbackParallelTest.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/callbackTest.c
+++ b/modules/database/test/ioc/db/callbackTest.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/chfPluginTest.c
+++ b/modules/database/test/ioc/db/chfPluginTest.c
@@ -3,6 +3,7 @@
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     für Materialien und Energie GmbH.
 * Copyright (c) 2014 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/dbCACTest.cpp
+++ b/modules/database/test/ioc/db/dbCACTest.cpp
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Assoc. as operator of Brookhaven
 *               National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/dbCaLinkTest.c
+++ b/modules/database/test/ioc/db/dbCaLinkTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Assoc. as operator of Brookhaven
 *               National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/dbCaStatsTest.c
+++ b/modules/database/test/ioc/db/dbCaStatsTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2014 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/dbChArrTest.cpp
+++ b/modules/database/test/ioc/db/dbChArrTest.cpp
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2003 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to the Software License Agreement
 * found in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/dbChannelTest.c
+++ b/modules/database/test/ioc/db/dbChannelTest.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/dbLinkdset.c
+++ b/modules/database/test/ioc/db/dbLinkdset.c
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+ \*************************************************************************/
 
 #include <stdlib.h>
 

--- a/modules/database/test/ioc/db/dbLockTest.c
+++ b/modules/database/test/ioc/db/dbLockTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Assoc. as operator of Brookhaven
 *               National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/dbPutGetTest.c
+++ b/modules/database/test/ioc/db/dbPutGetTest.c
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+ \*************************************************************************/
 
 #include <string.h>
 

--- a/modules/database/test/ioc/db/dbPutLinkTest.c
+++ b/modules/database/test/ioc/db/dbPutLinkTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Assoc. as operator of Brookhaven
 *               National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/dbScanTest.c
+++ b/modules/database/test/ioc/db/dbScanTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Assoc. as operator of Brookhaven
 *               National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/dbServerTest.c
+++ b/modules/database/test/ioc/db/dbServerTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2017 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/dbShutdownTest.c
+++ b/modules/database/test/ioc/db/dbShutdownTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2013 Brookhaven National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/dbStateTest.c
+++ b/modules/database/test/ioc/db/dbStateTest.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/dbStaticTest.c
+++ b/modules/database/test/ioc/db/dbStaticTest.c
@@ -1,3 +1,9 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+ \*************************************************************************/
+
 #include <string.h>
 
 #include <errlog.h>

--- a/modules/database/test/ioc/db/dbStressLock.c
+++ b/modules/database/test/ioc/db/dbStressLock.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Assoc. as operator of Brookhaven
 *               National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/devx.c
+++ b/modules/database/test/ioc/db/devx.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Assoc. as Operator of Brookhaven
 *     National Lab
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/devx.h
+++ b/modules/database/test/ioc/db/devx.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Assoc. as Operator of Brookhaven
 *     National Lab
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/epicsRunDbTests.c
+++ b/modules/database/test/ioc/db/epicsRunDbTests.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/jlinkz.c
+++ b/modules/database/test/ioc/db/jlinkz.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2016 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/jlinkz.h
+++ b/modules/database/test/ioc/db/jlinkz.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2016 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/db/recGblCheckDeadbandTest.c
+++ b/modules/database/test/ioc/db/recGblCheckDeadbandTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2014 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/rtemsTestHarness.c
+++ b/modules/database/test/ioc/db/rtemsTestHarness.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/scanIoTest.c
+++ b/modules/database/test/ioc/db/scanIoTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2013 Helmholtz-Zentrum Berlin
 *     für Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/testdbConvert.c
+++ b/modules/database/test/ioc/db/testdbConvert.c
@@ -1,6 +1,9 @@
 /*************************************************************************\
 * Copyright (c) 2013 Brookhaven Science Assoc, as Operator of Brookhaven
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
 \*************************************************************************/
 #include "string.h"
 

--- a/modules/database/test/ioc/db/xLink.c
+++ b/modules/database/test/ioc/db/xLink.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2016 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/db/xRecord.c
+++ b/modules/database/test/ioc/db/xRecord.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/ioc/dbtemplate/dbltExpand.c
+++ b/modules/database/test/ioc/dbtemplate/dbltExpand.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 * National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS Base is distributed subject to a Software License Agreement found
 * in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/ioc/dbtemplate/msi.plt
+++ b/modules/database/test/ioc/dbtemplate/msi.plt
@@ -2,6 +2,7 @@
 #*************************************************************************
 # Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/database/test/std/filters/arrRecord.c
+++ b/modules/database/test/std/filters/arrRecord.c
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/filters/arrTest.cpp
+++ b/modules/database/test/std/filters/arrTest.cpp
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2003 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to the Software License Agreement
 * found in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/filters/dbndTest.c
+++ b/modules/database/test/std/filters/dbndTest.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/filters/decTest.c
+++ b/modules/database/test/std/filters/decTest.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/filters/epicsRunFilterTests.c
+++ b/modules/database/test/std/filters/epicsRunFilterTests.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/filters/rtemsTestHarness.c
+++ b/modules/database/test/std/filters/rtemsTestHarness.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/filters/syncTest.c
+++ b/modules/database/test/std/filters/syncTest.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/filters/tsTest.c
+++ b/modules/database/test/std/filters/tsTest.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/filters/xRecord.c
+++ b/modules/database/test/std/filters/xRecord.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2010 Brookhaven National Laboratory.
 * Copyright (c) 2010 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/std/link/epicsRunLinkTests.c
+++ b/modules/database/test/std/link/epicsRunLinkTests.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2018 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/link/ioRecord.c
+++ b/modules/database/test/std/link/ioRecord.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2018 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in the file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/std/link/lnkCalcTest.c
+++ b/modules/database/test/std/link/lnkCalcTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2018 Andrew Johnson
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/link/lnkStateTest.c
+++ b/modules/database/test/std/link/lnkStateTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2018 Andrew Johnson
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/link/rtemsTestHarness.c
+++ b/modules/database/test/std/link/rtemsTestHarness.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2018 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in the file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/analogMonitorTest.c
+++ b/modules/database/test/std/rec/analogMonitorTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2014 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/arrayOpTest.c
+++ b/modules/database/test/std/rec/arrayOpTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Assoc. as operator of Brookhaven
 *               National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/std/rec/asTest.c
+++ b/modules/database/test/std/rec/asTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Assoc. as operator of Brookhaven
 *               National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/std/rec/asTestLib.c
+++ b/modules/database/test/std/rec/asTestLib.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Assoc. as operator of Brookhaven
 *               National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/std/rec/asyncSoftTest.c
+++ b/modules/database/test/std/rec/asyncSoftTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2017 UChicago Argonne LLC, as operator of Argonne
 * National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/asyncproctest.c
+++ b/modules/database/test/std/rec/asyncproctest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2018 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/compressTest.c
+++ b/modules/database/test/std/rec/compressTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2016 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/dbHeaderTest.c
+++ b/modules/database/test/std/rec/dbHeaderTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2019 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/epicsRunRecordTests.c
+++ b/modules/database/test/std/rec/epicsRunRecordTests.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/linkInitTest.c
+++ b/modules/database/test/std/rec/linkInitTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2015 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/linkRetargetLinkTest.c
+++ b/modules/database/test/std/rec/linkRetargetLinkTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2015 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/std/rec/mbbioDirectTest.c
+++ b/modules/database/test/std/rec/mbbioDirectTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2017 Dirk Zimoch
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/recMiscTest.c
+++ b/modules/database/test/std/rec/recMiscTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2017 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/regressTest.c
+++ b/modules/database/test/std/rec/regressTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2016 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/std/rec/rtemsTestHarness.c
+++ b/modules/database/test/std/rec/rtemsTestHarness.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/scanEventTest.c
+++ b/modules/database/test/std/rec/scanEventTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2018 Paul Scherrer Institut
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
  \*************************************************************************/

--- a/modules/database/test/std/rec/seqTest.c
+++ b/modules/database/test/std/rec/seqTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2020 Gabriel Fedel
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/simmTest.c
+++ b/modules/database/test/std/rec/simmTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2017 ITER Organization
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/softTest.c
+++ b/modules/database/test/std/rec/softTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2017 UChicago Argonne LLC, as operator of Argonne
 * National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/tools/Base.plt
+++ b/modules/database/test/tools/Base.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/Breaktable.plt
+++ b/modules/database/test/tools/Breaktable.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/DBD.plt
+++ b/modules/database/test/tools/DBD.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/Device.plt
+++ b/modules/database/test/tools/Device.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/Driver.plt
+++ b/modules/database/test/tools/Driver.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/Function.plt
+++ b/modules/database/test/tools/Function.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/Menu.plt
+++ b/modules/database/test/tools/Menu.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/Recfield.plt
+++ b/modules/database/test/tools/Recfield.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/Recordtype.plt
+++ b/modules/database/test/tools/Recordtype.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/Registrar.plt
+++ b/modules/database/test/tools/Registrar.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/database/test/tools/Variable.plt
+++ b/modules/database/test/tools/Variable.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/libcom/RTEMS/epicsMemFs.c
+++ b/modules/libcom/RTEMS/epicsMemFs.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/RTEMS/epicsMemFs.h
+++ b/modules/libcom/RTEMS/epicsMemFs.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/RTEMS/epicsRtemsInitHookPost.c
+++ b/modules/libcom/RTEMS/epicsRtemsInitHookPost.c
@@ -1,8 +1,8 @@
 /*************************************************************************\
 * Copyright (c) 2006 The University of Chicago, as Operator of Argonne
 *     National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/RTEMS/epicsRtemsInitHookPre.c
+++ b/modules/libcom/RTEMS/epicsRtemsInitHookPre.c
@@ -1,8 +1,8 @@
 /*************************************************************************\
 * Copyright (c) 2006 The University of Chicago, as Operator of Argonne
 *     National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/RTEMS/epicsRtemsInitHooks.h
+++ b/modules/libcom/RTEMS/epicsRtemsInitHooks.h
@@ -1,8 +1,8 @@
 /*************************************************************************\
 * Copyright (c) 2006 The University of Chicago, as Operator of Argonne
 *     National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/RTEMS/ne2kpci.c
+++ b/modules/libcom/RTEMS/ne2kpci.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/RTEMS/rtems_config.c
+++ b/modules/libcom/RTEMS/rtems_config.c
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/RTEMS/rtems_init.c
+++ b/modules/libcom/RTEMS/rtems_init.c
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/RTEMS/rtems_netconfig.c
+++ b/modules/libcom/RTEMS/rtems_netconfig.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/RTEMS/rtems_util.c
+++ b/modules/libcom/RTEMS/rtems_util.c
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
+++ b/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/as/asLib.h
+++ b/modules/libcom/src/as/asLib.h
@@ -4,6 +4,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/as/asLib.y
+++ b/modules/libcom/src/as/asLib.y
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/as/asLib_lex.l
+++ b/modules/libcom/src/as/asLib_lex.l
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/as/asTrapWrite.c
+++ b/modules/libcom/src/as/asTrapWrite.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/as/asTrapWrite.h
+++ b/modules/libcom/src/as/asTrapWrite.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/bucketLib/bucketLib.c
+++ b/modules/libcom/src/bucketLib/bucketLib.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/bucketLib/bucketLib.h
+++ b/modules/libcom/src/bucketLib/bucketLib.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/calc/calcPerform.c
+++ b/modules/libcom/src/calc/calcPerform.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/calc/postfix.c
+++ b/modules/libcom/src/calc/postfix.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/calc/postfix.h
+++ b/modules/libcom/src/calc/postfix.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/calc/postfixPvt.h
+++ b/modules/libcom/src/calc/postfixPvt.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/cppStd/epicsAlgorithm.h
+++ b/modules/libcom/src/cppStd/epicsAlgorithm.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/cvtFast/cvtFast.c
+++ b/modules/libcom/src/cvtFast/cvtFast.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/cvtFast/cvtFast.h
+++ b/modules/libcom/src/cvtFast/cvtFast.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/cxxTemplates/epicsGuard.h
+++ b/modules/libcom/src/cxxTemplates/epicsGuard.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/epicsSingleton.h
+++ b/modules/libcom/src/cxxTemplates/epicsSingleton.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/epicsSingletonMutex.cpp
+++ b/modules/libcom/src/cxxTemplates/epicsSingletonMutex.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/resourceLib.cpp
+++ b/modules/libcom/src/cxxTemplates/resourceLib.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/cxxTemplates/resourceLib.h
+++ b/modules/libcom/src/cxxTemplates/resourceLib.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/cxxTemplates/test/minmaxTest.cc
+++ b/modules/libcom/src/cxxTemplates/test/minmaxTest.cc
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/test/resourceLibTest.cc
+++ b/modules/libcom/src/cxxTemplates/test/resourceLibTest.cc
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/test/tsDLListBench.cc
+++ b/modules/libcom/src/cxxTemplates/test/tsDLListBench.cc
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/test/tsDLListTest.cc
+++ b/modules/libcom/src/cxxTemplates/test/tsDLListTest.cc
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/test/tsSLListBench.cc
+++ b/modules/libcom/src/cxxTemplates/test/tsSLListBench.cc
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/test/tsSLListTest.cc
+++ b/modules/libcom/src/cxxTemplates/test/tsSLListTest.cc
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/tsDLList.h
+++ b/modules/libcom/src/cxxTemplates/tsDLList.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/cxxTemplates/tsFreeList.h
+++ b/modules/libcom/src/cxxTemplates/tsFreeList.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/tsMinMax.h
+++ b/modules/libcom/src/cxxTemplates/tsMinMax.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/cxxTemplates/tsSLList.h
+++ b/modules/libcom/src/cxxTemplates/tsSLList.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/dbmf/dbmf.c
+++ b/modules/libcom/src/dbmf/dbmf.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/dbmf/dbmf.h
+++ b/modules/libcom/src/dbmf/dbmf.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/ellLib/ellLib.c
+++ b/modules/libcom/src/ellLib/ellLib.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/ellLib/ellLib.h
+++ b/modules/libcom/src/ellLib/ellLib.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/ellLib/ellSort.c
+++ b/modules/libcom/src/ellLib/ellSort.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2014 Brookhaven Science Assoc., as Operator of Argonne
 *     National Laboratory.
 * Copyright (c) 2016 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/env/bldEnvData.pl
+++ b/modules/libcom/src/env/bldEnvData.pl
@@ -4,6 +4,7 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/libcom/src/env/envDefs.h
+++ b/modules/libcom/src/env/envDefs.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/env/envSubr.c
+++ b/modules/libcom/src/env/envSubr.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/error/epicsPrint.h
+++ b/modules/libcom/src/error/epicsPrint.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*epicsPrint.h */

--- a/modules/libcom/src/error/errMdef.h
+++ b/modules/libcom/src/error/errMdef.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/error/errSymLib.c
+++ b/modules/libcom/src/error/errSymLib.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/error/errSymTbl.h
+++ b/modules/libcom/src/error/errSymTbl.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/error/makeStatTbl.pl
+++ b/modules/libcom/src/error/makeStatTbl.pl
@@ -5,6 +5,7 @@
 #     National Laboratory.
 # Copyright (c) 2014 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/libcom/src/fdmgr/fdManager.cpp
+++ b/modules/libcom/src/fdmgr/fdManager.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 //

--- a/modules/libcom/src/fdmgr/fdManager.h
+++ b/modules/libcom/src/fdmgr/fdManager.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/fdmgr/fdmgr.cpp
+++ b/modules/libcom/src/fdmgr/fdmgr.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 //

--- a/modules/libcom/src/fdmgr/fdmgr.h
+++ b/modules/libcom/src/fdmgr/fdmgr.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* fdmgr.h

--- a/modules/libcom/src/flex/ccl.c
+++ b/modules/libcom/src/flex/ccl.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* ccl - routines for character classes */
 
 /*-

--- a/modules/libcom/src/flex/dfa.c
+++ b/modules/libcom/src/flex/dfa.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* dfa - DFA construction routines */
 
 /*-

--- a/modules/libcom/src/flex/ecs.c
+++ b/modules/libcom/src/flex/ecs.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* ecs - equivalence class routines */
 
 /*-

--- a/modules/libcom/src/flex/flex.c
+++ b/modules/libcom/src/flex/flex.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* flex - tool to generate fast lexical analyzers */
 
 /*-

--- a/modules/libcom/src/flex/flexdef.h
+++ b/modules/libcom/src/flex/flexdef.h
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* flexdef - definitions file for flex */
 
 /*-

--- a/modules/libcom/src/flex/gen.c
+++ b/modules/libcom/src/flex/gen.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* gen - actual generation (writing) of flex scanners */
 
 /*-

--- a/modules/libcom/src/flex/libmain.c
+++ b/modules/libcom/src/flex/libmain.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* libmain - flex run-time support library "main" function */
 
 extern int yylex();

--- a/modules/libcom/src/flex/misc.c
+++ b/modules/libcom/src/flex/misc.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* misc - miscellaneous flex routines */
 
 /*-

--- a/modules/libcom/src/flex/nfa.c
+++ b/modules/libcom/src/flex/nfa.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* nfa - NFA construction routines */
 
 /*-

--- a/modules/libcom/src/flex/sym.c
+++ b/modules/libcom/src/flex/sym.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* sym - symbol table routines */
 
 /*-

--- a/modules/libcom/src/flex/tblcmp.c
+++ b/modules/libcom/src/flex/tblcmp.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* tblcmp - table compression routines */
 
 /*-

--- a/modules/libcom/src/flex/yylex.c
+++ b/modules/libcom/src/flex/yylex.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* yylex - scanner front-end for flex */
 
 /*-

--- a/modules/libcom/src/freeList/freeList.h
+++ b/modules/libcom/src/freeList/freeList.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* Author:  Marty Kraimer Date:    04-19-94     */

--- a/modules/libcom/src/freeList/freeListLib.c
+++ b/modules/libcom/src/freeList/freeListLib.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* Author:  Marty Kraimer Date:    04-19-94 */

--- a/modules/libcom/src/gpHash/gpHash.h
+++ b/modules/libcom/src/gpHash/gpHash.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* Author:  Marty Kraimer Date:    04-07-94 */

--- a/modules/libcom/src/gpHash/gpHashLib.c
+++ b/modules/libcom/src/gpHash/gpHashLib.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/iocsh/initHooks.c
+++ b/modules/libcom/src/iocsh/initHooks.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/iocsh/initHooks.h
+++ b/modules/libcom/src/iocsh/initHooks.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/iocsh/iocsh.h
+++ b/modules/libcom/src/iocsh/iocsh.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* iocsh.h  ioc: call registered function*/

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The University of Saskatchewan
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/iocsh/libComRegister.h
+++ b/modules/libcom/src/iocsh/libComRegister.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2007 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/iocsh/registry.c
+++ b/modules/libcom/src/iocsh/registry.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*registry.c */

--- a/modules/libcom/src/iocsh/registry.h
+++ b/modules/libcom/src/iocsh/registry.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 #ifndef INCregistryh

--- a/modules/libcom/src/libComVersion.h@
+++ b/modules/libcom/src/libComVersion.h@
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2017 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/log/iocLog.c
+++ b/modules/libcom/src/log/iocLog.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* logClient.c,v 1.25.2.6 2004/10/07 13:37:34 mrk Exp */

--- a/modules/libcom/src/log/iocLog.h
+++ b/modules/libcom/src/log/iocLog.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/log/iocLogServer.c
+++ b/modules/libcom/src/log/iocLogServer.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/log/logClient.c
+++ b/modules/libcom/src/log/logClient.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/log/logClient.h
+++ b/modules/libcom/src/log/logClient.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/macLib/EPICS/macLib.pm
+++ b/modules/libcom/src/macLib/EPICS/macLib.pm
@@ -1,6 +1,7 @@
 #*************************************************************************
 # Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/libcom/src/macLib/macCore.c
+++ b/modules/libcom/src/macLib/macCore.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/macLib/macEnv.c
+++ b/modules/libcom/src/macLib/macEnv.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2009 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/macLib/macLib.h
+++ b/modules/libcom/src/macLib/macLib.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/macLib/macUtil.c
+++ b/modules/libcom/src/macLib/macUtil.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/aToIPAddr.c
+++ b/modules/libcom/src/misc/aToIPAddr.c
@@ -3,6 +3,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/adjustment.c
+++ b/modules/libcom/src/misc/adjustment.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* src/libCom/adjustment.c */

--- a/modules/libcom/src/misc/adjustment.h
+++ b/modules/libcom/src/misc/adjustment.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/misc/alarm.h
+++ b/modules/libcom/src/misc/alarm.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/alarmString.c
+++ b/modules/libcom/src/misc/alarmString.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/alarmString.h
+++ b/modules/libcom/src/misc/alarmString.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/cantProceed.c
+++ b/modules/libcom/src/misc/cantProceed.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/misc/cantProceed.h
+++ b/modules/libcom/src/misc/cantProceed.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/dbDefs.h
+++ b/modules/libcom/src/misc/dbDefs.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsConvert.c
+++ b/modules/libcom/src/misc/epicsConvert.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsConvert.h
+++ b/modules/libcom/src/misc/epicsConvert.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsExit.c
+++ b/modules/libcom/src/misc/epicsExit.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsExit.h
+++ b/modules/libcom/src/misc/epicsExit.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsExport.h
+++ b/modules/libcom/src/misc/epicsExport.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/misc/epicsStdlib.c
+++ b/modules/libcom/src/misc/epicsStdlib.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsStdlib.h
+++ b/modules/libcom/src/misc/epicsStdlib.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsString.c
+++ b/modules/libcom/src/misc/epicsString.c
@@ -4,6 +4,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsString.h
+++ b/modules/libcom/src/misc/epicsString.h
@@ -4,6 +4,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsTypes.h
+++ b/modules/libcom/src/misc/epicsTypes.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsUnitTest.c
+++ b/modules/libcom/src/misc/epicsUnitTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2006 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/epicsUnitTest.h
+++ b/modules/libcom/src/misc/epicsUnitTest.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/ipAddrToAsciiAsynchronous.cpp
+++ b/modules/libcom/src/misc/ipAddrToAsciiAsynchronous.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/misc/ipAddrToAsciiAsynchronous.h
+++ b/modules/libcom/src/misc/ipAddrToAsciiAsynchronous.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/misc/locationException.h
+++ b/modules/libcom/src/misc/locationException.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/misc/makeEpicsVersion.pl
+++ b/modules/libcom/src/misc/makeEpicsVersion.pl
@@ -5,6 +5,7 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/modules/libcom/src/misc/shareLib.h
+++ b/modules/libcom/src/misc/shareLib.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/testMain.h
+++ b/modules/libcom/src/misc/testMain.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2006 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/misc/truncateFile.c
+++ b/modules/libcom/src/misc/truncateFile.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/misc/unixFileName.h
+++ b/modules/libcom/src/misc/unixFileName.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/compiler/clang/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/clang/compilerSpecific.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compiler/clang/epicsAtomicCD.h
+++ b/modules/libcom/src/osi/compiler/clang/epicsAtomicCD.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compiler/default/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/default/compilerSpecific.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compiler/default/epicsAtomicCD.h
+++ b/modules/libcom/src/osi/compiler/default/epicsAtomicCD.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compiler/gcc/epicsAtomicCD.h
+++ b/modules/libcom/src/osi/compiler/gcc/epicsAtomicCD.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compiler/msvc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/msvc/compilerSpecific.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compiler/msvc/epicsAtomicCD.h
+++ b/modules/libcom/src/osi/compiler/msvc/epicsAtomicCD.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compiler/solStudio/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/solStudio/compilerSpecific.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compiler/solStudio/epicsAtomicCD.h
+++ b/modules/libcom/src/osi/compiler/solStudio/epicsAtomicCD.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/compilerDependencies.h
+++ b/modules/libcom/src/osi/compilerDependencies.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/devLib.h
+++ b/modules/libcom/src/osi/devLib.h
@@ -5,6 +5,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/devLibVME.c
+++ b/modules/libcom/src/osi/devLibVME.c
@@ -5,6 +5,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/devLibVME.h
+++ b/modules/libcom/src/osi/devLibVME.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/devLibVMEImpl.h
+++ b/modules/libcom/src/osi/devLibVMEImpl.h
@@ -5,6 +5,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsAssert.h
+++ b/modules/libcom/src/osi/epicsAssert.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsAtomic.h
+++ b/modules/libcom/src/osi/epicsAtomic.h
@@ -3,6 +3,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsAtomicDefault.h
+++ b/modules/libcom/src/osi/epicsAtomicDefault.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsEndian.h
+++ b/modules/libcom/src/osi/epicsEndian.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsEvent.cpp
+++ b/modules/libcom/src/osi/epicsEvent.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsEvent.h
+++ b/modules/libcom/src/osi/epicsEvent.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsFindSymbol.h
+++ b/modules/libcom/src/osi/epicsFindSymbol.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsGeneralTime.c
+++ b/modules/libcom/src/osi/epicsGeneralTime.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2008 Diamond Light Source Ltd
 * Copyright (c) 2004 Oak Ridge National Laboratory
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsGeneralTime.h
+++ b/modules/libcom/src/osi/epicsGeneralTime.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2008 Diamond Light Source Ltd
 * Copyright (c) 2004 Oak Ridge National Laboratory
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsInterrupt.h
+++ b/modules/libcom/src/osi/epicsInterrupt.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsMath.cpp
+++ b/modules/libcom/src/osi/epicsMath.cpp
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2010 UChicago Argonna LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsMessageQueue.cpp
+++ b/modules/libcom/src/osi/epicsMessageQueue.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/epicsMessageQueue.h
+++ b/modules/libcom/src/osi/epicsMessageQueue.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/epicsMutex.cpp
+++ b/modules/libcom/src/osi/epicsMutex.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* epicsMutex.cpp */

--- a/modules/libcom/src/osi/epicsMutex.h
+++ b/modules/libcom/src/osi/epicsMutex.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsReadline.c
+++ b/modules/libcom/src/osi/epicsReadline.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2002 The University of Saskatchewan
 * Copyright (c) 2015 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsReadline.h
+++ b/modules/libcom/src/osi/epicsReadline.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsSignal.h
+++ b/modules/libcom/src/osi/epicsSignal.h
@@ -3,6 +3,7 @@
  *     National Laboratory.
  * Copyright (c) 2002 The Regents of the University of California, as
  *     Operator of Los Alamos National Laboratory.
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsSpin.h
+++ b/modules/libcom/src/osi/epicsSpin.h
@@ -2,6 +2,7 @@
 * Copyright (c) 2012 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
 * Copyright (c) 2012 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsStackTrace.c
+++ b/modules/libcom/src/osi/epicsStackTrace.c
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/epicsStackTrace.h
+++ b/modules/libcom/src/osi/epicsStackTrace.h
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/epicsStackTracePvt.h
+++ b/modules/libcom/src/osi/epicsStackTracePvt.h
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/epicsStdio.c
+++ b/modules/libcom/src/osi/epicsStdio.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsStdio.h
+++ b/modules/libcom/src/osi/epicsStdio.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsStdioRedirect.h
+++ b/modules/libcom/src/osi/epicsStdioRedirect.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsTempFile.h
+++ b/modules/libcom/src/osi/epicsTempFile.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsThread.cpp
+++ b/modules/libcom/src/osi/epicsThread.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsThread.h
+++ b/modules/libcom/src/osi/epicsThread.h
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsTime.cpp
+++ b/modules/libcom/src/osi/epicsTime.cpp
@@ -5,6 +5,7 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2007 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/epicsTime.h
+++ b/modules/libcom/src/osi/epicsTime.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/generalTimeSup.h
+++ b/modules/libcom/src/osi/generalTimeSup.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2008 Diamond Light Source Ltd
 * Copyright (c) 2004 Oak Ridge National Laboratory
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Darwin/epicsMath.h
+++ b/modules/libcom/src/osi/os/Darwin/epicsMath.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Darwin/osdBackTrace.cpp
+++ b/modules/libcom/src/osi/os/Darwin/osdBackTrace.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/Darwin/osdEnv.c
+++ b/modules/libcom/src/osi/os/Darwin/osdEnv.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Darwin/osdFindAddr.c
+++ b/modules/libcom/src/osi/os/Darwin/osdFindAddr.c
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/Darwin/osdMonotonic.c
+++ b/modules/libcom/src/osi/os/Darwin/osdMonotonic.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2017 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Darwin/osdSock.h
+++ b/modules/libcom/src/osi/os/Darwin/osdSock.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Darwin/osdSockUnsentCount.c
+++ b/modules/libcom/src/osi/os/Darwin/osdSockUnsentCount.c
@@ -1,4 +1,5 @@
 /*************************************************************************\
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Darwin/osdTime.cpp
+++ b/modules/libcom/src/osi/os/Darwin/osdTime.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Darwin/osdTime.h
+++ b/modules/libcom/src/osi/os/Darwin/osdTime.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Darwin/osdgetexec.c
+++ b/modules/libcom/src/osi/os/Darwin/osdgetexec.c
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
 
 #include <string.h>
 #include <stdlib.h>

--- a/modules/libcom/src/osi/os/Darwin/osiFileName.h
+++ b/modules/libcom/src/osi/os/Darwin/osiFileName.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/Linux/osdBackTrace.cpp
+++ b/modules/libcom/src/osi/os/Linux/osdBackTrace.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/Linux/osdFindAddr.c
+++ b/modules/libcom/src/osi/os/Linux/osdFindAddr.c
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/Linux/osdSock.h
+++ b/modules/libcom/src/osi/os/Linux/osdSock.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Linux/osdSockUnsentCount.c
+++ b/modules/libcom/src/osi/os/Linux/osdSockUnsentCount.c
@@ -1,4 +1,5 @@
 /*************************************************************************\
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Linux/osdThread.h
+++ b/modules/libcom/src/osi/os/Linux/osdThread.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Linux/osdThreadExtra.c
+++ b/modules/libcom/src/osi/os/Linux/osdThreadExtra.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2012 ITER Organization
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/Linux/osdTime.h
+++ b/modules/libcom/src/osi/os/Linux/osdTime.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/Linux/osdgetexec.c
+++ b/modules/libcom/src/osi/os/Linux/osdgetexec.c
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
 
 #include <string.h>
 #include <stdlib.h>

--- a/modules/libcom/src/osi/os/Linux/osiFileName.h
+++ b/modules/libcom/src/osi/os/Linux/osiFileName.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/Linux/osiUnistd.h
+++ b/modules/libcom/src/osi/os/Linux/osiUnistd.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/RTEMS/devLibVMEOSD.c
+++ b/modules/libcom/src/osi/os/RTEMS/devLibVMEOSD.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/RTEMS/epicsAtomicOSD.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/epicsMMIO.h
+++ b/modules/libcom/src/osi/os/RTEMS/epicsMMIO.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2010 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/epicsMath.h
+++ b/modules/libcom/src/osi/os/RTEMS/epicsMath.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdEnv.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdEnv.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdEvent.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdEvent.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2002 The University of Saskatchewan
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdEvent.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdEvent.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/RTEMS/osdFindSymbol.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdFindSymbol.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdInterrupt.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdInterrupt.c
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/RTEMS/osdInterrupt.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdInterrupt.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/RTEMS/osdMutex.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdMutex.c
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/RTEMS/osdMutex.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdMutex.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/RTEMS/osdPoolStatus.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdPoolStatus.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 #include <rtems/malloc.h>

--- a/modules/libcom/src/osi/os/RTEMS/osdProcess.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdProcess.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/RTEMS/osdReadline.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdReadline.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2002 The University of Saskatchewan
 * Copyright (c) 2014 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdSignal.cpp
+++ b/modules/libcom/src/osi/os/RTEMS/osdSignal.cpp
@@ -3,8 +3,8 @@
  *     National Laboratory.
  * Copyright (c) 2002 The Regents of the University of California, as
  *     Operator of Los Alamos National Laboratory.
- * EPICS BASE Versions 3.13.7
- * and higher are distributed subject to a Software License Agreement found
+ * SPDX-License-Identifier: EPICS
+ * EPICS Base is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/RTEMS/osdSock.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdSock.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdSpin.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdSpin.c
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2013 Brookhaven Science Assoc. as Operator of Brookhaven
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdStrtod.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdStrtod.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/RTEMS/osdThread.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdThread.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdThread.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdThread.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdThreadExtra.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdThreadExtra.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 ITER Organization
 *
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdTime.cpp
+++ b/modules/libcom/src/osi/os/RTEMS/osdTime.cpp
@@ -2,6 +2,7 @@
 * Copyright (c) 2002 The University of Saskatchewan
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdTime.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdTime.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/RTEMS/osdVME.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdVME.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/RTEMS/osiFileName.h
+++ b/modules/libcom/src/osi/os/RTEMS/osiFileName.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/RTEMS/osiUnistd.h
+++ b/modules/libcom/src/osi/os/RTEMS/osiUnistd.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/WIN32/epicsAtomicMS.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsAtomicMS.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsAtomicOSD.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/epicsGetopt.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsGetopt.h
@@ -5,8 +5,8 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2002 Berliner Elektronenspeicherringgesellschaft fuer
 *     Synchrotronstrahlung.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 #ifndef _EPICS_GETOPT_H

--- a/modules/libcom/src/osi/os/WIN32/epicsMath.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsMath.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/epicsSocketConvertErrnoToString.cpp
+++ b/modules/libcom/src/osi/os/WIN32/epicsSocketConvertErrnoToString.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/epicsTempFile.c
+++ b/modules/libcom/src/osi/os/WIN32/epicsTempFile.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/forceBadAllocException.cpp
+++ b/modules/libcom/src/osi/os/WIN32/forceBadAllocException.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 //

--- a/modules/libcom/src/osi/os/WIN32/osdBackTrace.cpp
+++ b/modules/libcom/src/osi/os/WIN32/osdBackTrace.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/WIN32/osdEnv.c
+++ b/modules/libcom/src/osi/os/WIN32/osdEnv.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdEvent.c
+++ b/modules/libcom/src/osi/os/WIN32/osdEvent.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdEvent.h
+++ b/modules/libcom/src/osi/os/WIN32/osdEvent.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* osdEvent.c */

--- a/modules/libcom/src/osi/os/WIN32/osdFindAddr.c
+++ b/modules/libcom/src/osi/os/WIN32/osdFindAddr.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (C) 2017 Freddie Akeroyd
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdFindSymbol.c
+++ b/modules/libcom/src/osi/os/WIN32/osdFindSymbol.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2013 Dirk Zimoch, PSI
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdMonotonic.c
+++ b/modules/libcom/src/osi/os/WIN32/osdMonotonic.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2015 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdMutex.c
+++ b/modules/libcom/src/osi/os/WIN32/osdMutex.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* osdMutex.c */

--- a/modules/libcom/src/osi/os/WIN32/osdMutex.h
+++ b/modules/libcom/src/osi/os/WIN32/osdMutex.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/WIN32/osdNetIntf.c
+++ b/modules/libcom/src/osi/os/WIN32/osdNetIntf.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdPoolStatus.c
+++ b/modules/libcom/src/osi/os/WIN32/osdPoolStatus.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/WIN32/osdPoolStatus.h
+++ b/modules/libcom/src/osi/os/WIN32/osdPoolStatus.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/WIN32/osdProcess.c
+++ b/modules/libcom/src/osi/os/WIN32/osdProcess.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/WIN32/osdSignal.cpp
+++ b/modules/libcom/src/osi/os/WIN32/osdSignal.cpp
@@ -3,8 +3,8 @@
  *     National Laboratory.
  * Copyright (c) 2002 The Regents of the University of California, as
  *     Operator of Los Alamos National Laboratory.
- * EPICS BASE Versions 3.13.7
- * and higher are distributed subject to a Software License Agreement found
+ * SPDX-License-Identifier: EPICS
+ * EPICS Base is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/WIN32/osdSock.c
+++ b/modules/libcom/src/osi/os/WIN32/osdSock.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/WIN32/osdSock.h
+++ b/modules/libcom/src/osi/os/WIN32/osdSock.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdSockUnsentCount.c
+++ b/modules/libcom/src/osi/os/WIN32/osdSockUnsentCount.c
@@ -1,4 +1,5 @@
 /*************************************************************************\
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdStdio.c
+++ b/modules/libcom/src/osi/os/WIN32/osdStdio.c
@@ -4,6 +4,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdStrtod.h
+++ b/modules/libcom/src/osi/os/WIN32/osdStrtod.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/WIN32/osdThread.c
+++ b/modules/libcom/src/osi/os/WIN32/osdThread.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdThread.h
+++ b/modules/libcom/src/osi/os/WIN32/osdThread.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdThreadExtra.c
+++ b/modules/libcom/src/osi/os/WIN32/osdThreadExtra.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 ITER Organization
 *
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdTime.cpp
+++ b/modules/libcom/src/osi/os/WIN32/osdTime.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdTime.h
+++ b/modules/libcom/src/osi/os/WIN32/osdTime.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/osdWireConfig.h
+++ b/modules/libcom/src/osi/os/WIN32/osdWireConfig.h
@@ -1,3 +1,9 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
 /*
  * WIN32 version of
  * osdWireConfig.h

--- a/modules/libcom/src/osi/os/WIN32/osdgetexec.c
+++ b/modules/libcom/src/osi/os/WIN32/osdgetexec.c
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
 
 #include <string.h>
 #include <stdlib.h>

--- a/modules/libcom/src/osi/os/WIN32/osiFileName.h
+++ b/modules/libcom/src/osi/os/WIN32/osiFileName.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/WIN32/osiUnistd.h
+++ b/modules/libcom/src/osi/os/WIN32/osiUnistd.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/WIN32/setThreadName.cpp
+++ b/modules/libcom/src/osi/os/WIN32/setThreadName.cpp
@@ -4,8 +4,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/WIN32/systemCallIntMech.cpp
+++ b/modules/libcom/src/osi/os/WIN32/systemCallIntMech.cpp
@@ -4,8 +4,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/cygwin32/devLibVMEOSD.c
+++ b/modules/libcom/src/osi/os/cygwin32/devLibVMEOSD.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2009 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/cygwin32/osdSock.h
+++ b/modules/libcom/src/osi/os/cygwin32/osdSock.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/cygwin32/osdStrtod.h
+++ b/modules/libcom/src/osi/os/cygwin32/osdStrtod.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/cygwin32/osiFileName.h
+++ b/modules/libcom/src/osi/os/cygwin32/osiFileName.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/cygwin32/systemCallIntMech.cpp
+++ b/modules/libcom/src/osi/os/cygwin32/systemCallIntMech.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/devLibVMEOSD.c
+++ b/modules/libcom/src/osi/os/default/devLibVMEOSD.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2006 The University of Chicago, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/epicsGetopt.h
+++ b/modules/libcom/src/osi/os/default/epicsGetopt.h
@@ -5,8 +5,8 @@
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2002 Berliner Elektronenspeicherringgesellschaft fuer
 *     Synchrotronstrahlung.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 #ifndef _EPICS_GETOPT_H

--- a/modules/libcom/src/osi/os/default/epicsMMIODef.h
+++ b/modules/libcom/src/osi/os/default/epicsMMIODef.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2010 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/epicsSocketConvertErrnoToString.cpp
+++ b/modules/libcom/src/osi/os/default/epicsSocketConvertErrnoToString.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/gnuReadline.c
+++ b/modules/libcom/src/osi/os/default/gnuReadline.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2002 The University of Saskatchewan
 * Copyright (c) 2014 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdAssert.c
+++ b/modules/libcom/src/osi/os/default/osdAssert.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdBackTrace.cpp
+++ b/modules/libcom/src/osi/os/default/osdBackTrace.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/default/osdEnv.c
+++ b/modules/libcom/src/osi/os/default/osdEnv.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdFindAddr.c
+++ b/modules/libcom/src/osi/os/default/osdFindAddr.c
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/default/osdFindSymbol.c
+++ b/modules/libcom/src/osi/os/default/osdFindSymbol.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdInterrupt.c
+++ b/modules/libcom/src/osi/os/default/osdInterrupt.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdInterrupt.h
+++ b/modules/libcom/src/osi/os/default/osdInterrupt.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/default/osdMessageQueue.cpp
+++ b/modules/libcom/src/osi/os/default/osdMessageQueue.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/default/osdNetIntf.c
+++ b/modules/libcom/src/osi/os/default/osdNetIntf.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/default/osdPoolStatus.c
+++ b/modules/libcom/src/osi/os/default/osdPoolStatus.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/default/osdPoolStatus.h
+++ b/modules/libcom/src/osi/os/default/osdPoolStatus.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/default/osdSignal.cpp
+++ b/modules/libcom/src/osi/os/default/osdSignal.cpp
@@ -3,8 +3,8 @@
  *     National Laboratory.
  * Copyright (c) 2002 The Regents of the University of California, as
  *     Operator of Los Alamos National Laboratory.
- * EPICS BASE Versions 3.13.7
- * and higher are distributed subject to a Software License Agreement found
+ * SPDX-License-Identifier: EPICS
+ * EPICS Base is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/default/osdSockAddrReuse.cpp
+++ b/modules/libcom/src/osi/os/default/osdSockAddrReuse.cpp
@@ -4,8 +4,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/default/osdSockUnsentCount.c
+++ b/modules/libcom/src/osi/os/default/osdSockUnsentCount.c
@@ -1,4 +1,5 @@
 /*************************************************************************\
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdSpin.c
+++ b/modules/libcom/src/osi/os/default/osdSpin.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2012 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
 * Copyright (c) 2012 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdThreadExtra.c
+++ b/modules/libcom/src/osi/os/default/osdThreadExtra.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 ITER Organization
 *
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdThreadHooks.c
+++ b/modules/libcom/src/osi/os/default/osdThreadHooks.c
@@ -3,6 +3,7 @@
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
 *
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdVME.h
+++ b/modules/libcom/src/osi/os/default/osdVME.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/default/osdWireConfig.h
+++ b/modules/libcom/src/osi/os/default/osdWireConfig.h
@@ -1,3 +1,9 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
 /*
  * Default version of osdWireConfig.h that might
  * work on UNIX like systems that define <sys/param.h>

--- a/modules/libcom/src/osi/os/default/osdWireFormat.h
+++ b/modules/libcom/src/osi/os/default/osdWireFormat.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/default/osdgetexec.c
+++ b/modules/libcom/src/osi/os/default/osdgetexec.c
@@ -1,3 +1,9 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
 #include <stdlib.h>
 
 #include <osiFileName.h>

--- a/modules/libcom/src/osi/os/freebsd/osdSock.h
+++ b/modules/libcom/src/osi/os/freebsd/osdSock.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/freebsd/osdTime.h
+++ b/modules/libcom/src/osi/os/freebsd/osdTime.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/freebsd/osdgetexec.c
+++ b/modules/libcom/src/osi/os/freebsd/osdgetexec.c
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
 
 #include <string.h>
 #include <stdlib.h>

--- a/modules/libcom/src/osi/os/freebsd/osiFileName.h
+++ b/modules/libcom/src/osi/os/freebsd/osiFileName.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/freebsd/osiUnistd.h
+++ b/modules/libcom/src/osi/os/freebsd/osiUnistd.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/iOS/epicsMath.h
+++ b/modules/libcom/src/osi/os/iOS/epicsMath.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/iOS/osdEnv.c
+++ b/modules/libcom/src/osi/os/iOS/osdEnv.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/iOS/osdMonotonic.c
+++ b/modules/libcom/src/osi/os/iOS/osdMonotonic.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2015 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/iOS/osdSock.h
+++ b/modules/libcom/src/osi/os/iOS/osdSock.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/iOS/osdSockUnsentCount.c
+++ b/modules/libcom/src/osi/os/iOS/osdSockUnsentCount.c
@@ -1,4 +1,5 @@
 /*************************************************************************\
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/iOS/osdTime.h
+++ b/modules/libcom/src/osi/os/iOS/osdTime.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/iOS/osiFileName.h
+++ b/modules/libcom/src/osi/os/iOS/osiFileName.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/epicsAtomicOSD.cpp
+++ b/modules/libcom/src/osi/os/posix/epicsAtomicOSD.cpp
@@ -2,6 +2,7 @@
 /*************************************************************************\
 * Copyright (c) 2011 LANS LLC, as Operator of
 *     Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/posix/epicsAtomicOSD.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/epicsMath.h
+++ b/modules/libcom/src/osi/os/posix/epicsMath.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/epicsTempFile.c
+++ b/modules/libcom/src/osi/os/posix/epicsTempFile.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/posix/osdElfFindAddr.c
+++ b/modules/libcom/src/osi/os/posix/osdElfFindAddr.c
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/posix/osdEvent.c
+++ b/modules/libcom/src/osi/os/posix/osdEvent.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/osdEvent.h
+++ b/modules/libcom/src/osi/os/posix/osdEvent.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* for a pure posix implementation no osdEvent.h definitions are needed*/

--- a/modules/libcom/src/osi/os/posix/osdExecinfoBackTrace.cpp
+++ b/modules/libcom/src/osi/os/posix/osdExecinfoBackTrace.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/posix/osdFindSymbol.c
+++ b/modules/libcom/src/osi/os/posix/osdFindSymbol.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2009 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/osdMonotonic.c
+++ b/modules/libcom/src/osi/os/posix/osdMonotonic.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2015 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/osdMutex.c
+++ b/modules/libcom/src/osi/os/posix/osdMutex.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* osi/os/posix/osdMutex.c */

--- a/modules/libcom/src/osi/os/posix/osdMutex.h
+++ b/modules/libcom/src/osi/os/posix/osdMutex.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* for a pure posix implementation no osdMutex.h definitions are needed*/

--- a/modules/libcom/src/osi/os/posix/osdProcess.c
+++ b/modules/libcom/src/osi/os/posix/osdProcess.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/posix/osdSignal.cpp
+++ b/modules/libcom/src/osi/os/posix/osdSignal.cpp
@@ -3,6 +3,7 @@
  *     National Laboratory.
  * Copyright (c) 2002 The Regents of the University of California, as
  *     Operator of Los Alamos National Laboratory.
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/osdSock.c
+++ b/modules/libcom/src/osi/os/posix/osdSock.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* osdSock.c */

--- a/modules/libcom/src/osi/os/posix/osdSpin.c
+++ b/modules/libcom/src/osi/os/posix/osdSpin.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2012 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
 * Copyright (c) 2012 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/osdStdio.c
+++ b/modules/libcom/src/osi/os/posix/osdStdio.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/posix/osdStrtod.h
+++ b/modules/libcom/src/osi/os/posix/osdStrtod.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/osdThread.h
+++ b/modules/libcom/src/osi/os/posix/osdThread.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/osdThreadExtra.c
+++ b/modules/libcom/src/osi/os/posix/osdThreadExtra.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/osdTime.cpp
+++ b/modules/libcom/src/osi/os/posix/osdTime.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/posix/osdTime.h
+++ b/modules/libcom/src/osi/os/posix/osdTime.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/posix/osiUnistd.h
+++ b/modules/libcom/src/osi/os/posix/osiUnistd.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/posix/systemCallIntMech.cpp
+++ b/modules/libcom/src/osi/os/posix/systemCallIntMech.cpp
@@ -4,8 +4,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/solaris/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/solaris/epicsAtomicOSD.h
@@ -4,6 +4,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/solaris/epicsMath.h
+++ b/modules/libcom/src/osi/os/solaris/epicsMath.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne, LLC as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/solaris/osdBackTrace.cpp
+++ b/modules/libcom/src/osi/os/solaris/osdBackTrace.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/solaris/osdEnv.c
+++ b/modules/libcom/src/osi/os/solaris/osdEnv.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/solaris/osdFindAddr.c
+++ b/modules/libcom/src/osi/os/solaris/osdFindAddr.c
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/src/osi/os/solaris/osdSock.h
+++ b/modules/libcom/src/osi/os/solaris/osdSock.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/solaris/osdStrtod.h
+++ b/modules/libcom/src/osi/os/solaris/osdStrtod.h
@@ -1,7 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/solaris/osdWireConfig.h
+++ b/modules/libcom/src/osi/os/solaris/osdWireConfig.h
@@ -1,3 +1,9 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
 /*
  * Solaris version of
  * osdWireConfig.h

--- a/modules/libcom/src/osi/os/solaris/osdgetexec.c
+++ b/modules/libcom/src/osi/os/solaris/osdgetexec.c
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
 
 #include <string.h>
 #include <stdlib.h>

--- a/modules/libcom/src/osi/os/solaris/osiFileName.h
+++ b/modules/libcom/src/osi/os/solaris/osiFileName.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/vxWorks/atReboot.cpp
+++ b/modules/libcom/src/osi/os/vxWorks/atReboot.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/camacLib.h
+++ b/modules/libcom/src/osi/os/vxWorks/camacLib.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* camacLib.h -- Prototypes for camacLib.o

--- a/modules/libcom/src/osi/os/vxWorks/devLibVMEOSD.c
+++ b/modules/libcom/src/osi/os/vxWorks/devLibVMEOSD.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/vxWorks/epicsAtomicOSD.h
@@ -3,6 +3,7 @@
 *     Los Alamos National Laboratory.
 * Copyright (c) 2011 UChicago Argonne, LLC, as Operator of
 *     Argonne National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/epicsDynLink.c
+++ b/modules/libcom/src/osi/os/vxWorks/epicsDynLink.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/epicsDynLink.h
+++ b/modules/libcom/src/osi/os/vxWorks/epicsDynLink.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/epicsMMIO.h
+++ b/modules/libcom/src/osi/os/vxWorks/epicsMMIO.h
@@ -7,6 +7,7 @@
 *     as Operator of Los Alamos National Laboratory.
 * Copyright (c) 2006 The Board of Trustees of the Leland Stanford Junior
 *     University, as Operator of the Stanford Linear Accelerator Center.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/epicsMath.h
+++ b/modules/libcom/src/osi/os/vxWorks/epicsMath.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/logMsgToErrlog.cpp
+++ b/modules/libcom/src/osi/os/vxWorks/logMsgToErrlog.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/vxWorks/module_types.h
+++ b/modules/libcom/src/osi/os/vxWorks/module_types.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* module_types.h */

--- a/modules/libcom/src/osi/os/vxWorks/osdEnv.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdEnv.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdEvent.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdEvent.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdEvent.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdEvent.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdFindSymbol.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdFindSymbol.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdInterrupt.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdInterrupt.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* osi/os/vxWorks/osdInterrupt.c */

--- a/modules/libcom/src/osi/os/vxWorks/osdInterrupt.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdInterrupt.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* osi/os/vxWorks/osdInterrupt.h */

--- a/modules/libcom/src/osi/os/vxWorks/osdMessageQueue.cpp
+++ b/modules/libcom/src/osi/os/vxWorks/osdMessageQueue.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/vxWorks/osdMessageQueue.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdMessageQueue.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/vxWorks/osdMonotonic.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdMonotonic.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2017 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdMutex.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdMutex.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* os/vxWorks/osdMutex.c */

--- a/modules/libcom/src/osi/os/vxWorks/osdMutex.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdMutex.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* os/vxWorks/osdMutex.h */

--- a/modules/libcom/src/osi/os/vxWorks/osdPoolStatus.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdPoolStatus.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdProcess.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdProcess.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdReadline.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdReadline.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2002 The University of Saskatchewan
 * Copyright (c) 2014 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdSignal.cpp
+++ b/modules/libcom/src/osi/os/vxWorks/osdSignal.cpp
@@ -3,8 +3,8 @@
  *     National Laboratory.
  * Copyright (c) 2002 The Regents of the University of California, as
  *     Operator of Los Alamos National Laboratory.
- * EPICS BASE Versions 3.13.7
- * and higher are distributed subject to a Software License Agreement found
+ * SPDX-License-Identifier: EPICS
+ * EPICS Base is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/vxWorks/osdSock.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdSock.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdSock.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdSock.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdSpin.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdSpin.c
@@ -6,6 +6,7 @@
 *     National Laboratory.
 * Copyright (c) 2013 Brookhaven Science Assoc. as Operator of Brookhaven
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdStdio.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdStdio.c
@@ -4,6 +4,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdStrtod.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdStrtod.h
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2002 The University of Saskatchewan
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdThread.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdThread.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2012 ITER Organization
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdThread.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdThread.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdThreadExtra.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdThreadExtra.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 ITER Organization
 *
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdTime.cpp
+++ b/modules/libcom/src/osi/os/vxWorks/osdTime.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/osdTime.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdTime.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* Following needed for struct timeval */

--- a/modules/libcom/src/osi/os/vxWorks/osdVME.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdVME.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/vxWorks/osdWireConfig.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdWireConfig.h
@@ -1,3 +1,9 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
 /*
  * vxWorks version of
  * osdWireConfig.h

--- a/modules/libcom/src/osi/os/vxWorks/osiFileName.h
+++ b/modules/libcom/src/osi/os/vxWorks/osiFileName.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/vxWorks/task_params.h
+++ b/modules/libcom/src/osi/os/vxWorks/task_params.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/os/vxWorks/tz2timezone.c
+++ b/modules/libcom/src/osi/os/vxWorks/tz2timezone.c
@@ -3,6 +3,7 @@
 *     Brookhaven National Laboratory.
 * Copyright (c) 2019 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/os/vxWorks/veclist.c
+++ b/modules/libcom/src/osi/os/vxWorks/veclist.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/osi/os/vxWorks/vxComLibrary.c
+++ b/modules/libcom/src/osi/os/vxWorks/vxComLibrary.c
@@ -4,8 +4,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/osiClockTime.c
+++ b/modules/libcom/src/osi/osiClockTime.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/osiClockTime.h
+++ b/modules/libcom/src/osi/osiClockTime.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/osiNTPTime.c
+++ b/modules/libcom/src/osi/osiNTPTime.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/osiNTPTime.h
+++ b/modules/libcom/src/osi/osiNTPTime.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/osiPoolStatus.h
+++ b/modules/libcom/src/osi/osiPoolStatus.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/osiProcess.h
+++ b/modules/libcom/src/osi/osiProcess.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/osiSock.c
+++ b/modules/libcom/src/osi/osiSock.c
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/osi/osiSock.h
+++ b/modules/libcom/src/osi/osiSock.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/osi/osiWireFormat.h
+++ b/modules/libcom/src/osi/osiWireFormat.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/pool/epicsThreadPool.h
+++ b/modules/libcom/src/pool/epicsThreadPool.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/pool/poolJob.c
+++ b/modules/libcom/src/pool/poolJob.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/pool/poolPriv.h
+++ b/modules/libcom/src/pool/poolPriv.h
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/pool/threadPool.c
+++ b/modules/libcom/src/pool/threadPool.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/ring/epicsRingBytes.c
+++ b/modules/libcom/src/ring/epicsRingBytes.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2012 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/ring/epicsRingBytes.h
+++ b/modules/libcom/src/ring/epicsRingBytes.h
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2012 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/ring/epicsRingPointer.cpp
+++ b/modules/libcom/src/ring/epicsRingPointer.cpp
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2012 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/ring/epicsRingPointer.h
+++ b/modules/libcom/src/ring/epicsRingPointer.h
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2012 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/taskwd/taskwd.c
+++ b/modules/libcom/src/taskwd/taskwd.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/taskwd/taskwd.h
+++ b/modules/libcom/src/taskwd/taskwd.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/timer/epicsTimer.cpp
+++ b/modules/libcom/src/timer/epicsTimer.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/timer/epicsTimer.h
+++ b/modules/libcom/src/timer/epicsTimer.h
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /* epicsTimer.h */

--- a/modules/libcom/src/timer/timer.cpp
+++ b/modules/libcom/src/timer/timer.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 

--- a/modules/libcom/src/timer/timerPrivate.h
+++ b/modules/libcom/src/timer/timerPrivate.h
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/timer/timerQueue.cpp
+++ b/modules/libcom/src/timer/timerQueue.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/timer/timerQueueActive.cpp
+++ b/modules/libcom/src/timer/timerQueueActive.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/src/timer/timerQueueActiveMgr.cpp
+++ b/modules/libcom/src/timer/timerQueueActiveMgr.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/timer/timerQueuePassive.cpp
+++ b/modules/libcom/src/timer/timerQueuePassive.cpp
@@ -3,8 +3,8 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*

--- a/modules/libcom/src/yacc/antelope.c
+++ b/modules/libcom/src/yacc/antelope.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 #include <signal.h>
 #include "defs.h"
 

--- a/modules/libcom/src/yacc/closure.c
+++ b/modules/libcom/src/yacc/closure.c
@@ -1,12 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
-
 #include "defs.h"
 
 short *itemset;

--- a/modules/libcom/src/yacc/defs.h
+++ b/modules/libcom/src/yacc/defs.h
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 #include <assert.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/modules/libcom/src/yacc/error.c
+++ b/modules/libcom/src/yacc/error.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 /* routines for printing error messages  */
 
 #include "defs.h"

--- a/modules/libcom/src/yacc/lalr.c
+++ b/modules/libcom/src/yacc/lalr.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 #include "defs.h"
 
 typedef

--- a/modules/libcom/src/yacc/lr0.c
+++ b/modules/libcom/src/yacc/lr0.c
@@ -1,12 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
-
 #include "defs.h"
 
 extern short *itemset;

--- a/modules/libcom/src/yacc/mkpar.c
+++ b/modules/libcom/src/yacc/mkpar.c
@@ -1,12 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
-
 #include "defs.h"
 
 action **parser;

--- a/modules/libcom/src/yacc/output.c
+++ b/modules/libcom/src/yacc/output.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 #include "defs.h"
 
 static int nvectors;

--- a/modules/libcom/src/yacc/reader.c
+++ b/modules/libcom/src/yacc/reader.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 #include "defs.h"
 
 /*  The line size must be a positive integer.  One hundred was chosen   */

--- a/modules/libcom/src/yacc/skeleton.c
+++ b/modules/libcom/src/yacc/skeleton.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 #include "defs.h"
 
 /*  If the skeleton is changed, the banner should be changed so that    */

--- a/modules/libcom/src/yacc/symtab.c
+++ b/modules/libcom/src/yacc/symtab.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 #include "defs.h"
 
 

--- a/modules/libcom/src/yacc/verbose.c
+++ b/modules/libcom/src/yacc/verbose.c
@@ -1,12 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
-
 #include "defs.h"
 
 static short *null_rules;

--- a/modules/libcom/src/yacc/warshall.c
+++ b/modules/libcom/src/yacc/warshall.c
@@ -1,11 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE is distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution.
-\*************************************************************************/
 #include "defs.h"
 
 static void

--- a/modules/libcom/src/yacc/yacc.html
+++ b/modules/libcom/src/yacc/yacc.html
@@ -1,12 +1,3 @@
-/*************************************************************************\
-* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-*     National Laboratory.
-* Copyright (c) 2002 The Regents of the University of California, as
-*     Operator of Los Alamos National Laboratory.
-* EPICS BASE Versions 3.13.7
-* and higher are distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution. 
-\*************************************************************************/
 <HTML>
 <BODY>
 <PRE>

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2018 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/blockingSockTest.cpp
+++ b/modules/libcom/test/blockingSockTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/buckTest.c
+++ b/modules/libcom/test/buckTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/cvtFastPerform.cpp
+++ b/modules/libcom/test/cvtFastPerform.cpp
@@ -1,3 +1,9 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
 // Original Author: Jeff Hill, LANL
 
 #include <cmath>

--- a/modules/libcom/test/cvtFastTest.c
+++ b/modules/libcom/test/cvtFastTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2013 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsAlgorithmTest.cpp
+++ b/modules/libcom/test/epicsAlgorithmTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsAtomicPerform.cpp
+++ b/modules/libcom/test/epicsAtomicPerform.cpp
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
 
 #include <cstdlib>
 #include <cstdio>

--- a/modules/libcom/test/epicsAtomicTest.cpp
+++ b/modules/libcom/test/epicsAtomicTest.cpp
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
 
 #include <stdlib.h>
 #include <assert.h>

--- a/modules/libcom/test/epicsCalcTest.cpp
+++ b/modules/libcom/test/epicsCalcTest.cpp
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsEllTest.c
+++ b/modules/libcom/test/epicsEllTest.c
@@ -4,6 +4,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsEnvTest.c
+++ b/modules/libcom/test/epicsEnvTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2013 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsEnvUnsetTest.c
+++ b/modules/libcom/test/epicsEnvUnsetTest.c
@@ -1,3 +1,9 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>

--- a/modules/libcom/test/epicsErrlogTest.c
+++ b/modules/libcom/test/epicsErrlogTest.c
@@ -3,6 +3,7 @@
 *     Brookhaven National Laboratory.
 * Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsEventTest.cpp
+++ b/modules/libcom/test/epicsEventTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsExitTest.c
+++ b/modules/libcom/test/epicsExitTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsInlineTest1.c
+++ b/modules/libcom/test/epicsInlineTest1.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsInlineTest2.c
+++ b/modules/libcom/test/epicsInlineTest2.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsInlineTest3.cpp
+++ b/modules/libcom/test/epicsInlineTest3.cpp
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsInlineTest4.cpp
+++ b/modules/libcom/test/epicsInlineTest4.cpp
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2015 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsLoadTest.cpp
+++ b/modules/libcom/test/epicsLoadTest.cpp
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2020 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsMMIOTest.c
+++ b/modules/libcom/test/epicsMMIOTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2013 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsMathTest.c
+++ b/modules/libcom/test/epicsMathTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsMaxThreads.c
+++ b/modules/libcom/test/epicsMaxThreads.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsMessageQueueTest.cpp
+++ b/modules/libcom/test/epicsMessageQueueTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsMutexTest.cpp
+++ b/modules/libcom/test/epicsMutexTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsRunLibComTests.c
+++ b/modules/libcom/test/epicsRunLibComTests.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsSockResolveTest.c
+++ b/modules/libcom/test/epicsSockResolveTest.c
@@ -3,6 +3,9 @@
 *     Brookhaven National Lab.
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
 \*************************************************************************/
 
 #include "dbDefs.h"

--- a/modules/libcom/test/epicsSpinTest.c
+++ b/modules/libcom/test/epicsSpinTest.c
@@ -2,6 +2,7 @@
 * Copyright (c) 2012 Helmholtz-Zentrum Berlin
 *     fuer Materialien und Energie GmbH.
 * Copyright (c) 2012 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsStackTraceTest.c
+++ b/modules/libcom/test/epicsStackTraceTest.c
@@ -1,6 +1,7 @@
 /*
  * Copyright: Stanford University / SLAC National Laboratory.
  *
+ * SPDX-License-Identifier: EPICS
  * EPICS BASE is distributed subject to a Software License Agreement found
  * in file LICENSE that is included with this distribution.
  *

--- a/modules/libcom/test/epicsStdioTest.c
+++ b/modules/libcom/test/epicsStdioTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsStdlibTest.c
+++ b/modules/libcom/test/epicsStdlibTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsStringTest.c
+++ b/modules/libcom/test/epicsStringTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsThreadClassTest.cpp
+++ b/modules/libcom/test/epicsThreadClassTest.cpp
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2020 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsThreadHooksTest.c
+++ b/modules/libcom/test/epicsThreadHooksTest.c
@@ -3,6 +3,7 @@
 * Copyright (c) 2012 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
 *
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsThreadOnceTest.c
+++ b/modules/libcom/test/epicsThreadOnceTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsThreadPerform.cpp
+++ b/modules/libcom/test/epicsThreadPerform.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsThreadPoolTest.c
+++ b/modules/libcom/test/epicsThreadPoolTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2014 Brookhaven Science Associates, as Operator of
 *     Brookhaven National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsThreadPriorityTest.cpp
+++ b/modules/libcom/test/epicsThreadPriorityTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsThreadPrivateTest.cpp
+++ b/modules/libcom/test/epicsThreadPrivateTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsThreadTest.cpp
+++ b/modules/libcom/test/epicsThreadTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsTimeTest.cpp
+++ b/modules/libcom/test/epicsTimeTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsTimeZoneTest.c
+++ b/modules/libcom/test/epicsTimeZoneTest.c
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2015 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsTimerTest.cpp
+++ b/modules/libcom/test/epicsTimerTest.cpp
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsTypesTest.c
+++ b/modules/libcom/test/epicsTypesTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2011 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsUnitTestTest.c
+++ b/modules/libcom/test/epicsUnitTestTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2006 The University of Chicago, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/epicsUnitTestTest.plt
+++ b/modules/libcom/test/epicsUnitTestTest.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/perl
+#*************************************************************************
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
 
 use strict;
 use Test;

--- a/modules/libcom/test/fdmgrTest.c
+++ b/modules/libcom/test/fdmgrTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/iocshTest.cpp
+++ b/modules/libcom/test/iocshTest.cpp
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2019 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/ipAddrToAsciiTest.cpp
+++ b/modules/libcom/test/ipAddrToAsciiTest.cpp
@@ -1,5 +1,6 @@
 /*************************************************************************\
 * Copyright (c) 2017 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/macDefExpandTest.c
+++ b/modules/libcom/test/macDefExpandTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/macLib.plt
+++ b/modules/libcom/test/macLib.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/perl
+#*************************************************************************
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
 
 use lib '@TOP@/lib/perl';
 

--- a/modules/libcom/test/macLibTest.c
+++ b/modules/libcom/test/macLibTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
+++ b/modules/libcom/test/nonEpicsThreadPriorityTest.cpp
@@ -1,3 +1,9 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
 #include <epicsThread.h>
 #include "epicsUnitTest.h"
 #include "testMain.h"

--- a/modules/libcom/test/osiSockTest.c
+++ b/modules/libcom/test/osiSockTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2017 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/ringBytesTest.c
+++ b/modules/libcom/test/ringBytesTest.c
@@ -3,6 +3,7 @@
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/ringPointerTest.c
+++ b/modules/libcom/test/ringPointerTest.c
@@ -4,6 +4,7 @@
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * Copyright (c) 2013 ITER Organization.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/rtemsTestHarness.c
+++ b/modules/libcom/test/rtemsTestHarness.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2006 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/taskwdTest.c
+++ b/modules/libcom/test/taskwdTest.c
@@ -1,6 +1,7 @@
 /*************************************************************************\
 * Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
+* SPDX-License-Identifier: EPICS
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/libcom/test/testexecname.c
+++ b/modules/libcom/test/testexecname.c
@@ -1,3 +1,8 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
 
 #include <string.h>
 

--- a/src/template/ext/top/configure/RULES_JAVA
+++ b/src/template/ext/top/configure/RULES_JAVA
@@ -3,8 +3,8 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution. 
 #*************************************************************************
 

--- a/src/tools/EPICS/Copy.pm
+++ b/src/tools/EPICS/Copy.pm
@@ -1,6 +1,7 @@
 #*************************************************************************
 # Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/EPICS/Path.pm
+++ b/src/tools/EPICS/Path.pm
@@ -1,6 +1,7 @@
 #*************************************************************************
 # Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/EPICS/Readfile.pm
+++ b/src/tools/EPICS/Readfile.pm
@@ -1,6 +1,7 @@
 #*************************************************************************
 # Copyright (c) 2015 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/EPICS/Release.pm
+++ b/src/tools/EPICS/Release.pm
@@ -1,6 +1,7 @@
 #*************************************************************************
 # Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/EpicsHostArch.pl
+++ b/src/tools/EpicsHostArch.pl
@@ -2,6 +2,7 @@
 #*************************************************************************
 # Copyright (c) 2018 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/assembleSnippets.pl
+++ b/src/tools/assembleSnippets.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 #*************************************************************************
 # Copyright (c) 2015 ITER Organization.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/convertRelease.pl
+++ b/src/tools/convertRelease.pl
@@ -4,6 +4,7 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/cvsclean.pl
+++ b/src/tools/cvsclean.pl
@@ -4,7 +4,8 @@
 # National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 # Operator of Los Alamos National Laboratory.
-# This file is distributed subject to a Software License Agreement found
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
 # in the file LICENSE that is included with this distribution. 
 #*************************************************************************
 

--- a/src/tools/depclean.pl
+++ b/src/tools/depclean.pl
@@ -2,7 +2,8 @@
 #*************************************************************************
 # Copyright (c) 2018 UChicago Argonne LLC, as Operator of Argonne
 # National Laboratory.
-# This file is distributed subject to a Software License Agreement found
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
 # in the file LICENSE that is included with this distribution.
 #*************************************************************************
 

--- a/src/tools/dos2unix.pl
+++ b/src/tools/dos2unix.pl
@@ -4,9 +4,9 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
-# in file LICENSE that is included with this distribution.
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution. 
 #*************************************************************************
 
 # Converts text file in DOS CR/LF format to unix ISO format

--- a/src/tools/epicsProve.pl
+++ b/src/tools/epicsProve.pl
@@ -1,8 +1,11 @@
 #!/usr/bin/env perl
+#*************************************************************************
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
 
-# Some Windows Perl installations provide a prove.bat file which
-# doesn't work properly. This also lets us make the output stand
-# out a bit more.
+# Portable test-runner to make the output stand out a bit more.
 
 use strict;
 use warnings;
@@ -14,9 +17,9 @@ my $path = abs_path('.');
 
 printf "\n%s\n%s\n", '-' x length($path), $path;
 
-my $app = App::Prove->new;
-$app->process_args(@ARGV);
-my $res = $app->run;
+my $prover = App::Prove->new;
+$prover->process_args(@ARGV);
+my $res = $prover->run;
 
 print "-------------------\n\n";
 

--- a/src/tools/expandVars.pl
+++ b/src/tools/expandVars.pl
@@ -1,5 +1,12 @@
 #!/usr/bin/env perl
-#
+#*************************************************************************
+# Copyright (c) 2005 UChicago Argonne LLC, as Operator of Argonne
+#     National Laboratory.
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
+
 # Tool to expand @VAR@ variables while copying a file.
 # The file will *not* be copied if it already exists.
 #

--- a/src/tools/fullPathName.pl
+++ b/src/tools/fullPathName.pl
@@ -2,6 +2,7 @@
 #*************************************************************************
 # Copyright (c) 2009 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/genVersionHeader.pl
+++ b/src/tools/genVersionHeader.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 #*************************************************************************
 # Copyright (c) 2014 Brookhaven National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/installEpics.pl
+++ b/src/tools/installEpics.pl
@@ -4,6 +4,7 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution. 
 #*************************************************************************

--- a/src/tools/makeAPIheader.pl
+++ b/src/tools/makeAPIheader.pl
@@ -1,4 +1,11 @@
 #!/usr/bin/env perl
+#*************************************************************************
+# Copyright (c) 2020 UChicago Argonne LLC, as Operator of Argonne
+#     National Laboratory.
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
 
 use strict;
 use warnings;

--- a/src/tools/makeMakefile.pl
+++ b/src/tools/makeMakefile.pl
@@ -4,9 +4,9 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
-# in file LICENSE that is included with this distribution.
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution. 
 #*************************************************************************
 #
 #	makeMakefile.pl

--- a/src/tools/makeRPath.py
+++ b/src/tools/makeRPath.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python
+#*************************************************************************
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
 
 from __future__ import print_function
 

--- a/src/tools/makeTestfile.pl
+++ b/src/tools/makeTestfile.pl
@@ -4,6 +4,7 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution. 
 #*************************************************************************

--- a/src/tools/mkmf.pl
+++ b/src/tools/mkmf.pl
@@ -5,6 +5,7 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution. 
 #*************************************************************************

--- a/src/tools/munch.pl
+++ b/src/tools/munch.pl
@@ -4,6 +4,7 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in the file LICENSE that is included with this distribution. 
 #*************************************************************************

--- a/src/tools/podRemove.pl
+++ b/src/tools/podRemove.pl
@@ -2,6 +2,7 @@
 #*************************************************************************
 # Copyright (c) 2015 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/podToHtml.pl
+++ b/src/tools/podToHtml.pl
@@ -2,6 +2,7 @@
 #*************************************************************************
 # Copyright (c) 2013 UChicago Argonne LLC, as Operator of Argonne
 #     National Laboratory.
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/replaceVAR.pl
+++ b/src/tools/replaceVAR.pl
@@ -4,8 +4,8 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution. 
 #*************************************************************************
 

--- a/src/tools/testFailures.pl
+++ b/src/tools/testFailures.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/env perl
 #*************************************************************************
+# SPDX-License-Identifier: EPICS
 # EPICS BASE is distributed subject to a Software License Agreement found
 # in the file LICENSE that is included with this distribution.
 #*************************************************************************

--- a/src/tools/useManifestTool.pl
+++ b/src/tools/useManifestTool.pl
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+#*************************************************************************
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
 #
 # Use MS Visual C++ compiler version number to determine if
 # we want to use the Manifest Tool (status=1) or not (status=0)

--- a/startup/EpicsHostArch
+++ b/startup/EpicsHostArch
@@ -1,4 +1,10 @@
 #!/bin/sh
+#*************************************************************************
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
+
 # Script to find and run the Perl EpicsHostArch.pl script.
 
 # This script is provided for backwards-compatibility only and may be

--- a/startup/unix.csh
+++ b/startup/unix.csh
@@ -3,8 +3,8 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************
 #

--- a/startup/unix.sh
+++ b/startup/unix.sh
@@ -3,8 +3,8 @@
 #     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
 #     Operator of Los Alamos National Laboratory.
-# EPICS BASE Versions 3.13.7
-# and higher are distributed subject to a Software License Agreement found
+# SPDX-License-Identifier: EPICS
+# EPICS Base is distributed subject to a Software License Agreement found
 # in file LICENSE that is included with this distribution.
 #*************************************************************************
 #

--- a/startup/win32.bat
+++ b/startup/win32.bat
@@ -4,6 +4,7 @@ rem  Copyright (c) 2017 UChicago Argonne LLC, as Operator of Argonne
 rem      National Laboratory.
 rem  Copyright (c) 2002 The Regents of the University of California, as
 rem      Operator of Los Alamos National Laboratory.
+rem  SPDX-License-Identifier: EPICS
 rem  EPICS BASE is distributed subject to a Software License Agreement found
 rem  in file LICENSE that is included with this distribution.
 rem *************************************************************************

--- a/startup/windows.bat
+++ b/startup/windows.bat
@@ -4,6 +4,7 @@ rem  Copyright (c) 2017 UChicago Argonne LLC, as Operator of Argonne
 rem      National Laboratory.
 rem  Copyright (c) 2002 The Regents of the University of California, as
 rem      Operator of Los Alamos National Laboratory.
+rem  SPDX-License-Identifier: EPICS
 rem  EPICS BASE is distributed subject to a Software License Agreement found
 rem  in file LICENSE that is included with this distribution.
 rem *************************************************************************

--- a/test/tools/Snippets.plt
+++ b/test/tools/Snippets.plt
@@ -1,4 +1,9 @@
 #!/usr/bin/env perl
+######################################################################
+# SPDX-License-Identifier: EPICS
+# EPICS BASE is distributed subject to a Software License Agreement
+# found in file LICENSE that is included with this distribution.
+######################################################################
 
 use File::Path;
 use Sys::Hostname;


### PR DESCRIPTION
Note: This is a big PR but it mostly contains just 1 or 2-line changes to the header comments of most of the core source files. I haven't discussed it with the group before now since I didn't know when we'd be able to apply it.

About a month ago I received notification of a request spdx/license-list-XML#1012 to add the EPICS Open license to the [SPDX License List](https://spdx.org/licenses). That has now been accepted but it won't actually appear on that page until they publish the next version in about a month's time. However we can now use the EPICS license identifier in our source code, so I went ahead and created the changes to do that. I suspect the original request may have come from someone associated with ESS, but I'm not certain of that.

To add an SPDX license tag, just add this to/as a comment in the file:
```C
/* SPDX-License-Identifier: EPICS */
```
The [formatting requirements](https://spdx.dev/ids/) for tags are fairly loose, AFAICS they doesn't have to be a separate comment but they must be on one line and there should be white-space between the colon and the license identifier.

This PR adds the license tag to all the appropriate sources in the main repository on the 7.0 branch, unifies all our license header comments, and removes notices from a few files that should never have had them added in the first place. The easiest way to automate adding the license tag was to put it immediately after the license header. I had to add a license header to some of the more recent files but I did not add Copyright notices (except for some files that I wrote). I did not add the tag to any Makefiles or other build system files (I could do if someone thinks we should include them but they don't all have license headers), nor did I do any work on the external submodules at all.