### PR TITLE
Extract compiler pre-defined macros as Make variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /include/
 /templates/
 /configure/*.local
+/configure/os/CONFIG_TOOLCHAIN.*
 /modules/RELEASE.*.local
 /modules/Makefile.local
 O.*/

--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -72,6 +72,7 @@ ifdef T_A
   #  Target architecture specific definitions
   #
   -include $(CONFIG)/os/CONFIG.Common.$(T_A)
+  -include $(CONFIG)/os/CONFIG_TOOLCHAIN.Common.$(T_A)
 
   #  Host-Target architecture specific definitions
   #

--- a/configure/Makefile
+++ b/configure/Makefile
@@ -15,7 +15,8 @@ include $(TOP)/configure/CONFIG
 TOOLS = $(TOP)/src/tools
 
 CONFIGS += $(subst ../,,$(wildcard ../CONFIG*))
-CONFIGS += $(subst ../,,$(wildcard ../os/CONFIG*))
+CONFIGS += $(subst ../,,$(wildcard ../os/CONFIG.*))
+CONFIGS += $(subst ../,,$(wildcard ../os/CONFIG_SITE.*))
 
 CONFIGS += $(subst ../,,$(wildcard ../RELEASE*))
 CONFIGS += $(subst ../,,$(wildcard ../RULES*))
@@ -31,3 +32,13 @@ CFG += CONFIG_DATABASE_VERSION
 
 include $(TOP)/configure/RULES
 
+ifdef T_A
+
+install: $(TOP)/configure/os/CONFIG_TOOLCHAIN.Common.$(T_A)
+
+$(TOP)/configure/os/CONFIG_TOOLCHAIN.Common.$(T_A): toolchain.c
+	$(PREPROCESS.cpp)
+
+CLEANS += ../os/CONFIG_TOOLCHAIN.Common.$(T_A)
+
+endif # T_A

--- a/configure/os/CONFIG.Common.RTEMS
+++ b/configure/os/CONFIG.Common.RTEMS
@@ -41,7 +41,7 @@ include $(CONFIG.CC)
 # RTEMS cross-development tools
 CC = $(RTEMS_TOOLS)/bin/$(CC_FOR_TARGET) $(GCCSPECS) -fasm
 CCC = $(RTEMS_TOOLS)/bin/$(CXX)
-CPP = $(RTEMS_TOOLS)/bin/$(CC_FOR_TARGET) -x c -E
+CPP = $(RTEMS_TOOLS)/bin/$(CC_FOR_TARGET) -x c -E $(GCCSPECS)
 AR = $(RTEMS_TOOLS)/bin/$(AR_FOR_TARGET)
 LD = $(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -r
 

--- a/configure/toolchain.c
+++ b/configure/toolchain.c
@@ -1,0 +1,35 @@
+#ifdef _COMMENT_
+/* Extract compiler pre-defined macros as Make variables
+ *
+ * Expanded as configure/os/CONFIG_TOOLCHAIN.Common.$(T_A)
+ *
+ * Must be careful not to #include any C definitions
+ * into what is really a Makefile snippet
+ *
+ * cf. https://sourceforge.net/p/predef/wiki/Home/
+ */
+/* GCC preprocessor drops C comments from output.
+ * MSVC preprocessor emits C comments in output
+ */
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__)
+GCC_MAJOR = __GNUC__
+GCC_MINOR = __GNUC_MINOR__
+GCC_PATCH = __GNUC_PATCHLEVEL__
+
+#elif defined(__clang__)
+CLANG_MAJOR = __clang_major__
+CLANG_MINOR = __clang_minor__
+CLANG_PATCH = __clang_patchlevel__
+
+#elif defined(_MSC_VER)
+MSVC_VER = _MSC_VER
+#endif
+
+#ifdef __rtems__
+#include <rtems/score/cpuopts.h>
+RTEMS_MAJOR = __RTEMS_MAJOR__
+RTEMS_MINOR = __RTEMS_MINOR__
+RTEMS_PATCH = __RTEMS_REVISION__
+#endif


### PR DESCRIPTION
Related to #23.  Extract `__RTEMS_MAJOR__` and similar with the preprocessor to avoid needing to configure the RTEMS OS version/series manually.
