### PR TITLE
First approach for the macro PWD inside the iocShell

### DIFF
--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include "epicsMath.h"
 #include "errlog.h"
@@ -545,6 +546,16 @@ int iocshSetError(int err)
     return err;
 }
 
+void addPwdMacro(iocshContext *context) {
+    if (context != NULL) {
+        char buf[256];
+        char *pwd = getcwd ( buf, sizeof(buf) - 1 );
+        if ( pwd ) {
+            macPutValue(context->handle, "PWD", pwd);
+        }
+    }
+}
+
 /*
  * The body of the command interpreter
  */
@@ -579,7 +590,6 @@ iocshBody (const char *pathname, const char *commandLine, const char *macros)
     int ret = 0;
 
     iocshInit();
-
     /*
      * See if command interpreter is interactive
      */
@@ -652,6 +662,8 @@ iocshBody (const char *pathname, const char *commandLine, const char *macros)
             return -1;
         }
 
+        addPwdMacro(context);
+
         epicsThreadPrivateSet(iocshContextId, (void *) context);
     }
     MAC_HANDLE *handle = context->handle;
@@ -661,6 +673,7 @@ iocshBody (const char *pathname, const char *commandLine, const char *macros)
 
     macPushScope(handle);
     macInstallMacros(handle, defines);
+    //addPwdMacro();
 
     wasOkToBlock = epicsThreadIsOkToBlock();
     epicsThreadSetOkToBlock(1);

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -546,7 +546,7 @@ int iocshSetError(int err)
     return err;
 }
 
-void addPwdMacro(iocshContext *context) {
+static void addPwdMacro(iocshContext *context) {
     if (context != NULL) {
         char buf[1024];
         char *pwd = getcwd(buf, sizeof(buf) - 1);

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -19,7 +19,6 @@
 #include <stdio.h>
 #include <ctype.h>
 #include <errno.h>
-#include "osiUnistd.h"
 
 #include "epicsMath.h"
 #include "errlog.h"
@@ -546,20 +545,6 @@ int iocshSetError(int err)
     return err;
 }
 
-static void addPwdMacro(iocshContext *context) {
-    if (context != NULL) {
-        char buf[1024];
-        char *pwd = getcwd(buf, sizeof(buf) - 1);
-        if (pwd) {
-            macPutValue(context->handle, "PWD", pwd);
-        } else {
-            if (errno == ERANGE) {
-                perror("Current path is too long");
-            }
-        }
-    }
-}
-
 /*
  * The body of the command interpreter
  */
@@ -666,8 +651,6 @@ iocshBody (const char *pathname, const char *commandLine, const char *macros)
             free(context);
             return -1;
         }
-
-        addPwdMacro(context);
 
         epicsThreadPrivateSet(iocshContextId, (void *) context);
     }

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -79,6 +79,8 @@ static void chdirCallFunc(const iocshArgBuf *args)
     if (args[0].sval == NULL ||
         iocshSetError(chdir(args[0].sval))) {
         fprintf(stderr, "Invalid directory path, ignored\n");
+    } else {
+        epicsEnvSet("PWD", args[0].sval);
     }
 }
 

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -401,23 +401,18 @@ static iocshVarDef asCheckClientIPDef[] = { { "asCheckClientIP", iocshArgInt, 0 
 // Register the PWD environment variable when the cd IOC shell function is 
 // registered. This variable contains the current directory path.
 static void registerPwd() {
-    // On Linux, the IOC already boots with the PWD env variable initialized.
-    // We check if it exists thinking about other OSs.
-    char* currentPwd = getenv("PWD");
-    if (currentPwd == NULL) {
-        char buf[1024];
-        char *pwd = getcwd(buf, sizeof(buf) - 1);
-        if (pwd) {
-            epicsEnvSet("PWD", buf);
-        } else {
-            if (errno == ERANGE) {
-                fprintf(stderr, "Current path exceeds %u characters and, so, ",
-                                                                  sizeof(buf));
-            }
-            fprintf(stderr, "env variable PWD (which contains the current path\
-                             ) could not be created. You can still use cd to \
-                             change directory and register PWD.\n");
+    char buf[1024];
+    char *pwd = getcwd(buf, sizeof(buf) - 1);
+    if (pwd) {
+        epicsEnvSet("PWD", buf);
+    } else {
+        if (errno == ERANGE) {
+            fprintf(stderr, "Current path exceeds %u characters and, so, ",
+                                                              sizeof(buf));
         }
+        fprintf(stderr, "env variable PWD (which contains the current path) \
+                         could not be created. You can still use cd to change \
+                         directory and register PWD.\n");
     }
 }
 

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -398,12 +398,38 @@ static void installLastResortEventProviderCallFunc(const iocshArgBuf *args)
 
 static iocshVarDef asCheckClientIPDef[] = { { "asCheckClientIP", iocshArgInt, 0 }, { NULL, iocshArgInt, NULL } };
 
+// Register the PWD environment variable when the cd IOC shell function is 
+// registered. This variable contains the current directory path.
+static void registerPwd() {
+    // On Linux, the IOC already boots with the PWD env variable initialized.
+    // We check if it exists thinking about other OSs.
+    char* currentPwd = getenv("PWD");
+    if (currentPwd == NULL) {
+        char buf[1024];
+        char *pwd = getcwd(buf, sizeof(buf) - 1);
+        if (pwd) {
+            epicsEnvSet("PWD", buf);
+        } else {
+            if (errno == ERANGE) {
+                fprintf(stderr, "Current path exceeds %u characters and, so, ",
+                                                                  sizeof(buf));
+            }
+            fprintf(stderr, "env variable PWD (which contains the current path\
+                             ) could not be created. You can still use cd to \
+                             change directory and register PWD.\n");
+        }
+    }
+}
+
 void epicsStdCall libComRegister(void)
 {
     iocshRegister(&dateFuncDef, dateCallFunc);
     iocshRegister(&echoFuncDef, echoCallFunc);
     iocshRegister(&chdirFuncDef, chdirCallFunc);
     iocshRegister(&pwdFuncDef, pwdCallFunc);
+
+    // Register the PWD environment variable, containing the current path
+    registerPwd();
 
     iocshRegister(&epicsEnvSetFuncDef, epicsEnvSetCallFunc);
     iocshRegister(&epicsEnvUnsetFuncDef, epicsEnvUnsetCallFunc);


### PR DESCRIPTION
This is the first approach. The function that creates the macro was called 3 times with the IOC example from makeBaseApp.pl:

1. Right in the beginning of the boot.
2. After the call to envPaths.
3. After IOC Init.

So, the macro is created during the boot, but it doesn't update when the user uses the cd IOC shell function. I thought about calling the function on libcomRegister.c, but my function addPwdMacro() doesn't seem to fit the scope of the IOC Shell API. I could duplicate the code on libcomRegister.c, too.

Any suggestion is appreciated.