### PR TITLE
iocsh automatic paths

### DIFF
--- a/modules/database/src/ioc/db/dbUnitTest.c
+++ b/modules/database/src/ioc/db/dbUnitTest.c
@@ -61,12 +61,10 @@ void testdbReadDatabase(const char* file,
         path = "." OSI_PATH_LIST_SEPARATOR ".." OSI_PATH_LIST_SEPARATOR
                 "../O.Common" OSI_PATH_LIST_SEPARATOR "O.Common";
     if(dbReadDatabase(&pdbbase, file, path, substitutions)) {
-        char buf[100];
-        const char *cwd = getcwd(buf, sizeof(buf));
-        if(!cwd)
-            cwd = "<directory too long>";
+        const char *cwd = epicsPathAllocCWD();
         testAbort("Failed to load test database\ndbReadDatabase(%s,%s,%s)\n from: \"%s\"",
                   file, path, substitutions, cwd);
+        free(cwd);
     }
 }
 

--- a/modules/database/src/ioc/db/dbUnitTest.c
+++ b/modules/database/src/ioc/db/dbUnitTest.c
@@ -61,7 +61,7 @@ void testdbReadDatabase(const char* file,
         path = "." OSI_PATH_LIST_SEPARATOR ".." OSI_PATH_LIST_SEPARATOR
                 "../O.Common" OSI_PATH_LIST_SEPARATOR "O.Common";
     if(dbReadDatabase(&pdbbase, file, path, substitutions)) {
-        const char *cwd = epicsPathAllocCWD();
+        char *cwd = epicsPathAllocCWD();
         testAbort("Failed to load test database\ndbReadDatabase(%s,%s,%s)\n from: \"%s\"",
                   file, path, substitutions, cwd);
         free(cwd);

--- a/modules/database/src/std/softIoc/Makefile
+++ b/modules/database/src/std/softIoc/Makefile
@@ -24,6 +24,8 @@ softIoc_SRCS += softIoc_registerRecordDeviceDriver.cpp
 softIoc_SRCS_DEFAULT += softMain.cpp
 softIoc_SRCS_vxWorks = -nil-
 
+softMain_CPPFLAGS += -I$(TOP)/modules/libcom/src/iocsh
+
 softIoc_LIBS = $(EPICS_BASE_IOC_LIBS)
 
 DB += softIocExit.db

--- a/modules/database/src/std/softIoc/softMain.cpp
+++ b/modules/database/src/std/softIoc/softMain.cpp
@@ -26,7 +26,7 @@
 #include "dbAccess.h"
 #include "asDbLib.h"
 #include "iocInit.h"
-#include "iocsh.h"
+#include "iocshpvt.h"
 #include "osiFileName.h"
 #include "epicsInstallDir.h"
 
@@ -122,6 +122,7 @@ void lazy_dbd(const std::string& dbd_file) {
 
 int main(int argc, char *argv[])
 {
+    iocshSetArgs(argc, argv);
     try {
         std::string dbd_file(DBD_FILE),
                     exit_file(EXIT_FILE),

--- a/modules/database/src/template/top/exampleApp/Db/user.substitutions
+++ b/modules/database/src/template/top/exampleApp/Db/user.substitutions
@@ -1,14 +1,16 @@
 # Example substitutions file
 
-file "db/circle.db" {
+# file "..." uses EPICS_DB_INCLUDE_PATH
+
+file "circle.db" {
     { user = "_USER_" }
 }
 
-file "db/dbExample1.db" {
+file "dbExample1.db" {
     { user = "_USER_" }
 }
 
-file db/dbExample2.db {
+file "dbExample2.db" {
     pattern { user, no, scan }
         { "_USER_", 1, "1 second" }
         { "_USER_", 2, "2 second" }

--- a/modules/database/src/template/top/exampleApp/src/_APPNAME_Main.cpp
+++ b/modules/database/src/template/top/exampleApp/src/_APPNAME_Main.cpp
@@ -13,6 +13,9 @@
 
 int main(int argc,char *argv[])
 {
+#ifdef iocshMain
+    return iocshMain(argc, argv);
+#else
     if(argc>=2) {
         iocsh(argv[1]);
         epicsThreadSleep(.2);
@@ -20,4 +23,5 @@ int main(int argc,char *argv[])
     iocsh(NULL);
     epicsExit(0);
     return(0);
+#endif
 }

--- a/modules/database/src/template/top/exampleBoot/ioc/st.cmd@Common
+++ b/modules/database/src/template/top/exampleBoot/ioc/st.cmd@Common
@@ -7,14 +7,17 @@
 
 cd "${TOP}"
 
+# search path for dbLoadRecords()
+epicsEnvSet("EPICS_DB_INCLUDE_PATH", "${TOP}/db:${IOCSH_SCRIPT_DIR}")
+
 ## Register all support components
-dbLoadDatabase "dbd/_APPNAME_.dbd"
+dbLoadDatabase "${TOP}/dbd/_APPNAME_.dbd"
 _CSAFEAPPNAME__registerRecordDeviceDriver pdbbase
 
 ## Load record instances
-dbLoadTemplate "db/user.substitutions"
-dbLoadRecords "db/_APPNAME_Version.db", "user=_USER_"
-dbLoadRecords "db/dbSubExample.db", "user=_USER_"
+dbLoadTemplate "${TOP}/db/user.substitutions"
+dbLoadRecords "_APPNAME_Version.db", "user=_USER_"
+dbLoadRecords "dbSubExample.db", "user=_USER_"
 
 #- Set this to see messages from mySub
 #var mySubDebug 1

--- a/modules/database/src/template/top/iocApp/src/_APPNAME_Main.cpp
+++ b/modules/database/src/template/top/iocApp/src/_APPNAME_Main.cpp
@@ -13,6 +13,9 @@
 
 int main(int argc,char *argv[])
 {
+#ifdef iocshMain
+    return iocshMain(argc, argv);
+#else
     if(argc>=2) {
         iocsh(argv[1]);
         epicsThreadSleep(.2);
@@ -20,4 +23,5 @@ int main(int argc,char *argv[])
     iocsh(NULL);
     epicsExit(0);
     return(0);
+#endif
 }

--- a/modules/database/src/template/top/iocBoot/ioc/st.cmd@Common
+++ b/modules/database/src/template/top/iocBoot/ioc/st.cmd@Common
@@ -5,6 +5,9 @@
 
 < envPaths
 
+# search path for dbLoadRecords()
+epicsEnvSet("EPICS_DB_INCLUDE_PATH", "${TOP}/db:${IOCSH_SCRIPT_DIR}")
+
 cd "${TOP}"
 
 ## Register all support components

--- a/modules/database/src/template/top/iocBoot/ioc/st.cmd@Cross
+++ b/modules/database/src/template/top/iocBoot/ioc/st.cmd@Cross
@@ -5,12 +5,15 @@
 
 #< envPaths
 
+# search path for dbLoadRecords()
+epicsEnvSet("EPICS_DB_INCLUDE_PATH", "${TOP}/db:${IOCSH_SCRIPT_DIR}")
+
 ## Register all support components
-dbLoadDatabase("../../dbd/_APPNAME_.dbd",0,0)
+dbLoadDatabase("${TOP}/dbd/_APPNAME_.dbd",0,0)
 _CSAFEAPPNAME__registerRecordDeviceDriver(pdbbase) 
 
 ## Load record instances
-dbLoadRecords("../../db/_APPNAME_.db","user=_USER_")
+dbLoadRecords("_APPNAME_.db","user=_USER_")
 
 iocInit()
 

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -1051,7 +1051,7 @@ int iocshMain(int argc,char *argv[])
 
 void iocshSetArgs(int argc, char *argv[])
 {
-    if(argc < 0) // should always be true, but don't blow up if it isn't
+    if(argc <= 0)
         return;
 
     free((void*)iocshStartDir);

--- a/modules/libcom/src/iocsh/iocsh.h
+++ b/modules/libcom/src/iocsh/iocsh.h
@@ -86,6 +86,20 @@ LIBCOM_API const iocshVarDef * epicsStdCall iocshFindVariable(
 /* This should only be called when iocsh is no longer needed*/
 LIBCOM_API void epicsStdCall iocshFree(void);
 
+/** Helper for implementing main() for an IOC.
+ *
+ * @code
+ * int main(int argc,char *argv[]) {
+ *     return iocshMain(argc, argv);
+ * }
+ * @endcode
+ *
+ * see the 'ioc' template of makeBaseApp.pl for an example with compatibility
+ * for older Base.
+ *
+ * @since UNRELEASED
+ */
+LIBCOM_API int iocshMain(int argc,char *argv[]);
 /** shorthand for \code iocshLoad(pathname, NULL) \endcode */
 LIBCOM_API int epicsStdCall iocsh(const char *pathname);
 /** shorthand for \code iocshRun(cmd, NULL) \endcode */

--- a/modules/libcom/src/iocsh/iocsh.h
+++ b/modules/libcom/src/iocsh/iocsh.h
@@ -86,6 +86,7 @@ LIBCOM_API const iocshVarDef * epicsStdCall iocshFindVariable(
 /* This should only be called when iocsh is no longer needed*/
 LIBCOM_API void epicsStdCall iocshFree(void);
 
+#define iocshMain iocshMain
 /** Helper for implementing main() for an IOC.
  *
  * @code

--- a/modules/libcom/src/iocsh/iocshpvt.h
+++ b/modules/libcom/src/iocsh/iocshpvt.h
@@ -1,0 +1,17 @@
+#ifndef IOCSHPVT_H
+#define IOCSHPVT_H
+
+#include "iocsh.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+LIBCOM_API
+void iocshSetArgs(int argc, char *argv[]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // IOCSHPVT_H

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -23,6 +23,7 @@
 #include "logClient.h"
 #include "errlog.h"
 #include "taskwd.h"
+#include "osiFileName.h"
 #include "registry.h"
 #include "epicsGeneralTime.h"
 #include "libComRegister.h"
@@ -86,11 +87,11 @@ static void chdirCallFunc(const iocshArgBuf *args)
 static const iocshFuncDef pwdFuncDef = { "pwd", 0, 0 };
 static void pwdCallFunc (const iocshArgBuf *args)
 {
-    char buf[256];
-    char *pwd = getcwd ( buf, sizeof(buf) - 1 );
+    char *pwd = epicsPathAllocCWD();
     if ( pwd ) {
         printf ( "%s\n", pwd );
     }
+    free(pwd);
 }
 
 /* epicsEnvSet */

--- a/modules/libcom/src/osi/Makefile
+++ b/modules/libcom/src/osi/Makefile
@@ -72,6 +72,7 @@ Com_SRCS += epicsTime.cpp
 Com_SRCS += epicsMessageQueue.cpp
 Com_SRCS += epicsMath.cpp
 Com_SRCS += epicsAtomicOSD.cpp
+Com_SRCS += osiFileName.c
 
 Com_SRCS += epicsGeneralTime.c
 

--- a/modules/libcom/src/osi/osiFileName.c
+++ b/modules/libcom/src/osi/osiFileName.c
@@ -128,16 +128,15 @@ char* epicsPathJoin(const char **fragments, size_t nfragments)
         if(epicsPathIsAbs(frag, flen)) {
             /* reset */
             firstfrag = i;
-            nfrags = 1;
+            nfrags = 0;
             totallen = 0;
-
-        } else {
-            nfrags++;
         }
 
         if(nfrags)
             totallen += 1; /* for separator */
+
         totallen += flen;
+        nfrags++;
     }
 
     ret = malloc(totallen + 1);
@@ -146,6 +145,7 @@ char* epicsPathJoin(const char **fragments, size_t nfragments)
 
         for(i=firstfrag, nfrags=0; i<nfragments; i++) {
             const char* frag = fragments[i];
+
             if(!frag|| frag[0]=='\0')
                 continue;
 
@@ -156,9 +156,11 @@ char* epicsPathJoin(const char **fragments, size_t nfragments)
 
             if(nfrags)
                 strcat(ret, OSI_PATH_SEPARATOR);
+
             strcat(ret, frag);
             nfrags++;
         }
+        assert(strlen(ret)==totallen);
     }
 
     free(cwd);

--- a/modules/libcom/src/osi/osiFileName.c
+++ b/modules/libcom/src/osi/osiFileName.c
@@ -1,0 +1,195 @@
+/*************************************************************************\
+* Copyright (c) 2021 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+
+#include <epicsAssert.h>
+#include <osiUnistd.h>
+#include <epicsString.h>
+#include "osiFileName.h"
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+// cf. https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats#canonicalize-separators
+#  define SEP(C) (C=='/' || C=='\\')
+#else
+#  define SEP(C) (C=='/')
+#endif
+
+static const char magicCWD[] = "<current_directory>";
+const char* const epicsPathJoinCurDir = magicCWD;
+
+static
+size_t epicsPathDF(char *path, size_t pathlen, int outfile)
+{
+    size_t pos;
+
+    /* search forward to ignore unused buffer */
+    pathlen = epicsStrnLen(path, pathlen);
+
+    /* search backwards for last separator */
+    pos = pathlen;
+    for(; pos>0; pos--) {
+        char c = path[pos-1u];
+        if(SEP(c)) {
+            /* found separator */
+            if(outfile) {
+                memcpy(path, &path[pos], pathlen-pos);
+                pos = pathlen-pos;
+            }
+            goto done;
+        }
+    }
+    /* no separator found */
+    if(outfile) {
+        pos = pathlen;
+    }
+
+done:
+    if(pos < pathlen) {
+        path[pos] = '\0';
+    }
+
+    return pos;
+}
+
+size_t epicsPathDir(char *path, size_t pathlen)
+{
+    return epicsPathDF(path, pathlen, 0);
+}
+
+size_t epicsPathFile(char *path, size_t pathlen)
+{
+    return epicsPathDF(path, pathlen, 1);
+}
+
+int epicsPathIsAbs(const char *path, size_t pathlen)
+{
+    /* for *NIX this is simple.  path[0]=='/' is absolute.  Anything else is relative
+     *
+     * for windows... not so much.
+     * cf. https://docs.microsoft.com/en-us/dotnet/standard/io/file-path-formats#identify-the-path
+     *
+     * we treat as absolute:
+     *  - device and UNC paths.
+     *  - absolute on current drive.  eg. "\foo" -> "C:\foo" if %CD% starts with C:
+     *  - absolute w/ drive.  eg. "C:\foo"
+     *
+     * we treat as relative
+     *  - relative to some drive.  eg. "C:foo" -> "D:\bar\foo" if %CD% == "D:\bar"  (sneaky!)
+     *  - anything else
+     */
+    if(pathlen>0 && SEP(path[0])) // *NIX: simple abs.  windows: device path, UNC path, or root of current drive
+        return 1;
+#if defined(_WIN32) || defined(__CYGWIN__)
+    if(pathlen>=3 && ((path[0]>='a' && path[0]<='z') || (path[0]>='A' && path[0]<='Z')) && path[1]==':' && SEP(path[2])) {
+        /* eg. C:FOO is relative
+         *     C:/FOO is absolute
+         */
+        return 1;
+    }
+#endif
+    return 0;
+}
+
+char* epicsPathJoin(const char **fragments, size_t nfragments)
+{
+    char* ret;
+    char* cwd = NULL;
+    size_t i;
+    size_t firstfrag = 0;
+    size_t nfrags = 0; /* nfragments excluding NULL and "" */
+    size_t totallen = 0;
+
+    STATIC_ASSERT(sizeof(OSI_PATH_SEPARATOR)==2);
+
+    /* first pass to compute buffer size */
+    for(i=0; i<nfragments; i++) {
+        const char* frag = fragments[i];
+        size_t flen;
+        if(!frag || frag[0]=='\0')
+            continue;
+
+        if(frag==magicCWD) {
+            if(!cwd)
+                cwd = epicsPathAllocCWD();
+            if(!cwd)
+                return NULL;
+            frag = cwd;
+        }
+
+        flen = strlen(frag);
+
+        if(epicsPathIsAbs(frag, flen)) {
+            /* reset */
+            firstfrag = i;
+            nfrags = 1;
+            totallen = 0;
+
+        } else {
+            nfrags++;
+        }
+
+        if(nfrags)
+            totallen += 1; /* for separator */
+        totallen += flen;
+    }
+
+    ret = malloc(totallen + 1);
+    if(ret) {
+        ret[0] = 0;
+
+        for(i=firstfrag, nfrags=0; i<nfragments; i++) {
+            const char* frag = fragments[i];
+            if(!frag|| frag[0]=='\0')
+                continue;
+
+            if(frag==magicCWD) {
+                assert(cwd);
+                frag = cwd;
+            }
+
+            if(nfrags)
+                strcat(ret, OSI_PATH_SEPARATOR);
+            strcat(ret, frag);
+            nfrags++;
+        }
+    }
+
+    free(cwd);
+    return ret;
+}
+
+char* epicsPathAllocCWD(void)
+{
+    size_t bsize = 64u;
+    char *buf = NULL;
+    while(1) {
+        char *temp = realloc(buf, bsize);
+        if(!temp) {
+            free(buf);
+            buf = 0;
+            break;
+        }
+        buf = temp;
+
+        if(getcwd(buf, bsize)) {
+            buf[bsize-1u] = '\0'; /* paranoia */
+            break;
+
+        } else if(errno==ERANGE && bsize<0x80000000) {
+            bsize *= 2u;
+
+        } else {
+            free(buf);
+            buf = 0;
+            break;
+        }
+    }
+    return buf;
+}

--- a/modules/libcom/src/osi/osiFileName.c
+++ b/modules/libcom/src/osi/osiFileName.c
@@ -97,7 +97,7 @@ int epicsPathIsAbs(const char *path, size_t pathlen)
     return 0;
 }
 
-char* epicsPathJoin(const char **fragments, size_t nfragments)
+char* epicsPathJoin(const char * const *fragments, size_t nfragments)
 {
     char* ret;
     char* cwd = NULL;

--- a/modules/libcom/src/osi/osiFileName.h
+++ b/modules/libcom/src/osi/osiFileName.h
@@ -14,6 +14,9 @@
 #ifndef osiFileNameH
 #define osiFileNameH
 
+#include <stdlib.h>
+#include <stdarg.h>
+
 #include <libComAPI.h>
 
 #ifdef __cplusplus
@@ -28,14 +31,88 @@ extern "C" {
 #  define OSI_PATH_SEPARATOR "/"
 #endif
 
+/** Extract directory component from path.  in-place.
+ *
+ * The path buffer will be modified by inserting a '\0' (nil) after
+ * the last path separator.
+ *
+ * cf. dirname() on *NIX
+ *
+ * @returns The location of the added nil, or pathlen if no nil could be added.
+ *
+ * @since UNRELEASED
+ */
+LIBCOM_API
+size_t epicsPathDir(char *path, size_t pathlen);
+
+/** Extract file (and extension) component from path.  in-place.
+ *
+ * The path buffer will be modified to contain only the string after
+ * the last path separator.
+ *
+ * cf. basename() on *NIX
+ *
+ * @returns The location of the added nil, or pathlen if no nil could be added.
+ *
+ * @since UNRELEASED
+ */
+LIBCOM_API
+size_t epicsPathFile(char *path, size_t pathlen);
+
+/** Test if path is absolute.
+ * @return non-zero if absolute.  zero if relative
+ *
+ * @since UNRELEASED
+ */
+LIBCOM_API
+int epicsPathIsAbs(const char *path, size_t pathlen);
+
+/** Concatenate zero or more path fragments (followed by a NULL)
+ *
+ * Fragments are joined together with the OS path separator character
+ * If any of the fragments is an absolute path, the preceding fragments
+ * are ignored.
+ *
+ * NULL and empty ("") fragments are ignored.
+ *
+ * The special fragment @code epicsPathJoinCurDir @endcode will be substituted
+ * with the current working directory (cf. epicsPathAllocCWD()).
+ *
+ * @returns A string buffer which must be free()'d, or NULL
+ *
+ * @since UNRELEASED
+ */
+LIBCOM_API
+char* epicsPathJoin(const char **fragments, size_t nfragments);
+
+/** Special path fragment for epicsPathJoin() which will be replaced with the current directory
+ *
+ * @since UNRELEASED
+ */
+LIBCOM_API
+extern const char* const epicsPathJoinCurDir;
+
+/** Allocate and return the current working directory.
+ *
+ * Called must free()
+ *
+ * @since UNRELEASED
+ */
+LIBCOM_API
+char* epicsPathAllocCWD(void);
+
 /** Return the absolute path of the current executable.
  \return NULL or the path.  Caller must free()
+ *
+ * @since 7.0.3.1
  */
 LIBCOM_API
 char *epicsGetExecName(void);
 
 /** Return the absolute path of the directory containing the current executable.
  \return NULL or the path.  Caller must free()
+ *
+ * @since 7.0.3.1
  */
 LIBCOM_API
 char *epicsGetExecDir(void);

--- a/modules/libcom/src/osi/osiFileName.h
+++ b/modules/libcom/src/osi/osiFileName.h
@@ -83,7 +83,7 @@ int epicsPathIsAbs(const char *path, size_t pathlen);
  * @since UNRELEASED
  */
 LIBCOM_API
-char* epicsPathJoin(const char **fragments, size_t nfragments);
+char* epicsPathJoin(const char * const *fragments, size_t nfragments);
 
 /** Special path fragment for epicsPathJoin() which will be replaced with the current directory
  *

--- a/modules/libcom/src/osi/osiFileName.h
+++ b/modules/libcom/src/osi/osiFileName.h
@@ -104,7 +104,7 @@ char* epicsPathAllocCWD(void);
 /** Return the absolute path of the current executable.
  \return NULL or the path.  Caller must free()
  *
- * @since 7.0.3.1
+ * @since UNRELEASED
  */
 LIBCOM_API
 char *epicsGetExecName(void);
@@ -112,7 +112,7 @@ char *epicsGetExecName(void);
 /** Return the absolute path of the directory containing the current executable.
  \return NULL or the path.  Caller must free()
  *
- * @since 7.0.3.1
+ * @since UNRELEASED
  */
 LIBCOM_API
 char *epicsGetExecDir(void);

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -79,6 +79,11 @@ epicsErrlogTest_SRCS += epicsErrlogTest.c
 testHarness_SRCS += epicsErrlogTest.c
 TESTS += epicsErrlogTest
 
+TESTPROD_HOST += epicsPathTest
+epicsPathTest_SRCS += epicsPathTest.cpp
+testHarness_SRCS += epicsPathTest.cpp
+TESTS += epicsPathTest
+
 TESTPROD_HOST += epicsStdioTest
 epicsStdioTest_SRCS += epicsStdioTest.c
 testHarness_SRCS += epicsStdioTest.c

--- a/modules/libcom/test/epicsPathTest.cpp
+++ b/modules/libcom/test/epicsPathTest.cpp
@@ -1,0 +1,134 @@
+/*************************************************************************\
+* Copyright (c) 2021 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include <string>
+#include <vector>
+
+#include <string.h>
+
+#include <epicsUnitTest.h>
+#include <testMain.h>
+
+#include <osiUnistd.h>
+#include <osiFileName.h>
+#include <dbDefs.h>
+
+#define SEP OSI_PATH_SEPARATOR
+
+namespace {
+
+void testDF(const char* inp, const char* expectdir, const char* expectfile)
+{
+    std::vector<char> dbuf(strlen(inp)+1u);
+    memcpy(&dbuf[0], inp, dbuf.size()-1u);
+
+    std::vector<char> fbuf(dbuf); // copy
+
+    size_t len = epicsPathDir(&dbuf[0], dbuf.size()-1u);
+    dbuf[dbuf.size()-1u] = '\0';
+    testOk(len==strlen(expectdir) && strcmp(expectdir, &dbuf[0])==0,
+            "\"%s\" directory (%u) \"%s\" == \"%s\"", inp, unsigned(len), &dbuf[0], expectdir);
+
+    len = epicsPathFile(&fbuf[0], fbuf.size()-1u);
+    fbuf[fbuf.size()-1u] = '\0';
+    testOk(len==strlen(expectfile) && strcmp(expectfile, &fbuf[0])==0,
+            "\"%s\" file (%u) \"%s\" == \"%s\"", inp, unsigned(len), &fbuf[0], expectfile);
+}
+
+#define testIsAbs(EXPECT, PATH) testOk((EXPECT)==epicsPathIsAbs(PATH, strlen(PATH)), "is %s \"%s\"", (EXPECT)?"abs":"rel", PATH)
+
+
+#define testJoin(EXPECT, ...) \
+do { \
+    const char* parts[] = {__VA_ARGS__}; \
+    char *actual = epicsPathJoin(parts, NELEMENTS(parts)); \
+    testOk(strcmp(actual, EXPECT)==0, "expect \"%s\" == \"%s\"", EXPECT, actual); \
+}while(0)
+
+} // namespace
+
+MAIN(epicsPathTest)
+{
+#if defined(_WIN32) || defined(__CYGWIN__)
+    testPlan(58);
+#else
+    testPlan(44);
+#endif
+
+    char *cwd = epicsPathAllocCWD();
+    testOk(cwd!=NULL, "cur dir \"%s\"", cwd);
+    free(cwd);
+
+    testDiag("Test path split");
+    testDF("", "", "");
+    testDF("\0notdir/junk", "", "");
+    testDF("a", "", "a");
+    testDF("/a", "/", "a");
+    testDF("a/", "a/", "");
+    testDF("test.txt", "", "test.txt");
+    testDF("test.txt\0junk", "", "test.txt");
+    testDF("test.txt\0notdir/junk", "", "test.txt");
+    testDF("dir/file", "dir/", "file");
+    testDF("some/dir/file", "some/dir/", "file");
+    testDF("some/dir/file\0junk", "some/dir/", "file");
+    testDF("/abs/file", "/abs/", "file");
+    testDF("./abs/file", "./abs/", "file");
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+    testDiag("Test path split windows");
+    testDF("dir\\file", "dir\\", "file");
+    testDF("dir\\file\0some\\junk/notdir", "dir\\", "file");
+    testDF("\\\\system07\\C$\\", "\\\\system07\\C$\\", "");
+    testDF("\\\\system07\\C$\\bar", "\\\\system07\\C$\\", "bar");
+#endif
+
+    testDiag("Test absolute/relative path classification");
+    testIsAbs(0, "");
+    testIsAbs(0, "foo");
+    testIsAbs(0, "foo/bar");
+    testIsAbs(0, "./foo/bar");
+    testIsAbs(0, "../foo/bar");
+    testIsAbs(1, "/foo");
+    testIsAbs(1, "/foo/bar");
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+    testDiag("Test absolute/relative path classification windows");
+    testIsAbs(0, "C:foo");
+    testIsAbs(0, "c:foo");
+    testIsAbs(1, "C:/foo");
+    testIsAbs(1, "c:/foo");
+    testIsAbs(1, "\\\\system07\\C$\\");
+    testIsAbs(1, "\\\\system07\\C$\\bar");
+#endif
+
+    testDiag("Test path join");
+    testJoin("", NULL);
+    testJoin("", "", NULL);
+    testJoin("", "", "", NULL);
+    testJoin("foo1", "foo1", NULL);
+    testJoin("foo2", "", "foo2", "", NULL);
+    testJoin("/foo3", "/foo3", NULL);
+    testJoin("foo" SEP "bar1", "foo", "bar1", NULL);
+    testJoin("/foo" SEP "bar2", "baz", "/foo", "bar2", NULL);
+    testJoin("/foo" SEP "bar3", "/baz", "/foo", "bar3", NULL);
+
+    {
+        std::vector<char> buf(1024);
+        if(getcwd(&buf[0], buf.size())==NULL)
+            testAbort("PWD is too large");
+
+        std::string expect(&buf[0]);
+        expect += SEP;
+        expect += "foo";
+        expect += SEP;
+        expect += "bar";
+
+        testJoin(expect.c_str(), "/ignore", epicsPathJoinCurDir, "foo", "bar", NULL);
+    }
+
+    return testDone();
+}

--- a/modules/libcom/test/epicsRunLibComTests.c
+++ b/modules/libcom/test/epicsRunLibComTests.c
@@ -25,6 +25,7 @@ int epicsCalcTest(void);
 int epicsEllTest(void);
 int epicsEnvTest(void);
 int epicsErrlogTest(void);
+int epicsPathTest(void);
 int epicsEventTest(void);
 int epicsExitTest(void);
 int epicsMathTest(void);
@@ -83,6 +84,7 @@ void epicsRunLibComTests(void)
     runTest(epicsEllTest);
     runTest(epicsEnvTest);
     runTest(epicsErrlogTest);
+    runTest(epicsPathTest);
     runTest(epicsEventTest);
     runTest(epicsInlineTest);
     runTest(epicsMathTest);


### PR DESCRIPTION
Provide several new IOC shell variables computed from the locations of files (not `$PWD`).  Intended to help writing scripts with less dependence on the current directory (less sensitive to an added `cd ...`).

- `${EPICS_EXEC_DIR}` Directory containing the executable.  Exactly the string returned by `epicsGetExecDir()` (if not NULL)
- `${TOP}` Provide a default value of `${EPICS_EXEC_DIR}/../..`.  Any `$TOP` in the environment takes precedence).
- `${IOCSH_SCRIPT_DIR}` Directory containing the current IOC shell script

@anjohnson What should these names be?

Note that these are IOC shell variables, not environment variables.

 `${IOCSH_SCRIPT_DIR}` handles nested scripts.  It will expand as the directory containing the current fragment.  eg.

```
cat <<EOF > test.cmd
< subdir/included.cmd
EOF
install -d subdir
cat <<EOF > subdir/included.cmd
echo "IOCSH_SCRIPT_DIR=${IOCSH_SCRIPT_DIR}"
EOF
softIoc test.cmd
```

Will show a path which ends with `subdir/`.

The first patch in the stack is standalone, and adds TOP and EPICS_EXEC_DIR.

The rest add the mechanics (including an OSI path handling) needed for IOCSH_SCRIPT_DIR.  This includes `epicsPathAllocCWD()` which handles really long directory names, and a detour to use it.  To make `#!/.../softIoc` work I need to capture `argv[0]`, which necessitates a change to the IOC main template code.  I do this in the form of `iocshMain()` to allow the possibility of further features (like `softIoc`-ish arguments) without needing another change to the template. existing IOC applications will see IOCSH_SCRIPT_DIR default to `$PWD`. 

The last patch changes to template to include these new variables, and to mention `${EPICS_DB_INCLUDE_PATH}` which otherwise isn't documented (still).  I've no problem omitting this for the time being if it turns out to be contentious.