### PR TITLE
Break recursion during early osd* errors

### DIFF
--- a/modules/libcom/src/misc/cantProceed.c
+++ b/modules/libcom/src/misc/cantProceed.c
@@ -54,6 +54,16 @@ LIBCOM_API void * mallocMustSucceed(size_t size, const char *msg)
 LIBCOM_API void cantProceed(const char *msg, ...)
 {
     va_list pvar;
+#if defined(__GNUC__)
+    static __thread char dead = 0;
+    if(dead) {
+        /* Probably here after a failure in OSD early initialization.
+         * So we don't know which, if any, of the OSI primitives are usable.
+         */
+        abort();
+    }
+    dead = 1;
+#endif
     va_start(pvar, msg);
     if (msg)
         errlogVprintf(msg, pvar);


### PR DESCRIPTION
Errors during initialization of osdthread or osdmutex can trigger recursive calls to errlog or cantProceed, which escalate to a stack overflow.

Add (so far) GCC specific (probably also clang) detection and breaking of loops via a `__thread` local variable.  Note that suncc also understands `__thread`, and msvc has `__declspec(thread)`.

I'm not sure if this is the right approach, or the right behavior.  eg. maybe better for errlog to write directly to stderr?  maybe cantProceed() should become OSD?