### PR TITLE
Add VALID_BUILDS support for "Command"

### DIFF
--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -32,12 +32,12 @@ vpath %.l $(USR_VPATH) $(ALL_SRC_DIRS)
 include $(CONFIG)/CONFIG_ADDONS
 
 #---------------------------------------------------------------
-# Set PROD, TESTPROD, OBJS, and LIBRARY
 
 SCRIPTS_HOST += $(PERL_SCRIPTS)
 # PERL_SCRIPTS are installed into existing $(INSTALL_BIN) for Host systems
 
-ifeq ($(findstring Host,$(VALID_BUILDS)),Host)
+# Host targets can compile and run programs
+ifneq (,$(findstring Host,$(VALID_BUILDS)))
 LIBRARY += $(LIBRARY_HOST)
 LOADABLE_LIBRARY += $(LOADABLE_LIBRARY_HOST)
 OBJS += $(OBJS_HOST)
@@ -49,7 +49,21 @@ TESTSCRIPTS += $(TESTSCRIPTS_HOST)
 TESTPROD += $(TESTPROD_HOST)
 endif
 
-ifeq ($(findstring Ioc,$(VALID_BUILDS)),Ioc)
+# Command targets have a command line and support main()
+ifneq (,$(findstring Command,$(VALID_BUILDS)))
+LIBRARY += $(LIBRARY_CMD)
+LOADABLE_LIBRARY += $(LOADABLE_LIBRARY_CMD)
+OBJS += $(OBJS_CMD)
+PROD += $(PROD_CMD)
+SCRIPTS += $(SCRIPTS_CMD)
+TARGETS += $(TARGETS_CMD)
+TESTLIBRARY += $(TESTLIBRARY_CMD)
+TESTSCRIPTS += $(TESTSCRIPTS_CMD)
+TESTPROD += $(TESTPROD_CMD)
+endif
+
+# Ioc targets can run IOCs
+ifneq (,$(findstring Ioc,$(VALID_BUILDS)))
 LIBRARY += $(LIBRARY_IOC)
 LOADABLE_LIBRARY += $(LOADABLE_LIBRARY_IOC)
 OBJS += $(OBJS_IOC)

--- a/configure/os/CONFIG.Common.UnixCommon
+++ b/configure/os/CONFIG.Common.UnixCommon
@@ -8,7 +8,7 @@
 #-------------------------------------------------------
 
 # Unix valid build types
-VALID_BUILDS = Host Ioc
+VALID_BUILDS = Host Ioc Command
 
 #-------------------------------------------------------
 # Unix prefix and suffix definitions

--- a/configure/os/CONFIG.Common.linux-386
+++ b/configure/os/CONFIG.Common.linux-386
@@ -12,7 +12,7 @@ include $(CONFIG)/os/CONFIG.Common.linux-x86
 ARCH_DEP_CFLAGS = -march=i386
 
 ifeq ($(BUILD_CLASS),CROSS)
-  VALID_BUILDS = Ioc
+  VALID_BUILDS = Ioc Command
 endif
 
 # If your crosscompiler name has a GNU target prefix like <gnutarget>-gcc,

--- a/configure/os/CONFIG.Common.linux-486
+++ b/configure/os/CONFIG.Common.linux-486
@@ -10,7 +10,7 @@ include $(CONFIG)/os/CONFIG.Common.linux-x86
 ARCH_DEP_CFLAGS = -march=i486
 
 ifeq ($(BUILD_CLASS),CROSS)
-   VALID_BUILDS = Ioc
+   VALID_BUILDS = Ioc Command
 endif
 
 # If your crosscompiler name has a GNU target prefix like <gnutarget>-gcc,

--- a/configure/os/CONFIG.Common.linux-586
+++ b/configure/os/CONFIG.Common.linux-586
@@ -11,7 +11,7 @@ include $(CONFIG)/os/CONFIG.Common.linux-x86
 ARCH_DEP_CFLAGS = -march=i586
 
 ifeq ($(BUILD_CLASS),CROSS)
-   VALID_BUILDS = Ioc
+   VALID_BUILDS = Ioc Command
 endif
 
 # If your crosscompiler name has a GNU target prefix like <gnutarget>-gcc,

--- a/configure/os/CONFIG.Common.linux-686
+++ b/configure/os/CONFIG.Common.linux-686
@@ -11,7 +11,7 @@ include $(CONFIG)/os/CONFIG.Common.linux-x86
 ARCH_DEP_CFLAGS = -march=i686
 
 ifeq ($(BUILD_CLASS),CROSS)
-   VALID_BUILDS = Ioc
+   VALID_BUILDS = Ioc Command
 endif
 
 # If your crosscompiler name has a GNU target prefix like <gnutarget>-gcc,

--- a/configure/os/CONFIG.Common.linux-athlon
+++ b/configure/os/CONFIG.Common.linux-athlon
@@ -10,7 +10,7 @@ include $(CONFIG)/os/CONFIG.Common.linux-x86
 ARCH_DEP_CFLAGS += -march=athlon-mp -mfpmath=sse
 
 ifeq ($(BUILD_CLASS),CROSS)
-   VALID_BUILDS = Ioc
+   VALID_BUILDS = Ioc Command
 endif
 
 # If your crosscompiler name has a GNU target prefix like <gnutarget>-gcc,

