### PR TITLE
Substitute strncpy by memcpy to avoid gcc 8 warnings

### DIFF
--- a/src/ca/legacy/pcas/generic/casStrmClient.cc
+++ b/src/ca/legacy/pcas/generic/casStrmClient.cc
@@ -1487,7 +1487,7 @@ caStatus casStrmClient::hostNameAction ( epicsGuard < casClientMutex > & guard )
         }
         return S_cas_internal;
     }
-    strncpy ( pMalloc, pName, size - 1 );
+    memcpy ( pMalloc, pName, (size - 1)*sizeof(char));
     pMalloc[ size - 1 ]='\0';
 
     if ( this->pHostName ) {
@@ -1531,7 +1531,7 @@ caStatus casStrmClient::clientNameAction (
         }
         return S_cas_internal;
     }
-    strncpy ( pMalloc, pName, size - 1 );
+    memcpy ( pMalloc, pName, (size - 1)*sizeof(char));
     pMalloc[size-1]='\0';
 
     if ( this->pUserName ) {

--- a/src/ioc/dbStatic/dbStaticLib.c
+++ b/src/ioc/dbStatic/dbStaticLib.c
@@ -742,7 +742,7 @@ static long dbAddOnePath (DBBASE *pdbbase, const char *path, unsigned length)
 
     pdbPathNode = (dbPathNode *)dbCalloc(1, sizeof(dbPathNode));
     pdbPathNode->directory = (char *)dbCalloc(length+1, sizeof(char));
-    strncpy(pdbPathNode->directory, path, length);
+    memcpy(pdbPathNode->directory, path, length*sizeof(char));
     pdbPathNode->directory[length] = '\0';
     ellAdd(ppathList, &pdbPathNode->node);
     return 0;

--- a/src/libCom/error/errSymLib.c
+++ b/src/libCom/error/errSymLib.c
@@ -162,7 +162,7 @@ static void errRawCopy ( long statusToDecode, char *pBuf, unsigned bufLength )
                 status = sprintf ( pBuf, "%d", errnum );
             }
             else {
-                strncpy ( pBuf,"<err copy fail>", bufLength );
+                memcpy(pBuf, "<err copy fail>", bufLength*sizeof(char) );
                 pBuf[bufLength-1] = '\0';
                 status = 0;
             }
@@ -181,8 +181,8 @@ static void errRawCopy ( long statusToDecode, char *pBuf, unsigned bufLength )
                     "(%d,%d)", modnum, errnum );
             }
             else {
-                strncpy ( pBuf, 
-                    "<err copy fail>", bufLength);
+                memcpy ( pBuf, 
+                    "<err copy fail>", bufLength*sizeof(char));
                 pBuf[bufLength-1] = '\0';
                 status = 0;
             }

--- a/src/libCom/osi/epicsTime.cpp
+++ b/src/libCom/osi/epicsTime.cpp
@@ -658,7 +658,7 @@ size_t epicsTime::strftime (
                     if ( tmpLen >= bufLenLeft ) {
                         tmpLen = bufLenLeft - 1;
                     }
-                    strncpy ( pBufCur, pOVF, tmpLen );
+                    memcpy(pBufCur, pOVF, tmpLen*sizeof(char));
                     pBufCur[tmpLen] = '\0';
                     pBufCur += tmpLen;
                     bufLenLeft -= tmpLen;
@@ -670,7 +670,7 @@ size_t epicsTime::strftime (
                 if ( tmpLen >= bufLenLeft ) {
                     tmpLen = bufLenLeft - 1;
                 }
-                strncpy ( pBufCur, pDoesntFit, tmpLen );
+                memcpy(pBufCur, pDoesntFit, tmpLen*sizeof(char));
                 pBufCur[tmpLen] = '\0';
                 pBufCur += tmpLen;
                 bufLenLeft -= tmpLen;

--- a/src/libCom/osi/osiSock.c
+++ b/src/libCom/osi/osiSock.c
@@ -74,7 +74,7 @@ unsigned epicsShareAPI sockAddrToA (
             return len;
         }
         else {
-		    strncpy ( pBuf, "<Ukn Addr Type>", bufSize-1 );
+		    memcpy ( pBuf, "<Ukn Addr Type>", (bufSize-1)*sizeof(char));
 		    pBuf[bufSize-1] = '\0';
             return bufSize-1;
         }

--- a/src/libCom/test/epicsStackTraceTest.c
+++ b/src/libCom/test/epicsStackTraceTest.c
@@ -94,7 +94,8 @@ static void logClient(void *ptr, const char *msg)
 
     if ( sz > mx )
         sz = mx;
-    strncpy( td->buf+td->pos, msg, sz );
+    memcpy( td->buf+td->pos, msg, sz*sizeof(char) );
+
     td->pos += sz;
 }
 


### PR DESCRIPTION
This MR is related to this issue: https://bugs.launchpad.net/epics-base/+bug/1905159
These changes remove the strncpy warnings on gcc 8.
I choose to apply the PR on the 3.15 because these changes could be propagated to the 7.0

It looks safer to use memcpy instead of disable this kind of warnings