### PR TITLE
errlog rewrite w/ color removal

### DIFF
--- a/modules/ca/src/client/casw.cpp
+++ b/modules/ca/src/client/casw.cpp
@@ -188,7 +188,7 @@ int main ( int argc, char ** argv )
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
             epicsSocketDestroy ( sock );
-            errlogPrintf ("casw: error from recv was = \"%s\"\n",
+            errlogPrintf ("casw: " ERL_ERROR " from recv was = \"%s\"\n",
                 sockErrBuf );
             return -1;
         }

--- a/modules/ca/src/client/tcpiiu.cpp
+++ b/modules/ca/src/client/tcpiiu.cpp
@@ -178,7 +178,7 @@ void tcpSendThread::run ()
                 char sockErrBuf[64];
                 epicsSocketConvertErrnoToString (
                     sockErrBuf, sizeof ( sockErrBuf ) );
-                errlogPrintf ("CAC TCP clean socket shutdown error was %s\n",
+                errlogPrintf ("CAC TCP clean socket shutdown " ERL_ERROR " was %s\n",
                     sockErrBuf );
             }
         }
@@ -194,7 +194,7 @@ void tcpSendThread::run ()
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
-            errlogPrintf ("CAC TCP clean socket shutdown error was %s\n",
+            errlogPrintf ("CAC TCP clean socket shutdown " ERL_ERROR " was %s\n",
                 sockErrBuf );
         }
     }
