### PR TITLE
Print if some links still disconnected after 5 seconds

### DIFF
--- a/modules/database/src/ioc/db/dbLinkPvt.h
+++ b/modules/database/src/ioc/db/dbLinkPvt.h
@@ -1,0 +1,26 @@
+/*************************************************************************\
+* Copyright (c) 2020 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef INC_dbLinkPvt_H
+#define INC_dbLinkPvt_H
+
+#include "dbLink.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern double dbLinkConnectionCheckDelay;
+
+void dbLinkCheckStart(void);
+void dbLinkConnCheck(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INC_dbLinkPvt_H */

--- a/modules/database/src/ioc/misc/dbCore.dbd
+++ b/modules/database/src/ioc/misc/dbCore.dbd
@@ -36,3 +36,8 @@ variable(dbThreadRealtimeLock,int)
 
 # show logClient network activity
 variable(logClientDebug,int)
+
+# Delay (sec) after iocInit of one time courtesy
+# check for dis-connected volatile (eg. CA) links.
+# Set to < 0.0 to disable.
+variable(dbLinkConnectionCheckDelay,double)

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -62,6 +62,7 @@
 #include "initHooks.h"
 #include "iocInit.h"
 #include "link.h"
+#include "dbLinkPvt.h"
 #include "menuConvert.h"
 #include "menuPini.h"
 #include "recGbl.h"
@@ -97,6 +98,9 @@ static void iterateRecords(recIterFunc func, void *user);
 
 int dbThreadRealtimeLock = 1;
 epicsExportAddress(int, dbThreadRealtimeLock);
+
+double dbLinkConnectionCheckDelay = 5.0;
+epicsExportAddress(double, dbLinkConnectionCheckDelay);
 
 enum iocStateEnum getIocState(void)
 {
@@ -182,6 +186,8 @@ static int iocBuild_2(void)
 
     initialProcess();
     initHookAnnounce(initHookAfterInitialProcess);
+
+    dbLinkCheckStart();
     return 0;
 }
 


### PR DESCRIPTION
Help catch typos resulting from unexpected implicit CA links by printing a short notice if any link are disconnected 5 seconds after `iocInit()`.

```
iocRun: All initialization complete
epics> Notice: 1 link(s) have not yet connected
```

Intended to be a hint that something may be off, which could trigger further investigation with `dbcar`.  Hopefully won't be too annoying in cases where remote links were deliberate.

"Borrows" access to the timer queue created in `callback.c` instead of creating a dedicated thread.