### PR TITLE
Fix a bug which causes timers to expire early on modern Linux systems

### DIFF
--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -185,7 +185,9 @@ RES=.res
 
 # MS Visual C++ doesn't recognize *.cc as a C++ source file,
 # so C++ compiles get the flag -TP
-COMPILER_CXXFLAGS = -TP
+# We want MSVC to report a reasonable C++ version in the __cplusplus macro so
+# we need to set -Zc:__cplusplus (this is at least required for MSVC 19.xx).
+COMPILER_CXXFLAGS = -TP -Zc:__cplusplus
 
 # Operating system flags
 OP_SYS_CFLAGS =

--- a/src/libCom/osi/Makefile
+++ b/src/libCom/osi/Makefile
@@ -39,6 +39,7 @@ INC += epicsGeneralTime.h
 INC += osdTime.h
 INC += generalTimeSup.h
 INC += osiClockTime.h
+INC += osdTimer.h
 INC += epicsSignal.h
 INC += osiProcess.h
 INC += osiUnistd.h

--- a/src/libCom/osi/os/Linux/osdTimer.h
+++ b/src/libCom/osi/os/Linux/osdTimer.h
@@ -1,0 +1,14 @@
+/*************************************************************************\
+* Copyright (c) 2021 Facility for Rare Isotope Beams
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef osdTimerh
+#define osdTimerh
+
+/* Linux supports high-precision timers (in contrast to quantized timers which
+ * only support sleeping for a multiple of the quantum). */
+#define HAS_HIGH_PREC_TIMERS
+
+#endif /* osdTimerh */

--- a/src/libCom/osi/os/default/osdTimer.h
+++ b/src/libCom/osi/os/default/osdTimer.h
@@ -1,0 +1,12 @@
+/*************************************************************************\
+* Copyright (c) 2021 Facility for Rare Isotope Beams
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef osdTimerh
+#define osdTimerh
+
+/* For systems other than Linux we do not define HAS_HIGH_PREC_TIMERS. */
+
+#endif /* osdTimerh */

--- a/src/libCom/test/epicsTimerTest.cpp
+++ b/src/libCom/test/epicsTimerTest.cpp
@@ -36,7 +36,11 @@
     epicsAssert(__FILE__, __LINE__, #exp, epicsAssertAuthor))
 
 #if __cplusplus >= 201103L
+#ifdef HAS_HIGH_PREC_TIMERS
+const double timeTolerance { 1e-3 };
+#else
 const double timeTolerance { 1e-3 + epicsThreadSleepQuantum() };
+#endif
 
 class handler : public epicsTimerNotify
 {

--- a/src/libCom/test/epicsTimerTest.cpp
+++ b/src/libCom/test/epicsTimerTest.cpp
@@ -64,12 +64,12 @@ private:
   std::function<void()> expireFct;
 };
 
-void verifyExpirationTime(double delta_t, double tolerance) {
-  if (!testOk(std::abs(delta_t) < tolerance, "timer expired at the expected "
-              "time (error = %f ms, tolerance = +/-%f ms)", 1000.0 * delta_t,
-              1000.0 * tolerance)) {
-    const char * msg = delta_t < 0.0 ? "early" : "late";
-    testDiag("delta t = %g ms (timer expired too %s)", 1000.0 * delta_t, msg);
+void verifyExpirationTime(double delta, double tolerance) {
+  if (!testOk(delta >= 0.0 && delta < tolerance, "timer expired at the expected"
+              " time (error = %f ms, tolerance = +%f/-0.0 ms)",
+              1000.0 * delta, 1000.0 * tolerance)) {
+    const char * msg = delta < 0.0 ? "early" : "late";
+    testDiag("delta t = %g ms (timer expired too %s)", 1000.0 * delta, msg);
   }
 }
 

--- a/src/libCom/timer/epicsTimer.h
+++ b/src/libCom/timer/epicsTimer.h
@@ -19,6 +19,7 @@
 #include "shareLib.h"
 #include "epicsTime.h"
 #include "epicsThread.h"
+#include "osdTimer.h"
 
 #ifdef __cplusplus
 

--- a/src/libCom/timer/timer.cpp
+++ b/src/libCom/timer/timer.cpp
@@ -21,6 +21,7 @@
 
 #define epicsExportSharedSymbols
 #include "epicsGuard.h"
+#include "osdTimer.h"
 #include "timerPrivate.h"
 #include "errlog.h"
 
@@ -66,7 +67,11 @@ void timer::start ( epicsTimerNotify & notify, const epicsTime & expire )
 void timer::privateStart ( epicsTimerNotify & notify, const epicsTime & expire )
 {
     this->pNotify = & notify;
+#ifdef HAS_HIGH_PREC_TIMERS
+    this->exp = expire;
+#else
     this->exp = expire - ( this->queue.notify.quantum () / 2.0 );
+# endif
 
     bool reschedualNeeded = false;
     if ( this->curState == stateActive ) {


### PR DESCRIPTION
Fixes #106. Tested on
- [X] Linux
- [ ] Darwin
- [ ] VxWorks
- [ ] RTEMS