### PR TITLE
Add DB link modifier

### DIFF
--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -1104,9 +1104,9 @@ static long dbPutFieldLink(DBADDR *paddr,
     if (link_info.ltype == PV_LINK &&
         (link_info.modifiers & (pvlOptCA | pvlOptCP | pvlOptCPP)) == 0) {
         chan = dbChannelCreate(link_info.target);
-        if (chan && dbChannelOpen(chan) != 0) {
-            errlogPrintf("ERROR: dbPutFieldLink %s.%s=%s: dbChannelOpen() failed\n",
-                precord->name, pfldDes->name, link_info.target);
+        if (chan && (status = dbChannelOpen(chan)) != 0) {
+            errlogPrintf(ERL_ERROR ": dbPutFieldLink %s.%s=%s: dbChannelOpen() failed w/ 0x%lx\n",
+                precord->name, pfldDes->name, link_info.target, status);
             goto cleanup;
         }
     }

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -24,6 +24,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#define EPICS_PRIVATE_API
+
 #include "alarm.h"
 #include "cantProceed.h"
 #include "cvtFast.h"

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -1111,6 +1111,13 @@ static long dbPutFieldLink(DBADDR *paddr,
                 precord->name, pfldDes->name, link_info.target, status);
             goto cleanup;
         }
+        if (!chan && (link_info.modifiers & pvlOptDB)) {
+            errlogPrintf("%s.%s " ERL_ERROR ": Unable to create DB link to \"%s\"\n",
+                         precord->name, dbLinkFieldName(plink),
+                         plink->value.pv_link.pvname);
+            status = S_dbLib_recNotFound;
+            goto cleanup;
+        }
     }
 
     isDevLink = ellCount(&precord->rdes->devList) > 0 &&

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -392,7 +392,7 @@ typedef struct lset {
 DBCORE_API const char * dbLinkFieldName(const struct link *plink);
 
 #ifdef EPICS_PRIVATE_API
-void dbInitLink(struct link *plink, short dbfType);
+long dbInitLink(struct link *plink, short dbfType);
 void dbAddLink(struct dbLocker *locker, struct link *plink,
                short dbfType, dbChannel *ptarget);
 #endif /* EPICS_PRIVATE_API */

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -391,9 +391,11 @@ typedef struct lset {
 
 DBCORE_API const char * dbLinkFieldName(const struct link *plink);
 
-DBCORE_API void dbInitLink(struct link *plink, short dbfType);
-DBCORE_API void dbAddLink(struct dbLocker *locker, struct link *plink,
-        short dbfType, dbChannel *ptarget);
+#ifdef EPICS_PRIVATE_API
+void dbInitLink(struct link *plink, short dbfType);
+void dbAddLink(struct dbLocker *locker, struct link *plink,
+               short dbfType, dbChannel *ptarget);
+#endif /* EPICS_PRIVATE_API */
 
 DBCORE_API void dbLinkOpen(struct link *plink);
 DBCORE_API void dbRemoveLink(struct dbLocker *locker, struct link *plink);

--- a/modules/database/src/ioc/db/dbLock.c
+++ b/modules/database/src/ioc/db/dbLock.c
@@ -935,9 +935,10 @@ long dblsr(char *recordname,int level)
                 } else if(pdbFldDes->field_type==DBF_FWDLINK) {
                     printf("\tFWDLINK");
                 }
-                printf(" %s %s",
+                printf(" %s %s%s",
                     ((plink->value.pv_link.pvlMask&pvlOptPP)?" PP":"NPP"),
-                    msstring[plink->value.pv_link.pvlMask&pvlOptMsMode]);
+                    msstring[plink->value.pv_link.pvlMask&pvlOptMsMode],
+                    plink->value.pv_link.pvlMask & pvlOptDB ? " DB" : "");
                 printf(" %s\n",pdbAddr->precord->name);
             }
         }

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -1922,11 +1922,12 @@ char * dbGetString(DBENTRY *pdbentry)
             else if(pvlMask&pvlOptCP) ppind=3;
             else if(pvlMask&pvlOptCPP) ppind=4;
             else ppind=0;
-            dbMsgPrint(pdbentry, "%s%s%s%s",
+            dbMsgPrint(pdbentry, "%s%s%s%s%s",
                    plink->value.pv_link.pvname ? plink->value.pv_link.pvname : "",
                    (plink->flags & DBLINK_FLAG_TSELisTIME) ? ".TIME" : "",
                    ppstring[ppind],
-                   msstring[plink->value.pv_link.pvlMask&pvlOptMsMode]);
+                   msstring[plink->value.pv_link.pvlMask&pvlOptMsMode],
+                   pvlMask & pvlOptDB ? " DB" : "");
             break;
         }
         case VME_IO:
@@ -2018,9 +2019,10 @@ char * dbGetString(DBENTRY *pdbentry)
                 pvlMask = plink->value.pv_link.pvlMask;
                 if (pvlMask&pvlOptCA) ppind=2;
                 else ppind=0;