--- a/configure/os/CONFIG.Common.linux-microblaze
+++ b/configure/os/CONFIG.Common.linux-microblaze
@@ -15,7 +15,7 @@ include $(CONFIG)/os/CONFIG.Common.linuxCommon
 ARCH_CLASS = microblaze
 
 ifeq ($(BUILD_CLASS),CROSS)
-	VALID_BUILDS = Ioc
+	VALID_BUILDS = Ioc Command
 	GNU_TARGET = microblazeel-unknown-linux-gnu
 	CMPLR_PREFIX = $(addsuffix -,$(GNU_TARGET))
 endif

--- a/configure/os/CONFIG.Common.linux-xscale_be
+++ b/configure/os/CONFIG.Common.linux-xscale_be
@@ -13,7 +13,7 @@ include $(CONFIG)/os/CONFIG.Common.linuxCommon
 ARCH_CLASS = xscale
 
 ifeq ($(BUILD_CLASS),CROSS)
-    VALID_BUILDS = Ioc
+    VALID_BUILDS = Ioc Command
     GNU_TARGET = xscale_be
     CMPLR_PREFIX = $(GNU_TARGET:%=%-)
 

--- a/configure/os/CONFIG.linux-x86.linux-arm
+++ b/configure/os/CONFIG.linux-x86.linux-arm
@@ -4,7 +4,7 @@
 # Override these settings in CONFIG_SITE.linux-x86.linux-arm
 #-------------------------------------------------------
 
-VALID_BUILDS = Ioc
+VALID_BUILDS = Ioc Command
 GNU_TARGET = arm-linux
 
 # prefix of compiler tools

--- a/configure/os/CONFIG.linux-x86_64.linux-aarch64
+++ b/configure/os/CONFIG.linux-x86_64.linux-aarch64
@@ -4,7 +4,7 @@
 # Sites may override these in CONFIG_SITE.linux-x86_64.linux-aarch64
 #-------------------------------------------------------
 
-VALID_BUILDS = Ioc
+VALID_BUILDS = Ioc Command
 GNU_TARGET = aarch64-linux
 
 # prefix of compiler tools

--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -6,7 +6,7 @@
 
 # Win32 valid build types and include directory suffixes
 
-VALID_BUILDS = Host Ioc
+VALID_BUILDS = Host Ioc Command
 
 CMPLR_CLASS = msvc
 

--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -17,6 +17,26 @@ should also be read to understand what has changed since earlier releases.
 
 <!-- Insert new items immediately below here ... -->
 
+
+
+### Build System: New `VALID_BUILDS` type "Command"
+
+Target architectures that support command-line programs that run the `main()`
+routine can now be marked as such in their `VALID_BUILDS` definition. This
+enables a new set of Makefile target variables `PROD_CMD` (similar to
+`PROD_HOST`), `LIBRARY_CMD` (like `LIBRARY_HOST`, etc.), `LOADABLE_LIBRARY_CMD`,
+`OBJS_CMD`, `SCRIPTS_CMD`, `TARGETS_CMD`, `TESTLIBRARY_CMD`, `TESTSCRIPTS_CMD`
+and `TESTPROD_CMD`. The CA client tools and programs such as `caRepeater` are now built for all such targets (previously they were built for all targets except where the OS was VxWorks, RTEMS and iOS).
+
+If you have created your own site-specific target architectures you may need to
+update the `VALID_BUILDS` variable if it gets set in your locally added
+`configure/os/CONFIG.Common.<arch>` files. This is usually only needed for
+cross-compiled targets though since `CONFIG.Common.UnixCommon` sets it.
+
+The other `VALID_BUILDS` types are "Host" for target architectures that can
+compile and run their own programs (`PROD_HOST` etc.), and "Ioc" for targets
+that can run IOCs (`PROD_IOC` etc.).
+
 ### Support for JSON5
 
 The YAJL parser and generator routines in libcom and in the IOC's dbStatic

--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -95,10 +95,7 @@ PROD_LIBS = ca Com
 # needed when its an object library build
 PROD_SYS_LIBS_WIN32 = ws2_32 advapi32 user32
 
-PROD_DEFAULT += caRepeater catime acctst caConnTest casw caEventRate
-PROD_vxWorks = -nil-
-PROD_RTEMS = -nil-
-PROD_iOS = -nil-
+PROD_CMD += caRepeater catime acctst caConnTest casw caEventRate
 
 OBJS_vxWorks = catime acctst caConnTest casw caEventRate acctstRegister
 

--- a/modules/ca/src/tools/Makefile
+++ b/modules/ca/src/tools/Makefile
@@ -13,10 +13,7 @@ TOP = ../../../..
 
 include $(TOP)/configure/CONFIG
 
-PROD_DEFAULT += caget camonitor cainfo caput
-PROD_vxWorks = -nil-
-PROD_RTEMS = -nil-
-PROD_iOS = -nil-
+PROD_CMD = caget camonitor cainfo caput
 
 PROD_SRCS = tool_lib.c
 


### PR DESCRIPTION
This adds Makefile variables `PROD_CMD`, `LIBRARY_CMD` etc. for building command-line programs on targets that can support them but which are not build hosts (e.g. cross-building for other Linux arch's). It changes catools and other CA programs to build using these, instead of writing "build for all arch's except where the OS is VxWorks, RTEMS or iOS".