### PR TITLE
Improve error message for DBF_MENU fields in .db files

### DIFF
--- a/modules/database/src/ioc/db/dbAccessDefs.h
+++ b/modules/database/src/ioc/db/dbAccessDefs.h
@@ -173,9 +173,8 @@ struct dbr_alDouble     {DBRalDouble};
 #define dbr_alLong_size sizeof(struct dbr_alLong)
 #define dbr_alDouble_size sizeof(struct dbr_alDouble)
 
-#ifndef INCerrMdefh
 #include "errMdef.h"
-#endif
+
 #define S_db_notFound   (M_dbAccess| 1) /*Process Variable Not Found*/
 #define S_db_badDbrtype (M_dbAccess| 3) /*Illegal Database Request Type*/
 #define S_db_noMod      (M_dbAccess| 5) /*Attempt to modify noMod field*/

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1185,8 +1185,8 @@ static void dbRecordField(char *name,char *value)
         char msg[128];
 
         errSymLookup(status, msg, sizeof(msg));
-        epicsPrintf("Can't set \"%s.%s\" to \"%s\" %s\n",
-            dbGetRecordName(pdbentry), name, value, msg);
+        epicsPrintf("Can't set \"%s.%s\" to \"%s\" %s : %s\n",
+            dbGetRecordName(pdbentry), name, value, pdbentry->message ? pdbentry->message : "", msg);
         yyerror(NULL);
         return;
     }

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1187,6 +1187,7 @@ static void dbRecordField(char *name,char *value)
         errSymLookup(status, msg, sizeof(msg));
         epicsPrintf("Can't set \"%s.%s\" to \"%s\" %s : %s\n",
             dbGetRecordName(pdbentry), name, value, pdbentry->message ? pdbentry->message : "", msg);
+        dbPutStringSuggest(pdbentry, value);
         yyerror(NULL);
         return;
     }

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -81,8 +81,6 @@ maplinkType pamaplinkType[LINK_NTYPES] = {
 };
 
 /*forward references for private routines*/
-static void dbMsgPrint(DBENTRY *pdbentry, const char *fmt, ...)
-    EPICS_PRINTF_STYLE(2,3);
 static long dbAddOnePath (DBBASE *pdbbase, const char *path, unsigned length);
 
 /* internal routines*/
@@ -199,7 +197,6 @@ void dbMsgNCpy(DBENTRY *pdbentry, const char *msg, size_t len)
     pdbentry->message[len] = '\0';
 }
 