-                dbMsgPrint(pdbentry, "%s%s",
+                dbMsgPrint(pdbentry, "%s%s%s",
                     plink->value.pv_link.pvname ? plink->value.pv_link.pvname : "",
-                    ppind ? ppstring[ppind] : "");
+                    ppind ? ppstring[ppind] : "",
+                    pvlMask & pvlOptDB ? " DB" : "");
                 break;
             }
             default :
@@ -2353,6 +2355,11 @@ long dbParseLink(const char *str, short ftype, dbLinkInfo *pinfo)
         else if (strstr(pstr, "MSI")) pinfo->modifiers |= pvlOptMSI;
         else if (strstr(pstr, "MSS")) pinfo->modifiers |= pvlOptMSS;
         else if (strstr(pstr, "MS")) pinfo->modifiers |= pvlOptMS;
+
+        if (strstr(pstr, "DB")) {
+            pinfo->modifiers &= ~(pvlOptCA | pvlOptCP | pvlOptCPP); /* pvlOptPP is ok */
+            pinfo->modifiers |= pvlOptDB;
+        }
 
         /* filter modifiers based on link type */
         switch(ftype) {

--- a/modules/database/src/ioc/dbStatic/link.h
+++ b/modules/database/src/ioc/dbStatic/link.h
@@ -68,6 +68,7 @@ DBCORE_API extern maplinkType pamaplinkType[];
 #define pvlOptInpString  0x100  /*Input as string*/
 #define pvlOptOutNative  0x200  /*Output native*/
 #define pvlOptOutString  0x400  /*Output as string*/
+#define pvlOptDB         0x800  /*Force local database link*/
 
 /* DBLINK Flag bits */
 #define DBLINK_FLAG_INITIALIZED    1 /* dbInitLink() called */

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -28,6 +28,7 @@
 #include "dbDefs.h"
 #include "ellLib.h"
 #include "envDefs.h"
+#include "errSymTbl.h"
 #include "epicsExit.h"
 #include "epicsGeneralTime.h"
 #include "epicsPrint.h"
@@ -538,9 +539,10 @@ static long doResolveLinks(dbRecordType *pdbRecordType, dbCommon *precord,
     dbFldDes **papFldDes = pdbRecordType->papFldDes;
     short *link_ind = pdbRecordType->link_ind;
     int j;
+    long ret = 0;
 
     /* For all the links in the record type... */
-    for (j = 0; j < pdbRecordType->no_links; j++) {
+    for (j = 0; !ret && j < pdbRecordType->no_links; j++) {
         dbFldDes *pdbFldDes = papFldDes[link_ind[j]];
         DBLINK *plink = (DBLINK*)((char*)precord + pdbFldDes->offset);
 
@@ -555,9 +557,9 @@ static long doResolveLinks(dbRecordType *pdbRecordType, dbCommon *precord,
             }
         }
 
-        dbInitLink(plink, pdbFldDes->field_type);
+        ret = dbInitLink(plink, pdbFldDes->field_type);
     }
-    return 0;
+    return ret;
 }
 
 static long doInitRecord1(dbRecordType *pdbRecordType, dbCommon *precord,

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -23,6 +23,8 @@
 #include <errno.h>
 #include <limits.h>
 
+#define EPICS_PRIVATE_API
+
 #include "dbDefs.h"
 #include "ellLib.h"
 #include "envDefs.h"

--- a/modules/database/test/ioc/db/dbPutLinkTest.c
+++ b/modules/database/test/ioc/db/dbPutLinkTest.c
@@ -247,6 +247,32 @@ static void testCADBSet(void)
     testdbCleanup();
 }
 
+static
+void testDBMod(void)
+{
+    testDiag("\n# Checking DB link modifier\n#");
+    testdbPrepare();
+
+    testdbReadDatabase("dbTestIoc.dbd", NULL, NULL);
+
+    dbTestIoc_registerRecordDeviceDriver(pdbbase);
+
+    testdbReadDatabase("dbPutLinkTest.db", NULL, NULL);
+
+    eltc(0);
+    testIocInitOk();
+    eltc(1);
+
+    testdbPutFieldOk("x1.INP", DBF_STRING, "x2 DB");
+    testdbGetFieldEqual("x1.INP", DBF_STRING, "x2 NPP NMS DB");
+    testdbPutFieldFail(S_dbLib_recNotFound, "x1.INP", DBF_STRING, "notrec DB");
+    testdbGetFieldEqual("x1.INP", DBF_STRING, "x2 NPP NMS DB");
+
+    testIocShutdownOk();
+
+    testdbCleanup();
+}
+
 typedef struct {
     const char * const recname;
     short ltype;
@@ -700,10 +726,11 @@ void testTSEL(void)
 
 MAIN(dbPutLinkTest)
 {
-    testPlan(342);
+    testPlan(346);
     testLinkParse();
     testLinkFailParse();
     testCADBSet();
+    testDBMod();
     testHWInitSet();
     testHWMod();
     testLinkInitFail();


### PR DESCRIPTION
Follow on, or maybe alternative to, #109 explores adding a new link modifier `DB` to mark a link which should not become a CA link.

```
record(ai, "src") {
    field(INP, "oops DB")
}
```

Results in an error during `iocInit()`.  Further, attempting to Put "oops DB" at runtime will error as well.