### PR TITLE
Deprecate epicsThreadExitMain()

### DIFF
--- a/modules/database/src/std/softIoc/softMain.cpp
+++ b/modules/database/src/std/softIoc/softMain.cpp
@@ -249,7 +249,10 @@ int main(int argc, char *argv[])
 
         } else {
             if (loadedDb || ranScript) {
-                epicsThreadExitMain();
+                // non-interactive IOC.  spin forever
+                while(true) {
+                    epicsThreadSleep(1000.0);
+                }
 
             } else {
                 usage(argv[0], dbd_file);

--- a/modules/libcom/src/osi/epicsThread.h
+++ b/modules/libcom/src/osi/epicsThread.h
@@ -59,6 +59,7 @@
 #include <stddef.h>
 
 #include "libComAPI.h"
+#include "compilerDependencies.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -142,8 +143,12 @@ LIBCOM_API void epicsThreadRealtimeLock(void);
  * call this routine. This should be the last call in main, except the
  * final return. On most systems epicsThreadExitMain never returns.This
  * must only be called by the main thread.
+ *
+ * @deprecated Deprecated for lack of use.  Please report any usage.
+ * Recommended replacement is loop + epicsThreadSleep(),
+ * epicsEventMustWait(), or similar.
  **/
-LIBCOM_API void epicsStdCall epicsThreadExitMain(void);
+LIBCOM_API void epicsStdCall epicsThreadExitMain(void) EPICS_DEPRECATED;
 
 /** For use with epicsThreadCreateOpt() */
 typedef struct epicsThreadOpts {

--- a/modules/libcom/src/osi/os/RTEMS/osdThread.c
+++ b/modules/libcom/src/osi/os/RTEMS/osdThread.c
@@ -219,6 +219,8 @@ threadWrapper (rtems_task_argument arg)
  */
 void epicsThreadExitMain (void)
 {
+    cantProceed("epicsThreadExitMain() has been deprecated for lack of usage."
+                "  Please report if you see this message.");
 }
 
 static rtems_status_code

--- a/modules/libcom/src/osi/os/WIN32/osdThread.c
+++ b/modules/libcom/src/osi/os/WIN32/osdThread.c
@@ -249,7 +249,8 @@ static void epicsParmCleanupWIN32 ( win32ThreadParam * pParm )
  */
 LIBCOM_API void epicsStdCall epicsThreadExitMain ( void )
 {
-    _endthread ();
+    cantProceed("epicsThreadExitMain() has been deprecated for lack of usage."
+                "  Please report if you see this message.");
 }
 
 /*

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -687,6 +687,10 @@ LIBCOM_API void epicsStdCall epicsThreadExitMain(void)
     epicsThreadOSD *pthreadInfo;
 
     epicsThreadInit();
+
+    cantProceed("epicsThreadExitMain() has been deprecated for lack of usage."
+                "  Please report if you see this message.");
+
     pthreadInfo = (epicsThreadOSD *)pthread_getspecific(getpthreadInfo);
     if(pthreadInfo==NULL)
         pthreadInfo = createImplicit();

--- a/modules/libcom/src/osi/os/vxWorks/osdThread.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdThread.c
@@ -353,7 +353,8 @@ void epicsThreadResume(epicsThreadId id)
 
 void epicsThreadExitMain(void)
 {
-    errlogPrintf("epicsThreadExitMain was called for vxWorks. Why?\n");
+    cantProceed("epicsThreadExitMain() has been deprecated for lack of usage."
+                "  Please report if you see this message.");
 }
 
 unsigned int epicsThreadGetPriority(epicsThreadId id)


### PR DESCRIPTION
Also, replace `epicsThreadExitMain()` with a loop calling `epicsThreadSleep()` to make a non-interactive softIoc easier to interrupt or debug.