@@ -283,7 +283,7 @@ unsigned tcpiiu::sendBytes ( const void *pBuf,
                 char sockErrBuf[64];
                 epicsSocketConvertErrnoToString (
                     sockErrBuf, sizeof ( sockErrBuf ) );
-                errlogPrintf ( "CAC: unexpected TCP send error: %s\n",
+                errlogPrintf ( "CAC: unexpected TCP send " ERL_ERROR ": %s\n",
                     sockErrBuf );
             }
 
@@ -957,7 +957,7 @@ void tcpiiu::initiateAbortShutdown (
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
-            errlogPrintf ( "CAC TCP socket linger set error was %s\n",
+            errlogPrintf ( "CAC TCP socket linger set " ERL_ERROR " was %s\n",
                 sockErrBuf );
         }
         this->discardingPendingData = true;
@@ -988,7 +988,7 @@ void tcpiiu::initiateAbortShutdown (
                     char sockErrBuf[64];
                     epicsSocketConvertErrnoToString (
                         sockErrBuf, sizeof ( sockErrBuf ) );
-                    errlogPrintf ("CAC TCP socket shutdown error was %s\n",
+                    errlogPrintf ("CAC TCP socket shutdown " ERL_ERROR " was %s\n",
                         sockErrBuf );
                 }
             }

--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -266,7 +266,7 @@ udpiiu::udpiiu (
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
             epicsSocketDestroy ( this->sock );
-            errlogPrintf ( "CAC: getsockname () error was \"%s\"\n", sockErrBuf );
+            errlogPrintf ( "CAC: getsockname () " ERL_ERROR " was \"%s\"\n", sockErrBuf );
             throwWithLocation ( noSocket () );
         }
         if ( tmpAddr.sa.sa_family != AF_INET) {
@@ -428,7 +428,7 @@ void udpRecvThread::run ()
                     char sockErrBuf[64];
                     epicsSocketConvertErrnoToString (
                         sockErrBuf, sizeof ( sockErrBuf ) );
-                    errlogPrintf ( "CAC: UDP recv error was \"%s\"\n",
+                    errlogPrintf ( "CAC: UDP recv " ERL_ERROR " was \"%s\"\n",
                         sockErrBuf );
                 }
             }

--- a/modules/database/src/ioc/db/callback.c
+++ b/modules/database/src/ioc/db/callback.c
@@ -85,7 +85,7 @@ static epicsEventId startStopEvent;
 static char *threadNamePrefix[NUM_CALLBACK_PRIORITIES] = {
     "cbLow", "cbMedium", "cbHigh"
 };
-#define FULL_MSG(name) "callbackRequest: " name " ring buffer full\n"
+#define FULL_MSG(name) "callbackRequest: " ERL_ERROR " " name " ring buffer full\n"
 static char *fullMessage[NUM_CALLBACK_PRIORITIES] = {
     FULL_MSG("cbLow"), FULL_MSG("cbMedium"), FULL_MSG("cbHigh")
 };
@@ -326,17 +326,17 @@ int callbackRequest(epicsCallback *pcallback)
     cbQueueSet *mySet;
 
     if (!pcallback) {
-        epicsInterruptContextMessage("callbackRequest: pcallback was NULL\n");
+        epicsInterruptContextMessage("callbackRequest: " ERL_ERROR " pcallback was NULL\n");
         return S_db_notInit;
     }
     priority = pcallback->priority;
     if (priority < 0 || priority >= NUM_CALLBACK_PRIORITIES) {
-        epicsInterruptContextMessage("callbackRequest: Bad priority\n");
+        epicsInterruptContextMessage("callbackRequest: " ERL_ERROR " Bad priority\n");
         return S_db_badChoice;
     }
     mySet = &callbackQueue[priority];
     if (!mySet->queue) {
-        epicsInterruptContextMessage("callbackRequest: Callbacks not initialized\n");
+        epicsInterruptContextMessage("callbackRequest: " ERL_ERROR " Callbacks not initialized\n");
         return S_db_notInit;
     }
     if (mySet->queueOverflow) return S_db_bufFull;

--- a/modules/database/src/ioc/db/dbCa.c
+++ b/modules/database/src/ioc/db/dbCa.c
@@ -881,10 +881,10 @@ static void eventCallback(struct event_handler_args arg)
         if (precord) {
             if (arg.status != ECA_NORDACCESS &&
                 arg.status != ECA_GETFAIL)
-                errlogPrintf("dbCa: eventCallback record %s error %s\n",
+                errlogPrintf("dbCa: eventCallback record %s " ERL_ERROR " %s\n",
                     precord->name, ca_message(arg.status));
         } else {
-            errlogPrintf("dbCa: eventCallback error %s\n",
+            errlogPrintf("dbCa: eventCallback " ERL_ERROR " %s\n",
                 ca_message(arg.status));
         }
         goto done;
@@ -1029,10 +1029,10 @@ static void getAttribEventCallback(struct event_handler_args arg)
     if (arg.status != ECA_NORMAL) {
         dbCommon *precord = plink->precord;
         if (precord) {
-            errlogPrintf("dbCa: getAttribEventCallback record %s error %s\n",
+            errlogPrintf("dbCa: getAttribEventCallback record %s " ERL_ERROR " %s\n",
                 precord->name, ca_message(arg.status));
         } else {
-            errlogPrintf("dbCa: getAttribEventCallback error %s\n",
+            errlogPrintf("dbCa: getAttribEventCallback " ERL_ERROR " %s\n",
                 ca_message(arg.status));
         }
         epicsMutexUnlock(pca->lock);

--- a/modules/database/src/ioc/db/dbConvertJSON.c
+++ b/modules/database/src/ioc/db/dbConvertJSON.c
@@ -98,7 +98,7 @@ static int dblsj_string(void *ctx, const unsigned char *val, size_t len) {
     char *pdest = parser->pdest;
 
     if (parser->dbrType != DBF_STRING) {
-        errlogPrintf("dbConvertJSON: dblsj_string dbrType error\n");
+        errlogPrintf("dbConvertJSON: dblsj_string dbrType " ERL_ERROR "\n");
         return 0; /* Illegal */
     }
 

--- a/modules/database/src/ioc/db/dbScan.c
+++ b/modules/database/src/ioc/db/dbScan.c
@@ -817,7 +817,7 @@ static void periodicTask(void *arg)
             epicsTimeAddSeconds(&next, delay);
             if (++overruns >= 10 &&
                 epicsTimeDiffInSeconds(&now, &reported) > report_delay) {
-                errlogPrintf("\ndbScan warning from '%s' scan thread:\n"
+                errlogPrintf("\ndbScan " ERL_WARNING " from '%s' scan thread:\n"
                     "\tScan processing averages %.3f seconds (%.3f .. %.3f).\n"
                     "\tOver-runs have now happened %u times in a row.\n"
                     "\tTo fix this, move some records to a slower scan rate.\n",

--- a/modules/database/src/ioc/rsrv/camsgtask.c
+++ b/modules/database/src/ioc/rsrv/camsgtask.c
@@ -58,7 +58,7 @@ void camsgtask ( void *pParm )
 
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
-            errlogPrintf("CAS: FIONREAD error: %s\n",
+            errlogPrintf("CAS: FIONREAD " ERL_ERROR ": %s\n",
                 sockErrBuf);
             cas_send_bs_msg(client, TRUE);
         }

--- a/modules/database/src/ioc/rsrv/caserverio.c
+++ b/modules/database/src/ioc/rsrv/caserverio.c
@@ -139,7 +139,7 @@ void cas_send_bs_msg ( struct client *pclient, int lock_needed )
                             char sockErrBuf[64];
                             epicsSocketConvertErrnoToString (
                                 sockErrBuf, sizeof ( sockErrBuf ) );
-                            errlogPrintf ("CAS: Socket shutdown error: %s\n",
+                            errlogPrintf ("CAS: Socket shutdown " ERL_ERROR ": %s\n",
                                 sockErrBuf );
                         }
                     }

--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -86,7 +86,7 @@ static void req_server (void *pParm)
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
-            errlogPrintf("CAS: Client accept error: %s (%d)\n",
+            errlogPrintf("CAS: Client accept " ERL_ERROR ": %s (%d)\n",
                 sockErrBuf, (int)addLen );
             epicsThreadSleep(15.0);
             continue;
@@ -131,7 +131,7 @@ int tryBind(SOCKET sock, const osiSockAddr* addr, const char *name)
         {
             epicsSocketConvertErrnoToString (
                         sockErrBuf, sizeof ( sockErrBuf ) );
-            errlogPrintf ( "CAS: %s bind error: %s\n",
+            errlogPrintf ( "CAS: %s bind " ERL_ERROR ": %s\n",
                            name, sockErrBuf );
             epicsThreadSuspendSelf ();
         }
@@ -196,7 +196,7 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
                         char sockErrBuf[64];
                         epicsSocketConvertErrnoToString (
                             sockErrBuf, sizeof ( sockErrBuf ) );
-                        errlogPrintf ( "CAS: getsockname error: %s\n",
+                        errlogPrintf ( "CAS: getsockname " ERL_ERROR ": %s\n",
                             sockErrBuf );
                         epicsThreadSuspendSelf ();
                         ok = 0;
@@ -576,12 +576,12 @@ void rsrv_init (void)
 
         if ( sport != ca_server_port ) {
             ca_server_port = sport;
-            errlogPrintf ( "cas warning: Configured TCP port was unavailable.\n");
-            errlogPrintf ( "cas warning: Using dynamically assigned TCP port %hu,\n",
+            errlogPrintf ( "cas " ERL_WARNING ": Configured TCP port was unavailable.\n");
+            errlogPrintf ( "cas " ERL_WARNING ": Using dynamically assigned TCP port %hu,\n",
                 ca_server_port );
-            errlogPrintf ( "cas warning: but now two or more servers share the same UDP port.\n");
-            errlogPrintf ( "cas warning: Depending on your IP kernel this server may not be\n" );
-            errlogPrintf ( "cas warning: reachable with UDP unicast (a host's IP in EPICS_CA_ADDR_LIST)\n" );
+            errlogPrintf ( "cas " ERL_WARNING ": but now two or more servers share the same UDP port.\n");
+            errlogPrintf ( "cas " ERL_WARNING ": Depending on your IP kernel this server may not be\n" );
+            errlogPrintf ( "cas " ERL_WARNING ": reachable with UDP unicast (a host's IP in EPICS_CA_ADDR_LIST)\n" );
         }
     }
 

--- a/modules/database/src/ioc/rsrv/online_notify.c
+++ b/modules/database/src/ioc/rsrv/online_notify.c
@@ -94,7 +94,7 @@ void rsrv_online_notify_task(void *pParm)
 
                     epicsSocketConvertErrorToString(sockErrBuf, sizeof(sockErrBuf), err);
                     ipAddrToDottedIP(&pAddr->addr.ia, sockDipBuf, sizeof(sockDipBuf));
-                    errlogPrintf ( "CAS: CA beacon send to %s error: %s\n",
+                    errlogPrintf ( "CAS: CA beacon send to %s " ERL_ERROR ": %s\n",
                         sockDipBuf, sockErrBuf);
 
                     lastError[i] = err;

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -353,6 +353,7 @@ int eltc(int yesno)
     epicsMutexMustLock(pvt.msgQueueLock);
     pvt.toConsole = yesno;
     epicsMutexUnlock(pvt.msgQueueLock);
+    errlogFlush();
     return 0;
 }
 

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -20,12 +20,12 @@
 #include <errno.h>
 
 #define ERRLOG_INIT
-#include "adjustment.h"
 #include "dbDefs.h"
 #include "epicsThread.h"
 #include "cantProceed.h"
 #include "epicsMutex.h"
 #include "epicsEvent.h"
+#include "epicsString.h"
 #include "epicsInterrupt.h"
 #include "errMdef.h"
 #include "errSymTbl.h"
@@ -35,8 +35,20 @@
 #include "epicsExit.h"
 
 
-#define BUFFER_SIZE 1280
-#define MAX_MESSAGE_SIZE 256
+#define MIN_BUFFER_SIZE 1280
+#define MIN_MESSAGE_SIZE 256
+#define MAX_MESSAGE_SIZE 0x00ffffff
+
+/* errlog buffers contain null terminated strings, each prefixed
+ * with a 1 byte header containing flags.
+ */
+/* State of entries in a buffer. */
+#define ERL_STATE_MASK  0xc0
+#define ERL_STATE_FREE  0x00
+#define ERL_STATE_WRITE 0x80
+#define ERL_STATE_READY 0x40
+/* should this message be echoed to the console? */
+#define ERL_LOCALECHO   0x20
 
 /*Declare storage for errVerbose */
 int errVerbose = 0;
@@ -44,137 +56,172 @@ int errVerbose = 0;
 static void errlogExitHandler(void *);
 static void errlogThread(void);
 
-static char *msgbufGetFree(int noConsoleMessage);
-static void msgbufSetSize(int size); /* Send 'size' chars plus trailing '\0' */
-static char *msgbufGetSend(int *noConsoleMessage);
-static void msgbufFreeSend(void);
-
 typedef struct listenerNode{
     ELLNODE node;
     errlogListener listener;
     void *pPrivate;
 } listenerNode;
 
-/*each message consists of a msgNode immediately followed by the message */
-typedef struct msgNode {
-    ELLNODE node;
-    char *message;
-    int length;
-    int noConsoleMessage;
-} msgNode;
+typedef struct {
+    char *base;
+    size_t pos;
+} buffer_t;
 
 static struct {
-    epicsEventId waitForWork; /*errlogThread waits for this*/
-    epicsMutexId msgQueueLock;
+    /* const after errlogInit() */
+    size_t maxMsgSize;
+    /* alloc size of both buffer_t::base */
+    size_t bufSize;
+    int    errlogInitFailed;
+
     epicsMutexId listenerLock;
-    epicsEventId waitForFlush; /*errlogFlush waits for this*/
-    epicsEventId flush; /*errlogFlush sets errlogThread does a Try*/
-    epicsMutexId flushLock;
-    epicsEventId waitForExit; /*errlogExitHandler waits for this*/
-    int          atExit;      /*TRUE when errlogExitHandler is active*/
     ELLLIST      listenerList;
-    ELLLIST      msgQueue;
-    msgNode      *pnextSend;
-    int          errlogInitFailed;
-    int          buffersize;
-    int          maxMsgSize;
-    int          msgNeeded;
+
+    /* notify when log->size!=0 */
+    epicsEventId waitForWork;
+    /* signals when worker increments flushSeq */
+    epicsEventId waitForSeq;
+    epicsMutexId msgQueueLock;
+
+    /* guarded by msgQueueLock */
+    int          atExit;
     int          sevToLog;
     int          toConsole;
     FILE         *console;
-    int          missedMessages;
-    char         *pbuffer;
-} pvtData;
 
+    /* A loop counter maintained by errlogThread. */
+    epicsUInt32 flushSeq;
+    size_t nFlushers;
+    size_t nLost;
 
-/*
- * vsnprintf with truncation message
+    /* 'log' and 'print' combine to form a double buffer. */
+    buffer_t *log;
+    buffer_t *print;
+
+    /* actual storage which 'log' and 'print' point to */
+    buffer_t bufs[2];
+} pvt;
+
+/* Returns an pointer to pvt.maxMsgSize bytes, or NULL if ring buffer is full.
+ * When !NULL, caller _must_ later msgbufCommit()
  */
-static int tvsnPrint(char *str, size_t size, const char *format, va_list ap)
+static
+char* msgbufAlloc(void)
 {
-    static const char tmsg[] = "<<TRUNCATED>>\n";
-    int nchar = epicsVsnprintf(str, size, format ? format : "", ap);
+    char *ret = NULL;
 
-    if (nchar >= size) {
-        if (size > sizeof tmsg)
-            strcpy(str + size - sizeof tmsg, tmsg);
-        nchar = size - 1;
+    if (epicsInterruptIsInterruptContext()) {
+        epicsInterruptContextMessage
+            ("errlog called from interrupt level\n");
+        return ret;
     }
+
+    errlogInit(0);
+    epicsMutexMustLock(pvt.msgQueueLock); /* matched in msgbufCommit() */
+    if(pvt.bufSize - pvt.log->pos >= 1+pvt.maxMsgSize) {
+        /* there is enough space for the worst cast */
+        ret = pvt.log->base + pvt.log->pos;
+        ret[0] = ERL_STATE_WRITE;
+        ret++;
+    }
+
+    if(!ret) {
+        pvt.nLost++;
+        epicsMutexUnlock(pvt.msgQueueLock);
+    }
+    return ret;
+}
+
+static
+size_t msgbufCommit(size_t nchar, int localEcho)
+{
+    int isOkToBlock = epicsThreadIsOkToBlock();
+    int wasEmpty = pvt.log->pos==0;
+    int atExit = pvt.atExit;
+    char *start = pvt.log->base + pvt.log->pos;
+
+    /* nchar returned by snprintf() is >= maxMsgSize when truncated */
+    if(nchar >= pvt.maxMsgSize) {
+        const char *trunc = "<<TRUNCATED>>\n";
+        nchar = pvt.maxMsgSize - 1u;
+
+        strcpy(start + 1u + nchar - strlen(trunc), trunc);
+        /* assert(strlen(start+1u)==nchar); */
+    }
+
+    start[1u + nchar] = '\0';
+
+    if(localEcho && isOkToBlock && atExit) {
+        /* errlogThread is not running, so we print directly
+         * and then abandon the buffer.
+         */
+        fprintf(pvt.console, "%s", start);
+
+    } else {
+        start[0u] = ERL_STATE_READY | (localEcho ? ERL_LOCALECHO : 0);
+
+        pvt.log->pos += 1u + nchar + 1u;
+    }
+
+    epicsMutexUnlock(pvt.msgQueueLock); /* matched in msgbufAlloc() */
+
+    if(wasEmpty && !atExit)
+        epicsEventMustTrigger(pvt.waitForWork);
+
+    if(localEcho && isOkToBlock && !atExit)
+        errlogFlush();
+
     return nchar;
+}
+
+static
+void errlogSequence(void)
+{
+    int wakeNext = 0;
+    size_t seq;
+
+    if (pvt.atExit)
+        return;
+
+    epicsMutexMustLock(pvt.msgQueueLock);
+    pvt.nFlushers++;
+    seq = pvt.flushSeq;
+
+    while(seq == pvt.flushSeq && !pvt.atExit) {
+        epicsMutexUnlock(pvt.msgQueueLock);
+        /* force worker to wake and increment seq */
+        epicsEventMustTrigger(pvt.waitForWork);
+        epicsEventMustWait(pvt.waitForSeq);
+        epicsMutexMustLock(pvt.msgQueueLock);
+    }
+
+    pvt.nFlushers--;
+    wakeNext = pvt.nFlushers!=0u;
+    epicsMutexUnlock(pvt.msgQueueLock);
+
+    if(wakeNext)
+        epicsEventMustTrigger(pvt.waitForSeq);
 }
 
 int errlogPrintf(const char *pFormat, ...)
 {
-    va_list pvar;
-    char *pbuffer;
-    int nchar;
-    int isOkToBlock;
-
-    if (epicsInterruptIsInterruptContext()) {
-        epicsInterruptContextMessage
-            ("errlogPrintf called from interrupt level\n");
-        return 0;
-    }
-
-    errlogInit(0);
-    isOkToBlock = epicsThreadIsOkToBlock();
-
-    if (pvtData.atExit || (isOkToBlock && pvtData.toConsole)) {
-        FILE *console = pvtData.console ? pvtData.console : stderr;
-
-        va_start(pvar, pFormat);
-        nchar = vfprintf(console, pFormat, pvar);
-        va_end (pvar);
-        fflush(console);
-    }
-
-    if (pvtData.atExit)
-        return nchar;
-
-    pbuffer = msgbufGetFree(isOkToBlock);
-    if (!pbuffer)
-        return 0;
-
-    va_start(pvar, pFormat);
-    nchar = tvsnPrint(pbuffer, pvtData.maxMsgSize, pFormat?pFormat:"", pvar);
-    va_end(pvar);
-    msgbufSetSize(nchar);
-    return nchar;
+    int ret;
+    va_list args;
+    va_start(args, pFormat);
+    ret = errlogVprintf(pFormat, args);
+    va_end(args);
+    return ret;
 }
 
 int errlogVprintf(const char *pFormat,va_list pvar)
 {
-    int nchar;
-    char *pbuffer;
-    int isOkToBlock;
-    FILE *console;
+    int nchar = 0;
+    char *buf = msgbufAlloc();
 
-    if (epicsInterruptIsInterruptContext()) {
-        epicsInterruptContextMessage
-            ("errlogVprintf called from interrupt level\n");
-        return 0;
+    if(buf) {
+        nchar = epicsVsnprintf(buf, pvt.maxMsgSize, pFormat, pvar);
+        nchar = msgbufCommit(nchar, pvt.toConsole);
     }
-
-    errlogInit(0);
-    if (pvtData.atExit)
-        return 0;
-    isOkToBlock = epicsThreadIsOkToBlock();
-
-    pbuffer = msgbufGetFree(isOkToBlock);
-    if (!pbuffer) {
-        console = pvtData.console ? pvtData.console : stderr;
-        vfprintf(console, pFormat, pvar);
-        fflush(console);
-        return 0;
-    }
-
-    nchar = tvsnPrint(pbuffer, pvtData.maxMsgSize, pFormat?pFormat:"", pvar);
-    if (pvtData.atExit || (isOkToBlock && pvtData.toConsole)) {
-        console = pvtData.console ? pvtData.console : stderr;
-        fprintf(console, "%s", pbuffer);
-        fflush(console);
-    }
-    msgbufSetSize(nchar);
     return nchar;
 }
 
@@ -188,14 +235,6 @@ int errlogPrintfNoConsole(const char *pFormat, ...)
 {
     va_list pvar;
     int nchar;
-
-    if (epicsInterruptIsInterruptContext()) {
-        epicsInterruptContextMessage
-            ("errlogPrintfNoConsole called from interrupt level\n");
-        return 0;
-    }
-
-    errlogInit(0);
     va_start(pvar, pFormat);
     nchar = errlogVprintfNoConsole(pFormat, pvar);
     va_end(pvar);
@@ -204,25 +243,13 @@ int errlogPrintfNoConsole(const char *pFormat, ...)
 
 int errlogVprintfNoConsole(const char *pFormat, va_list pvar)
 {
-    int nchar;
-    char *pbuffer;
+    int nchar = 0;
+    char *buf = msgbufAlloc();
 
-    if (epicsInterruptIsInterruptContext()) {
-        epicsInterruptContextMessage
-            ("errlogVprintfNoConsole called from interrupt level\n");
-        return 0;
+    if(buf) {
+        nchar = epicsVsnprintf(buf, pvt.maxMsgSize, pFormat, pvar);
+        nchar = msgbufCommit(nchar, 0);
     }
-
-    errlogInit(0);
-    if (pvtData.atExit)
-        return 0;
-
-    pbuffer = msgbufGetFree(1);
-    if (!pbuffer)
-        return 0;
-
-    nchar = tvsnPrint(pbuffer, pvtData.maxMsgSize, pFormat?pFormat:"", pvar);
-    msgbufSetSize(nchar);
     return nchar;
 }
 
@@ -231,29 +258,6 @@ int errlogSevPrintf(errlogSevEnum severity, const char *pFormat, ...)
 {
     va_list pvar;
     int nchar;
-    int isOkToBlock;
-
-    if (epicsInterruptIsInterruptContext()) {
-        epicsInterruptContextMessage
-            ("errlogSevPrintf called from interrupt level\n");
-        return 0;
-    }
-
-    errlogInit(0);
-    if (pvtData.sevToLog > severity)
-        return 0;
-
-    isOkToBlock = epicsThreadIsOkToBlock();
-    if (pvtData.atExit || (isOkToBlock && pvtData.toConsole)) {
-        FILE *console = pvtData.console ? pvtData.console : stderr;
-
-        fprintf(console, "sevr=%s ", errlogGetSevEnumString(severity));
-        va_start(pvar, pFormat);
-        vfprintf(console, pFormat, pvar);
-        va_end(pvar);
-        fflush(console);
-    }
-
     va_start(pvar, pFormat);
     nchar = errlogSevVprintf(severity, pFormat, pvar);
     va_end(pvar);
@@ -262,35 +266,15 @@ int errlogSevPrintf(errlogSevEnum severity, const char *pFormat, ...)
 
 int errlogSevVprintf(errlogSevEnum severity, const char *pFormat, va_list pvar)
 {
-    char *pnext;
-    int nchar;
-    int totalChar = 0;
-    int isOkToBlock;
+    int nchar = 0;
+    char *buf = msgbufAlloc();
 
-    if (epicsInterruptIsInterruptContext()) {
-        epicsInterruptContextMessage
-            ("errlogSevVprintf called from interrupt level\n");
-        return 0;
+    if(buf) {
+        nchar = sprintf(buf, "sevr=%s ", errlogGetSevEnumString(severity));
+        if(nchar < pvt.maxMsgSize)
+            nchar += epicsVsnprintf(buf + nchar, pvt.maxMsgSize - nchar, pFormat, pvar);
+        nchar = msgbufCommit(nchar, pvt.toConsole);
     }
-
-    errlogInit(0);
-    if (pvtData.atExit)
-        return 0;
-
-    isOkToBlock = epicsThreadIsOkToBlock();
-    pnext = msgbufGetFree(isOkToBlock);
-    if (!pnext)
-        return 0;
-
-    nchar = sprintf(pnext, "sevr=%s ", errlogGetSevEnumString(severity));
-    pnext += nchar; totalChar += nchar;
-    nchar = tvsnPrint(pnext, pvtData.maxMsgSize - totalChar - 1, pFormat, pvar);
-    pnext += nchar; totalChar += nchar;
-    if (pnext[-1] != '\n') {
-        strcpy(pnext,"\n");
-        totalChar++;
-    }
-    msgbufSetSize(totalChar);
     return nchar;
 }
 
@@ -306,13 +290,19 @@ const char * errlogGetSevEnumString(errlogSevEnum severity)
 void errlogSetSevToLog(errlogSevEnum severity)
 {
     errlogInit(0);
-    pvtData.sevToLog = severity;
+    epicsMutexMustLock(pvt.msgQueueLock);
+    pvt.sevToLog = severity;
+    epicsMutexUnlock(pvt.msgQueueLock);
 }
 
 errlogSevEnum errlogGetSevToLog(void)
 {
+    errlogSevEnum ret;
     errlogInit(0);
-    return pvtData.sevToLog;
+    epicsMutexMustLock(pvt.msgQueueLock);
+    ret = pvt.sevToLog;
+    epicsMutexUnlock(pvt.msgQueueLock);
+    return ret;
 }
 
 void errlogAddListener(errlogListener listener, void *pPrivate)
@@ -320,16 +310,16 @@ void errlogAddListener(errlogListener listener, void *pPrivate)
     listenerNode *plistenerNode;
 
     errlogInit(0);
-    if (pvtData.atExit)
+    if (pvt.atExit)
         return;
 
     plistenerNode = callocMustSucceed(1,sizeof(listenerNode),
         "errlogAddListener");
-    epicsMutexMustLock(pvtData.listenerLock);
+    epicsMutexMustLock(pvt.listenerLock);
     plistenerNode->listener = listener;
     plistenerNode->pPrivate = pPrivate;
-    ellAdd(&pvtData.listenerList,&plistenerNode->node);
-    epicsMutexUnlock(pvtData.listenerLock);
+    ellAdd(&pvt.listenerList,&plistenerNode->node);
+    epicsMutexUnlock(pvt.listenerLock);
 }
 
 int errlogRemoveListeners(errlogListener listener, void *pPrivate)
@@ -338,46 +328,42 @@ int errlogRemoveListeners(errlogListener listener, void *pPrivate)
     int count = 0;
 
     errlogInit(0);
-    if (!pvtData.atExit)
-        epicsMutexMustLock(pvtData.listenerLock);
+    epicsMutexMustLock(pvt.listenerLock);
 
-    plistenerNode = (listenerNode *)ellFirst(&pvtData.listenerList);
+    plistenerNode = (listenerNode *)ellFirst(&pvt.listenerList);
     while (plistenerNode) {
         listenerNode *pnext = (listenerNode *)ellNext(&plistenerNode->node);
 
         if (plistenerNode->listener == listener &&
             plistenerNode->pPrivate == pPrivate) {
-            ellDelete(&pvtData.listenerList, &plistenerNode->node);
+            ellDelete(&pvt.listenerList, &plistenerNode->node);
             free(plistenerNode);
             ++count;
         }
         plistenerNode = pnext;
     }
 
-    if (!pvtData.atExit)
-        epicsMutexUnlock(pvtData.listenerLock);
-
-    if (count == 0) {
-        FILE *console = pvtData.console ? pvtData.console : stderr;
-
-        fprintf(console,
-            "errlogRemoveListeners: No listeners found\n");
-    }
+    epicsMutexUnlock(pvt.listenerLock);
     return count;
 }
 
 int eltc(int yesno)
 {
     errlogInit(0);
-    errlogFlush();
-    pvtData.toConsole = yesno;
+    epicsMutexMustLock(pvt.msgQueueLock);
+    pvt.toConsole = yesno;
+    epicsMutexUnlock(pvt.msgQueueLock);
     return 0;
 }
 
 int errlogSetConsole(FILE *stream)
 {
     errlogInit(0);
-    pvtData.console = stream;
+    epicsMutexMustLock(pvt.msgQueueLock);
+    pvt.console = stream ? stream : stderr;
+    epicsMutexUnlock(pvt.msgQueueLock);
+    /* make sure worker has stopped writing to the previous stream */
+    errlogSequence();
     return 0;
 }
 
@@ -385,115 +371,93 @@ void errPrintf(long status, const char *pFileName, int lineno,
     const char *pformat, ...)
 {
     va_list pvar;
-    char    *pnext;
-    int     nchar;
-    int     totalChar=0;
-    int     isOkToBlock;
-    char    name[256];
+    int     nchar = 0;
+    char *buf = msgbufAlloc();
 
-    if (epicsInterruptIsInterruptContext()) {
-        epicsInterruptContextMessage("errPrintf called from interrupt level\n");
-        return;
-    }
-
-    errlogInit(0);
-    isOkToBlock = epicsThreadIsOkToBlock();
-    if (status == 0)
-        status = errno;
-
-    if (status > 0) {
-        errSymLookup(status, name, sizeof(name));
-    }
-
-    if (pvtData.atExit || (isOkToBlock && pvtData.toConsole)) {
-        FILE *console = pvtData.console ? pvtData.console : stderr;
-
-        if (pFileName)
-            fprintf(console, "filename=\"%s\" line number=%d\n",
-                pFileName, lineno);
-        if (status > 0)
-            fprintf(console, "%s ", name);
-
-        va_start(pvar, pformat);
-        vfprintf(console, pformat, pvar);
-        va_end(pvar);
-        fputc('\n', console);
-        fflush(console);
-    }
-
-    if (pvtData.atExit)
-        return;
-
-    pnext = msgbufGetFree(isOkToBlock);
-    if (!pnext)
-        return;
-
-    if (pFileName) {
-        nchar = sprintf(pnext,"filename=\"%s\" line number=%d\n",
-            pFileName, lineno);
-        pnext += nchar; totalChar += nchar;
-    }
-
-    if (status > 0) {
-        nchar = sprintf(pnext,"%s ",name);
-        pnext += nchar; totalChar += nchar;
-    }
     va_start(pvar, pformat);
-    nchar = tvsnPrint(pnext, pvtData.maxMsgSize - totalChar - 1, pformat, pvar);
-    va_end(pvar);
-    if (nchar>0) {
-        pnext += nchar;
-        totalChar += nchar;
+
+    if(buf) {
+        char    name[256] = "";
+
+        if (status > 0) {
+            errSymLookup(status, name, sizeof(name));
+        }
+
+        nchar = epicsSnprintf(buf, pvt.maxMsgSize, "%s%sfilename=\"%s\" line number=%d",
+                              name, status ? " " : "", pFileName, lineno);
+        if(nchar < pvt.maxMsgSize)
+            nchar += epicsVsnprintf(buf + nchar, pvt.maxMsgSize - nchar, pformat, pvar);
+        msgbufCommit(nchar, pvt.toConsole);
     }
-    strcpy(pnext, "\n");
-    totalChar++ ; /*include the \n */
-    msgbufSetSize(totalChar);
+
+    va_end(pvar);
 }
 
-
-static void errlogExitHandler(void *pvt)
+/* On *NIX.  also RTEM and vxWorks during controlled shutdown.
+ * On Windows when main() explicitly calls epicsExit(0), like default IOC main().
+ * Switch to sync. print and join errlogThread.
+ *
+ * On Windows otherwise, errlogThread killed by exit(), and this handler is never
+ *            invoked.  Use of errlog from OS atexit() handler is undefined.
+ */
+static void errlogExitHandler(void *raw)
 {
-    pvtData.atExit = 1;
-    epicsEventSignal(pvtData.waitForWork);
-    epicsEventMustWait(pvtData.waitForExit);
+    epicsThreadId tid = raw;
+    epicsMutexMustLock(pvt.msgQueueLock);
+    pvt.atExit = 1;
+    epicsMutexUnlock(pvt.msgQueueLock);
+    epicsEventSignal(pvt.waitForWork);
+    epicsThreadMustJoin(tid);
 }
 
 struct initArgs {
-    int bufsize;
-    int maxMsgSize;
+    size_t bufsize;
+    size_t maxMsgSize;
 };
 
 static void errlogInitPvt(void *arg)
 {
     struct initArgs *pconfig = (struct initArgs *) arg;
-    epicsThreadId tid;
+    epicsThreadId tid = NULL;
+    epicsThreadOpts topts = EPICS_THREAD_OPTS_INIT;
 
-    pvtData.errlogInitFailed = TRUE;
-    pvtData.buffersize = pconfig->bufsize;
-    pvtData.maxMsgSize = pconfig->maxMsgSize;
-    pvtData.msgNeeded = adjustToWorstCaseAlignment(pvtData.maxMsgSize +
-        sizeof(msgNode));
-    ellInit(&pvtData.listenerList);
-    ellInit(&pvtData.msgQueue);
-    pvtData.toConsole = TRUE;
-    pvtData.console = NULL;
-    pvtData.waitForWork = epicsEventMustCreate(epicsEventEmpty);
-    pvtData.listenerLock = epicsMutexMustCreate();
-    pvtData.msgQueueLock = epicsMutexMustCreate();
-    pvtData.waitForFlush = epicsEventMustCreate(epicsEventEmpty);
-    pvtData.flush = epicsEventMustCreate(epicsEventEmpty);
-    pvtData.flushLock = epicsMutexMustCreate();
-    pvtData.waitForExit = epicsEventMustCreate(epicsEventEmpty);
-    pvtData.pbuffer = callocMustSucceed(1, pvtData.buffersize,
-        "errlogInitPvt");
+    topts.priority = epicsThreadPriorityLow;
+    topts.stackSize = epicsThreadStackSmall;
+    topts.joinable = 1;
+
+    /* Use of *Must* alloc functions would recurse on failure since
+     * cantProceed() calls us.
+     */
+
+    pvt.errlogInitFailed = TRUE;
+    pvt.bufSize = pconfig->bufsize;
+    pvt.maxMsgSize = pconfig->maxMsgSize;
+    ellInit(&pvt.listenerList);
+    pvt.toConsole = TRUE;
+    pvt.console = stderr;
+    pvt.waitForWork = epicsEventCreate(epicsEventEmpty);
+    pvt.listenerLock = epicsMutexCreate();
+    pvt.msgQueueLock = epicsMutexCreate();
+    pvt.waitForSeq = epicsEventCreate(epicsEventEmpty);
+    pvt.log = &pvt.bufs[0];
+    pvt.print = &pvt.bufs[1];
+    pvt.log->base = calloc(1, pvt.bufSize);
+    pvt.print->base = calloc(1, pvt.bufSize);
 
     errSymBld();    /* Better not to do this lazily... */
 
-    tid = epicsThreadCreate("errlog", epicsThreadPriorityLow,
-        epicsThreadGetStackSize(epicsThreadStackSmall),
-        (EPICSTHREADFUNC)errlogThread, 0);
+    if(pvt.waitForWork
+            && pvt.listenerLock
+            && pvt.msgQueueLock
+            && pvt.waitForSeq
+            && pvt.log->base
+            && pvt.print->base
+            ) {
+        tid = epicsThreadCreateOpt("errlog", (EPICSTHREADFUNC)errlogThread, 0, &topts);
+    }
     if (tid) {
-        pvtData.errlogInitFailed = FALSE;
+        pvt.errlogInitFailed = FALSE;
+        epicsAtExit(errlogExitHandler, tid);
     }
 }
 
@@ -503,19 +467,21 @@ int errlogInit2(int bufsize, int maxMsgSize)
     static epicsThreadOnceId errlogOnceFlag = EPICS_THREAD_ONCE_INIT;
     struct initArgs config;
 
-    if (pvtData.atExit)
+    if (pvt.atExit)
         return 0;
 
-    if (bufsize < BUFFER_SIZE)
-        bufsize = BUFFER_SIZE;
+    if (bufsize < MIN_BUFFER_SIZE)
+        bufsize = MIN_BUFFER_SIZE;
     config.bufsize = bufsize;
 
-    if (maxMsgSize < MAX_MESSAGE_SIZE)
+    if (maxMsgSize < MIN_MESSAGE_SIZE)
+        maxMsgSize = MIN_MESSAGE_SIZE;
+    else if (maxMsgSize > MAX_MESSAGE_SIZE)
         maxMsgSize = MAX_MESSAGE_SIZE;
     config.maxMsgSize = maxMsgSize;
 
     epicsThreadOnce(&errlogOnceFlag, errlogInitPvt, &config);
-    if (pvtData.errlogInitFailed) {
+    if (pvt.errlogInitFailed) {
         fprintf(stderr,"errlogInit failed\n");
         exit(1);
     }
@@ -524,172 +490,88 @@ int errlogInit2(int bufsize, int maxMsgSize)
 
 int errlogInit(int bufsize)
 {
-    return errlogInit2(bufsize, MAX_MESSAGE_SIZE);
+    return errlogInit2(bufsize, MIN_MESSAGE_SIZE);
 }
 
 void errlogFlush(void)
 {
-    int count;
-
+    /* wait for both buffers to be handled to know that all currently
+     * logged message have been seen/sent.
+     */
     errlogInit(0);
-    if (pvtData.atExit)
-        return;
-
-   /*If nothing in queue don't wake up errlogThread*/
-    epicsMutexMustLock(pvtData.msgQueueLock);
-    count = ellCount(&pvtData.msgQueue);
-    epicsMutexUnlock(pvtData.msgQueueLock);
-    if (count <= 0)
-        return;
-
-    /*must let errlogThread empty queue*/
-    epicsMutexMustLock(pvtData.flushLock);
-    epicsEventSignal(pvtData.flush);
-    epicsEventSignal(pvtData.waitForWork);
-    epicsEventMustWait(pvtData.waitForFlush);
-    epicsMutexUnlock(pvtData.flushLock);
+    errlogSequence();
+    errlogSequence();
 }
 
 static void errlogThread(void)
 {
-    listenerNode *plistenerNode;
-    int noConsoleMessage;
-    char *pmessage;
+    epicsMutexMustLock(pvt.msgQueueLock);
+    while (!pvt.atExit) {
+        pvt.flushSeq++;
 
-    epicsAtExit(errlogExitHandler,0);
-    while (TRUE) {
-        epicsEventMustWait(pvtData.waitForWork);
-        while ((pmessage = msgbufGetSend(&noConsoleMessage))) {
-            epicsMutexMustLock(pvtData.listenerLock);
-            if (pvtData.toConsole && !noConsoleMessage) {
-                FILE *console = pvtData.console ? pvtData.console : stderr;
+        if(pvt.log->pos==0u) {
+            int wakeFlusher = pvt.nFlushers!=0;
+            epicsMutexUnlock(pvt.msgQueueLock);
+            if(wakeFlusher)
+                epicsEventMustTrigger(pvt.waitForSeq);
+            epicsEventMustWait(pvt.waitForWork);
+            epicsMutexMustLock(pvt.msgQueueLock);
 
-                fprintf(console, "%s", pmessage);
+        } else {
+            /* snapshot and swap buffers for use while unlocked */
+            size_t nLost = pvt.nLost;
+            FILE *console = pvt.toConsole ? pvt.console : NULL;
+            size_t pos = 0u;
+            buffer_t *print;
+
+            {
+                buffer_t *temp = pvt.log;
+                pvt.log = pvt.print;
+                pvt.print = print = temp;
+            }
+
+            pvt.nLost = 0u;
+            epicsMutexUnlock(pvt.msgQueueLock);
+
+            while(pos < print->pos) {
+                listenerNode *plistenerNode;
+                const char* base = print->base + pos;
+                size_t mlen = epicsStrnLen(base+1u, pvt.bufSize - pos);
+
+                if((base[0]&ERL_STATE_MASK) != ERL_STATE_READY || mlen>=pvt.bufSize - pos) {
+                    fprintf(stderr, "Logic Error: errlog buffer corruption. %02x, %zu\n",
+                            (unsigned)base[0], mlen);
+                    /* try to reset and recover */
+                    break;
+                }
+
+                if(base[0]&ERL_LOCALECHO && console) {
+                    fprintf(console, "%s", base+1u);
+                }
+
+                epicsMutexMustLock(pvt.listenerLock);
+                plistenerNode = (listenerNode *)ellFirst(&pvt.listenerList);
+                while (plistenerNode) {
+                    (*plistenerNode->listener)(plistenerNode->pPrivate, base+1u);
+                    plistenerNode = (listenerNode *)ellNext(&plistenerNode->node);
+                }
+                epicsMutexUnlock(pvt.listenerLock);
+
+                pos += 1u + mlen+1u;
+            }
+
+            memset(print->base, 0, pvt.bufSize);
+            print->pos = 0u;
+
+            if(nLost && console)
+                fprintf(console, "errlog: lost %zu messages\n", nLost);
+
+            if(console)
                 fflush(console);
-            }
 
-            plistenerNode = (listenerNode *)ellFirst(&pvtData.listenerList);
-            while (plistenerNode) {
-                (*plistenerNode->listener)(plistenerNode->pPrivate, pmessage);
-                plistenerNode = (listenerNode *)ellNext(&plistenerNode->node);
-            }
+            epicsMutexMustLock(pvt.msgQueueLock);
 
-            epicsMutexUnlock(pvtData.listenerLock);
-            msgbufFreeSend();
-        }
-
-        if (pvtData.atExit)
-            break;
-        if (epicsEventTryWait(pvtData.flush) != epicsEventWaitOK)
-            continue;
-
-        epicsThreadSleep(.2); /*just wait an extra .2 seconds*/
-        epicsEventSignal(pvtData.waitForFlush);
-    }
-    epicsEventSignal(pvtData.waitForExit);
-}
-
-
-static msgNode * msgbufGetNode(void)
-{
-    char *pbuffer = pvtData.pbuffer;
-    char *pnextFree;
-    msgNode *pnextSend;
-
-    if (ellCount(&pvtData.msgQueue) == 0 ) {
-        pnextFree = pbuffer;        /* Reset if empty */
-    }
-    else {
-        msgNode *pfirst = (msgNode *)ellFirst(&pvtData.msgQueue);
-        msgNode *plast = (msgNode *)ellLast(&pvtData.msgQueue);
-        char *plimit = pbuffer + pvtData.buffersize;
-
-        pnextFree = plast->message + adjustToWorstCaseAlignment(plast->length);
-        if (pfirst > plast) {
-            plimit = (char *)pfirst;
-        }
-        else if (pnextFree + pvtData.msgNeeded > plimit) {
-            pnextFree = pbuffer;    /* Hit end, wrap to start */
-            plimit = (char *)pfirst;
-        }
-        if (pnextFree + pvtData.msgNeeded > plimit) {
-            return 0;               /* No room */
         }
     }
-
-    pnextSend = (msgNode *)pnextFree;
-    pnextSend->message = pnextFree + sizeof(msgNode);
-    pnextSend->length = 0;
-    return pnextSend;
-}
-
-static char * msgbufGetFree(int noConsoleMessage)
-{
-    msgNode *pnextSend;
-
-    if (epicsMutexLock(pvtData.msgQueueLock) != epicsMutexLockOK)
-        return 0;
-
-    if ((ellCount(&pvtData.msgQueue) == 0) && pvtData.missedMessages) {
-        int nchar;
-
-        pnextSend = msgbufGetNode();
-        nchar = sprintf(pnextSend->message,
-            "errlog: %d messages were discarded\n", pvtData.missedMessages);
-        pnextSend->length = nchar + 1;
-        pvtData.missedMessages = 0;
-        ellAdd(&pvtData.msgQueue, &pnextSend->node);
-    }
-
-    pvtData.pnextSend = pnextSend = msgbufGetNode();
-    if (pnextSend) {
-        pnextSend->noConsoleMessage = noConsoleMessage;
-        pnextSend->length = 0;
-        return pnextSend->message;  /* NB: msgQueueLock is still locked */
-    }
-
-    ++pvtData.missedMessages;
-    epicsMutexUnlock(pvtData.msgQueueLock);
-    return 0;
-}
-
-static void msgbufSetSize(int size)
-{
-    msgNode *pnextSend = pvtData.pnextSend;
-
-    pnextSend->length = size+1;
-    ellAdd(&pvtData.msgQueue, &pnextSend->node);
-    epicsMutexUnlock(pvtData.msgQueueLock);
-    epicsEventSignal(pvtData.waitForWork);
-}
-
-
-static char * msgbufGetSend(int *noConsoleMessage)
-{
-    msgNode *pnextSend;
-
-    epicsMutexMustLock(pvtData.msgQueueLock);
-    pnextSend = (msgNode *)ellFirst(&pvtData.msgQueue);
-    epicsMutexUnlock(pvtData.msgQueueLock);
-    if (!pnextSend)
-        return 0;
-
-    *noConsoleMessage = pnextSend->noConsoleMessage;
-    return pnextSend->message;
-}
-
-static void msgbufFreeSend(void)
-{
-    msgNode *pnextSend;
-
-    epicsMutexMustLock(pvtData.msgQueueLock);
-    pnextSend = (msgNode *)ellFirst(&pvtData.msgQueue);
-    if (!pnextSend) {
-        FILE *console = pvtData.console ? pvtData.console : stderr;
-
-        fprintf(console, "errlog: msgbufFreeSend logic error\n");
-        epicsThreadSuspendSelf();
-    }
-    ellDelete(&pvtData.msgQueue, &pnextSend->node);
-    epicsMutexUnlock(pvtData.msgQueueLock);
+    epicsMutexUnlock(pvt.msgQueueLock);
 }

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -250,6 +250,42 @@ LIBCOM_API int errlogVprintfNoConsole(const char *pformat,va_list pvar);
  */
 LIBCOM_API void errSymLookup(long status, char *pBuf, size_t bufLength);
 
+/** @defgroup colormacros Color macros
+ *
+ * @brief Colorize string constants with ANSI terminal escapes.
+ *
+ * The ANSI_ESC_\* family of macros expand to individual escape sequences.
+ * The ANSI_\* family expand around a string constant to prepend a color, and append a RESET.
+ *
+ * @code
+ * // equivalent
+ * errlogPrintf(ERL_ERROR ": something is amiss\n");
+ * errlogPrintf(ANSI_RED("ERROR") ": something is amiss\n");
+ * errlogPrintf(ANSI_ESC_RED "ERROR" ANSI_ESC_RESET ": something is amiss\n");
+ * @endcode
+ *
+ * @since UNRELEASED
+ *
+ * @see errlogPrintf()
+ * @{
+ */
+#define ANSI_ESC_RED "\033[31;1m"
+#define ANSI_ESC_GREEN "\033[32;1m"
+#define ANSI_ESC_YELLOW "\033[33;1m"
+#define ANSI_ESC_BLUE "\033[34;1m"
+#define ANSI_ESC_MAGENTA "\033[35;1m"
+#define ANSI_ESC_CYAN "\033[36;1m"
+#define ANSI_ESC_RESET "\033[0m"
+#define ANSI_RED(STR)     ANSI_ESC_RED     STR ANSI_ESC_RESET
+#define ANSI_GREEN(STR)   ANSI_ESC_GREEN   STR ANSI_ESC_RESET
+#define ANSI_YELLOW(STR)  ANSI_ESC_YELLOW  STR ANSI_ESC_RESET
+#define ANSI_BLUE(STR)    ANSI_ESC_BLUE    STR ANSI_ESC_RESET
+#define ANSI_MAGENTA(STR) ANSI_ESC_MAGENTA STR ANSI_ESC_RESET
+#define ANSI_CYAN(STR)    ANSI_ESC_CYAN    STR ANSI_ESC_RESET
+#define ERL_ERROR ANSI_RED("ERROR")
+#define ERL_WARNING ANSI_MAGENTA("WARNING")
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/libcom/src/osi/os/posix/osdMutex.c
+++ b/modules/libcom/src/osi/os/posix/osdMutex.c
@@ -36,12 +36,12 @@
 
 #define checkStatus(status,message) \
     if((status)) { \
-        errlogPrintf("epicsMutex %s failed: error %s\n", \
+        errlogPrintf("epicsMutex %s failed: " ERL_ERROR " %s\n", \
             (message), strerror((status))); \
     }
 #define checkStatusQuit(status,message,method) \
     if(status) { \
-        errlogPrintf("epicsMutex %s failed: error %s\n", \
+        errlogPrintf("epicsMutex %s failed: " ERL_ERROR " %s\n", \
             (message), strerror((status))); \
         cantProceed((method)); \
     }

--- a/modules/libcom/src/osi/os/posix/osdSpin.c
+++ b/modules/libcom/src/osi/os/posix/osdSpin.c
@@ -34,7 +34,7 @@
 
 #define checkStatus(status,message) \
     if ((status)) { \
-        errlogPrintf("epicsSpin %s failed: error %s\n", \
+        errlogPrintf("epicsSpin %s failed: " ERL_ERROR " %s\n", \
             (message), strerror((status))); \
     }
 

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -94,12 +94,12 @@ static epicsThreadOSD *createImplicit(void);
 
 #define checkStatus(status,message) \
 if((status))  {\
-    errlogPrintf("%s error %s\n",(message),strerror((status))); \
+    errlogPrintf("%s " ERL_ERROR " %s\n",(message),strerror((status))); \
 }
 
 #define checkStatusQuit(status,message,method) \
 if(status) { \
-    errlogPrintf("%s  error %s\n",(message),strerror((status))); \
+    errlogPrintf("%s  " ERL_ERROR " %s\n",(message),strerror((status))); \
     cantProceed((method)); \
 }
 

--- a/modules/libcom/test/epicsErrlogTest.c
+++ b/modules/libcom/test/epicsErrlogTest.c
@@ -370,7 +370,8 @@ MAIN(epicsErrlogTest)
 
     testDiag("Logged %u messages", pvt.count);
     epicsEventMustWait(pvt.done);
-    testEqInt(pvt.count, N+1);
+    /* Expect N+1 messages +- 1 depending on impl */
+    testOk(pvt.count >= N && pvt.count<=N+2, "Logged %u messages, expected %zu", pvt.count, N+1);
 
     /* Clean up */
     testOk(1 == errlogRemoveListeners(&logClient, &pvt),

--- a/modules/libcom/test/epicsErrlogTest.c
+++ b/modules/libcom/test/epicsErrlogTest.c
@@ -28,6 +28,11 @@
 #include "envDefs.h"
 #include "osiSock.h"
 #include "fdmgr.h"
+#include "epicsString.h"
+
+/* private between errlog.c and this test */
+LIBCOM_API
+void errlogStripANSI(char *msg);
 
 #define LOGBUFSIZE 2048
 
@@ -167,13 +172,40 @@ void logClient(void* raw, const char* msg)
     epicsEventSignal(pvt->done);
 }
 
+static
+void testANSIStrip(void)
+{
+    char scratch[64];
+    char actual[128];
+    char input[128];
+#define testEscape(INP, EXPECT) \
+    strcpy(scratch, INP); \
+    epicsStrnEscapedFromRaw(input, sizeof(input), INP, sizeof(INP)); \
+    errlogStripANSI(scratch); \
+    epicsStrnEscapedFromRaw(actual, sizeof(actual), scratch, epicsStrnLen(scratch, sizeof(scratch))); \
+    testOk(strcmp(scratch, EXPECT)==0, "input \"%s\" expect \"%s\" actual \"%s\"", input, EXPECT, actual)
+
+    testEscape("", "");
+    testEscape("hello", "hello");
+    testEscape("he\033[31;1mllo", "hello");
+    testEscape("\033[31;1mhello", "hello");
+    testEscape("hello\033[31;1m", "hello");
+    testEscape("hello\033[31;1", "hello");
+    testEscape("hello\033[", "hello");
+    testEscape("hello\033", "hello");
+
+#undef testEscape
+}
+
 MAIN(epicsErrlogTest)
 {
     size_t mlen, i, N;
     char msg[256];
     clientPvt pvt, pvt2;
 
-    testPlan(40);
+    testPlan(48);
+
+    testANSIStrip();
 
     strcpy(msg, truncmsg);
 
@@ -211,10 +243,11 @@ MAIN(epicsErrlogTest)
 
     errlogAddListener(&logClient, &pvt2);
 
+    /* logClient will not see ANSI escape sequences */
     pvt2.expect = pvt.expect = "Testing2";
     pvt2.checkLen = pvt.checkLen = strlen(pvt.expect);
 
-    errlogPrintfNoConsole("%s", pvt.expect);
+    errlogPrintfNoConsole("%s", ANSI_RED("Testing2"));
     errlogFlush();
 
     epicsEventMustWait(pvt.done);


### PR DESCRIPTION
Following up the digression on https://github.com/epics-base/epics-base/pull/109#issuecomment-781816959.  There are two parts to this PI.  A re-write of errlog around a double buffer, and teaching errlog to strip out ANSI terminal CSI escape sequences before passing along to log handlers.

The "WIP: add some color" commit is intended as a demo, and should not be merged.  Starting softIoc on Linux should show a blue `iocInit` when `$TERM` is set, and not when it is cleared.  In either case log clients should see plain text without escapes.

The buffering of log entries is conceptually similar, with the additional of a second buffer to allow errlogThread to print without holding a mutex.  This might be a benefit by itself wrt. PI and latency.  I was able to rewrite eg. `errlogPrintf()` to simply delegate to `errlogVprintf()` to avoid duplication, although this savings in LoC is offset by adding `errlogStripANSI()` (which seems in need of improvement).

The only change I needed to make to the errlog unittest was to allow for an additional message in one case.  I think this is due to the added capacity of double buffering.

I suspect that the logic in `isATTY()` which is testing `$TERM` may need to be excluded on RTEMS/vxWorks, but I haven't checked.  As it stands, escapes will be striped unless `$TERM` is set to a non-empty string.

The main omission I can see is that `printf()`, `epicsPrintf()`, and friends aren't covered by this PR.  I couldn't see a straightforward and portable way to do this.

I also haven't investigated the the support for ANSI escapes in Windows 10.
