### PR TITLE
epicsTime: fix overflow handling

### DIFF
--- a/modules/libcom/src/osi/epicsTime.h
+++ b/modules/libcom/src/osi/epicsTime.h
@@ -325,8 +325,8 @@ private:
     epicsTime ( const unsigned long secPastEpoch, const unsigned long nSec );
     void addNanoSec ( long nanoSecAdjust );
 
-    unsigned long secPastEpoch; /* seconds since O000 Jan 1, 1990 */
-    unsigned long nSec; /* nanoseconds within second */
+    epicsUInt32 secPastEpoch; /* seconds since O000 Jan 1, 1990 */
+    epicsUInt32 nSec; /* nanoseconds within second */
 };
 
 extern "C" {

--- a/modules/libcom/test/epicsTimeTest.cpp
+++ b/modules/libcom/test/epicsTimeTest.cpp
@@ -80,12 +80,21 @@ static void testMonotonic()
     testDiag("Small Delta %u ns", (unsigned)(B-A));
 }
 
+static void testRollover()
+{
+    epicsTimeStamp A = {0xffffffff, 0};
+    epicsTimeStamp B = {0x00000001, 0};
+
+    double diff = epicsTimeDiffInSeconds(&B, &A);
+    testOk(diff==2.0, "Rollover diff %f", diff);
+}
+
 MAIN(epicsTimeTest)
 {
     const int wasteTime = 100000;
     const int nTimes = 10;
 
-    testPlan(22 + nTimes * 19);
+    testPlan(23 + nTimes * 19);
 
     try {
         const epicsTimeStamp epochTS = {0, 0};
@@ -284,6 +293,7 @@ MAIN(epicsTimeTest)
     }
 
     testMonotonic();
+    testRollover();
 
     return testDone();
 }


### PR DESCRIPTION
As I noted on [lp:1896295](https://bugs.launchpad.net/bugs/1896295), `epicsTimeDiffInSeconds()` and `class epicsTime` which underpins it, do not correctly handle 32-bit overflow on targets where `sizeof(long)==8` (eg. Linux).

This PR changes 'class epicsTime' to use `epicsUInt32` to match 'struct epicsTimeStamp', and tries to fix the various places in epicsTime.cpp where overflow is detected.  This passes existing tests, and a new test of `epicsTimeDiffInSeconds()` overflow.

I'm not certain that this is the best approach though.  I think a rewrite would be better.  Specifically to make `class epicsTime` a wrapper around `struct epicsTimeStamp`.
