### PR TITLE
Force device entries for "Soft Channel" to index 0

### DIFF
--- a/modules/database/src/template/top/exampleApp/src/xxxSupport.dbd
+++ b/modules/database/src/template/top/exampleApp/src/xxxSupport.dbd
@@ -1,2 +1,2 @@
 include "xxxRecord.dbd"
-device(xxx,CONSTANT,devXxxSoft,"SoftChannel")
+device(xxx,CONSTANT,devXxxSoft,"Soft Channel")

--- a/modules/database/test/ioc/db/dbStaticTest.c
+++ b/modules/database/test/ioc/db/dbStaticTest.c
@@ -290,11 +290,33 @@ static void testDbVerify(const char *record)
     dbFinishEntry(&entry);
 }
 
+static void testSoftChanDTYP(const char *record)
+{
+    DBENTRY entry;
+    epicsEnum16 *pdtyp;
+
+    testDiag("# # # # # # # testSoftChanDTYP('%s') # # # # # # # #", record);
+
+    dbInitEntry(pdbbase, &entry);
+    if (dbFindRecord(&entry, record) != 0)
+        testAbort("Can't find record '%s'", record);
+
+    dbFindField(&entry, "DTYP");
+    pdtyp = (epicsEnum16 *)entry.pfield;
+    if (!pdtyp)
+        testAbort("Can't find DTYP field in '%s'", record);
+
+    testOk(*pdtyp == 0, "Default DTYP is 0 (got %d)", *pdtyp);
+
+    dbPutString(&entry, "Soft Channel");
+    testOk(*pdtyp == 0, "Soft Channel is index 0 (got %d)", *pdtyp);
+}
+
 void dbTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 MAIN(dbStaticTest)
 {
-    testPlan(310);
+    testPlan(312);
     testdbPrepare();
 
     testdbReadDatabase("dbTestIoc.dbd", NULL, NULL);
@@ -313,6 +335,8 @@ MAIN(dbStaticTest)
     testRec2Entry("testalias");
     testRec2Entry("testalias2");
     testRec2Entry("testalias3");
+
+    testSoftChanDTYP("testrec");
 
     eltc(0);
     testIocInitOk();

--- a/modules/database/test/ioc/db/devx.dbd
+++ b/modules/database/test/ioc/db/devx.dbd
@@ -1,2 +1,7 @@
-device(x, CONSTANT, devxSoft, "Soft Channel")
 device(x, INST_IO , devxScanIO, "Scan I/O")
+
+# "Soft Channel" devices had to be loaded first so they become the
+# default for records that don't set DTYP. This is no longer needed.
+# dbStaticTest.c's testSoftChanDTYP() routine checks that loading it
+# second as we do here still causes it to have index 0 and be default.
+device(x, CONSTANT, devxSoft, "Soft Channel")


### PR DESCRIPTION
It used to be quite difficult to usurp the position of the Soft Channel device supports as the first loaded and hence default DTYP for records that don't set it. However now that dbdExpand.pl auto-creates a place-holder record type if a device names one that hasn't yet been seen it's no longer fatal to put another support DBD file in front of base.dbd when creating an IOC's DBD file, and that will cause devices in that support DBD file to become the default for records that don't set DTYP.

The changes here cause any device support named "Soft Channel" to be inserted into the zeroth position of the record device list whenever they are loaded, thus making them automatically the default.

Adds tests to dbStaticTest to ensure this works.

Fixes [lp: #1908305](https://bugs.launchpad.net/epics-base/+bug/1908305)