### PR TITLE
Add more timer tests

### DIFF
--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -185,7 +185,9 @@ RES=.res
 
 # MS Visual C++ doesn't recognize *.cc as a C++ source file,
 # so C++ compiles get the flag -TP
-COMPILER_CXXFLAGS = -TP
+# We want MSVC to report a reasonable C++ version in the __cplusplus macro so
+# we need to set -Zc:__cplusplus (this is at least required for MSVC 19.xx).
+COMPILER_CXXFLAGS = -TP -Zc:__cplusplus
 
 # Operating system flags
 OP_SYS_CFLAGS =

--- a/src/libCom/test/epicsTimerTest.cpp
+++ b/src/libCom/test/epicsTimerTest.cpp
@@ -64,12 +64,12 @@ private:
   std::function<void()> expireFct;
 };
 
-void verifyExpirationTime(double delta_t, double tolerance) {
-  if (!testOk(std::abs(delta_t) < tolerance, "timer expired at the expected "
-              "time (error = %f ms, tolerance = +/-%f ms)", 1000.0 * delta_t,
-              1000.0 * tolerance)) {
-    const char * msg = delta_t < 0.0 ? "early" : "late";
-    testDiag("delta t = %g ms (timer expired too %s)", 1000.0 * delta_t, msg);
+void verifyExpirationTime(double delta, double tolerance) {
+  if (!testOk(delta >= 0.0 && delta < tolerance, "timer expired at the expected"
+              " time (error = %f ms, tolerance = +%f/-0.0 ms)",
+              1000.0 * delta, 1000.0 * tolerance)) {
+    const char * msg = delta < 0.0 ? "early" : "late";
+    testDiag("delta t = %g ms (timer expired too %s)", 1000.0 * delta, msg);
   }
 }
 


### PR DESCRIPTION
The existing tests are testing many things in each test. In contrast to that the tests I'm adding here are each testing one basic property (they can also act as a sort of documentation). Each test is designed to fail for one reason only - creating a fresh timer queue for each test helps with isolation.

Note that currently these tests are leveraging C++11 features. We could either

- merge these tests into a new 7.1 branch (which will be the first EPICS version which requires a C++11 compiler)
- refactor them to make them compatible with C++98 for now (and then refactor them for better readability later when we are working on 7.1)
- put `ifdef`s around the new code to include these tests only with compilers which support C++11

Which one do you prefer?