-static
 void dbMsgPrint(DBENTRY *pdbentry, const char *fmt, ...)
 {
     va_list args;

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -36,6 +36,8 @@ char *dbRecordName(DBENTRY *pdbentry);
 char *dbGetStringNum(DBENTRY *pdbentry);
 long dbPutStringNum(DBENTRY *pdbentry,const char *pstring);
 
+void dbMsgPrint(DBENTRY *pdbentry, const char *fmt, ...) EPICS_PRINTF_STYLE(2,3);
+
 struct jlink;
 
 typedef struct dbLinkInfo {

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -38,6 +38,8 @@ long dbPutStringNum(DBENTRY *pdbentry,const char *pstring);
 
 void dbMsgPrint(DBENTRY *pdbentry, const char *fmt, ...) EPICS_PRINTF_STYLE(2,3);
 
+void dbPutStringSuggest(DBENTRY *pdbentry, const char *pstring);
+
 struct jlink;
 
 typedef struct dbLinkInfo {

--- a/modules/database/src/ioc/dbStatic/dbStaticRun.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticRun.c
@@ -28,6 +28,7 @@
 #include "dbCommonPvt.h"
 #include "dbStaticLib.h"
 #include "dbStaticPvt.h"
+#include "dbAccess.h"
 #include "devSup.h"
 #include "special.h"
 
@@ -479,8 +480,17 @@ long dbPutStringNum(DBENTRY *pdbentry, const char *pstring)
                 epicsEnum16 value;
                 long status = epicsParseUInt16(pstring, &value, 0, NULL);
 
-                if (status)
+                if (status) {
+                    status = S_db_badChoice;
+                    if(pflddes->field_type==DBF_MENU) {
+                        dbMenu  *pdbMenu = (dbMenu *)pflddes->ftPvt;
+                        dbMsgPrint(pdbentry, "using menu %s", pdbMenu->name);
+
+                    } else if(pflddes->field_type==DBF_DEVICE) {
+                        dbMsgPrint(pdbentry, "no such device support for '%s' record type", pdbentry->precordType->name);
+                    }
                     return status;
+                }
 
                 index = dbGetNMenuChoices(pdbentry);
                 if (value > index && index > 0 && value < USHRT_MAX)

--- a/modules/libcom/src/error/Makefile
+++ b/modules/libcom/src/error/Makefile
@@ -26,5 +26,7 @@ ERR_S_FILES += $(LIBCOM)/as/asLib.h
 ERR_S_FILES += $(LIBCOM)/misc/epicsStdlib.h
 ERR_S_FILES += $(LIBCOM)/pool/epicsThreadPool.h
 ERR_S_FILES += $(LIBCOM)/error/errMdef.h
+ERR_S_FILES += $(TOP)/modules/database/src/ioc/db/dbAccessDefs.h
+ERR_S_FILES += $(TOP)/modules/database/src/ioc/dbStatic/dbStaticLib.h
 
 CLEANS += errSymTbl.c

--- a/modules/libcom/src/misc/epicsString.h
+++ b/modules/libcom/src/misc/epicsString.h
@@ -41,6 +41,16 @@ LIBCOM_API char * epicsStrtok_r(char *s, const char *delim, char **lasts);
 LIBCOM_API unsigned int epicsStrHash(const char *str, unsigned int seed);
 LIBCOM_API unsigned int epicsMemHash(const char *str, size_t length,
                                          unsigned int seed);
+/** Compare two strings and return a number in the range [0.0, 1.0] or -1.0 on error.
+ *
+ * Computes a normalized edit distance representing the similarity between two strings.
+ *
+ * @returns 1.0 when A and B are identical, down to 0.0 when A and B are unrelated,
+ *          or < 0.0 on error.
+ *
+ * @since UNRELEASED
+ */
+LIBCOM_API double epicsStrSimilarity(const char *A, const char *B);
 
 /* dbTranslateEscape is deprecated, use epicsStrnRawFromEscaped instead */
 LIBCOM_API int dbTranslateEscape(char *s, const char *ct);


### PR DESCRIPTION
Arising from https://epics.anl.gov/core-talk/2021/msg00165.php

Adds some context eg `no such device support for 'ao' record type` or `using menu menuIvoa`when setting a DBF_MENU or DBF_DEVICE field from a .db file (not live).

Add `Did you mean "..."?` suggestion based using minimum [edit distance](https://en.wikipedia.org/wiki/Edit_distance) as a metric of "similarity".

```
$ cat badchoice.db 
record("ao", "foo") {
    field(DTYP, "Soft Chanel")
    field(PINI, "yes")
    field(IVOA, "Set output To IVOV")
    field(SCAN, "Pensive")
}
record("ai", "bar") {
    field(SCAN, "100")
}
$ softIoc -d badchoice.db
Can't set "foo.DTYP" to "Soft Chanel" no such device support for 'ao' record type : Illegal choice
    Did you mean "Soft Channel"?
Error at or before ")" in file "../../base-git/badchoice.db" line 2
Can't set "foo.PINI" to "yes" using menu menuPini : Illegal choice
    Did you mean "YES"?
ErrorCan't set "foo.IVOA" to "Set output To IVOV" using menu menuIvoa : Illegal choice
    Did you mean "Set output to IVOV"?
ErrorCan't set "foo.SCAN" to "Pensive" using menu menuScan : Illegal choice
    Did you mean "Passive"?
ErrorCan't set "bar.SCAN" to "100"  : Bad Field value
    Did you mean "10 second"?
ErrordbLoadRecords: failed to load '../../base-git/badchoice.db'
Error: Failed to load: ../../base-git/badchoice.db
```