### PR TITLE
[WIP] Remove strncpy warnings that are exclusively from branch 7.0

### DIFF
--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -834,7 +834,8 @@ static long getLinkValue(DBADDR *paddr, short dbrType,
     {
         const char *rtnString = dbGetString(&dbEntry);
 
-        strncpy(pbuf, rtnString, maxlen-1);
+        if (maxlen > 1)
+            strncpy(pbuf, rtnString, maxlen-1);
         pbuf[maxlen-1] = 0;
         if(dbrType!=DBR_STRING)
             nReq = strlen(pbuf)+1;


### PR DESCRIPTION
These changes removes warnings from strncpy on gcc 8. 
These warnings appears in files presents only on branch 7.0