### PR TITLE
Limit auto-declaration of record types to regRecDevDrv only

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -18,6 +18,20 @@ should also be read to understand what has changed since earlier releases.
 <!-- Insert new items immediately below here ... -->
 
 
+### Prevent default DTYPs from changing
+
+[Kay Kasemir reported](https://bugs.launchpad.net/epics-base/+bug/1908305) that
+it is possible to change the Base record type's default DTYP if a `device()`
+entry is seen before the `recordtype()` definition to which it refers. The
+default DTYP is the first device loaded, which is normally the `Soft Channel`
+support from Base. A warning was being displayed by dbdExpand when a `device()`
+entry was see first, but that was easily missed.
+
+The DBD file parser in dbdExpand.pl has now been modified to make this an error,
+although the registerRecordDeviceDriver.pl script will still accept `device()`
+entries without having their `recordtype()` loaded since this is necessary to
+compile device supports as loadable modules.
+
 
 ### Priority inversion safe posix mutexes
 

--- a/modules/database/src/template/top/exampleApp/src/xxxSupport.dbd
+++ b/modules/database/src/template/top/exampleApp/src/xxxSupport.dbd
@@ -1,2 +1,2 @@
 include "xxxRecord.dbd"
-device(xxx,CONSTANT,devXxxSoft,"SoftChannel")
+device(xxx,CONSTANT,devXxxSoft,"Soft Channel")

--- a/modules/database/src/tools/DBD/Parser.pm
+++ b/modules/database/src/tools/DBD/Parser.pm
@@ -103,8 +103,8 @@ sub ParseDBD {
                 unquote($1, $2, $3, $4);
             my $rtyp = $dbd->recordtype($record_type);
             if (!defined $rtyp) {
-                my $msg = "Device '$choice' defined for unknown record type '$record_type'.";
-                dieContext($msg, "DBD files must be added in the correct order.")
+                my $msg = "Device '$choice' refers to unknown record type '$record_type'.";
+                dieContext($msg, "DBD files must be combined in the correct order.")
                     unless $allowAutoDeclarations;
                 warn "$msg\nRecord type '$record_type' declared.\n";
                 $rtyp = DBD::Recordtype->new($record_type);

--- a/modules/database/src/tools/DBD/Parser.pm
+++ b/modules/database/src/tools/DBD/Parser.pm
@@ -29,6 +29,7 @@ use DBD::Function;
 use DBD::Variable;
 
 our $debug=0;
+our $allowAutoDeclarations=0;
 
 sub ParseDBD {
     (my $dbd, $_) = @_;
@@ -102,8 +103,11 @@ sub ParseDBD {
                 unquote($1, $2, $3, $4);
             my $rtyp = $dbd->recordtype($record_type);
             if (!defined $rtyp) {
+                my $msg = "Device '$choice' defined for unknown record type '$record_type'.";
+                dieContext($msg, "DBD files must be added in the correct order.")
+                    unless $allowAutoDeclarations;
+                warn "$msg\nRecord type '$record_type' declared.\n";
                 $rtyp = DBD::Recordtype->new($record_type);
-                warn "Device using unknown record type '$record_type', declaration created\n";
                 $dbd->add($rtyp);
             }
             $rtyp->add_device(DBD::Device->new($link_type, $dset, $choice));

--- a/modules/database/src/tools/registerRecordDeviceDriver.pl
+++ b/modules/database/src/tools/registerRecordDeviceDriver.pl
@@ -31,7 +31,7 @@ my @path = map { split /[:;]/ } @opt_I; # FIXME: Broken on Win32?
 
 my ($file, $subname, $bldTop) = @ARGV;
 
-# Permit auto-declaration of record types for building runtime-loadable modules
+# Auto-declaration of record types is needed to build loadable modules
 $DBD::Parser::allowAutoDeclarations = 1;
 
 my $dbd = DBD->new();

--- a/modules/database/src/tools/registerRecordDeviceDriver.pl
+++ b/modules/database/src/tools/registerRecordDeviceDriver.pl
@@ -31,6 +31,9 @@ my @path = map { split /[:;]/ } @opt_I; # FIXME: Broken on Win32?
 
 my ($file, $subname, $bldTop) = @ARGV;
 
+# Permit auto-declaration of record types for building runtime-loadable modules
+$DBD::Parser::allowAutoDeclarations = 1;
+
 my $dbd = DBD->new();
 ParseDBD($dbd, Readfile($file, "", \@path));
 


### PR DESCRIPTION
Allowing this while expanding DBD files for IOCs can insert other device supports before of the Base "Soft Channel" ones, making the other type the default, so only allow the registerRecordDeviceDriver.pl script to auto-declare unknown record types that are seen in a DBD `device()` entry. Adds a note to errors that the DBD file order matters.

Fixes [lp: #1908305](https://bugs.launchpad.net/bugs/1908305)

This PR replaces #96 and no longer makes `Soft Channel` a special device support name, Kay would have seen a build error with this change.

Still missing a Release Notes entry.
