### PR TITLE
#80 - Use OS strtod if MSVC 1900 or above

### DIFF
--- a/src/libCom/osi/os/WIN32/osdStrtod.h
+++ b/src/libCom/osi/os/WIN32/osdStrtod.h
@@ -13,10 +13,6 @@
 extern "C" {
 #endif
 
-/*
- * epicsStrtod() for systems with broken strtod() routine
- */
-epicsShareFunc double epicsStrtod(const char *str, char **endp); 
 
 /*
  * Microsoft apparently added strto[u]ll() in VS2013
@@ -26,6 +22,15 @@ epicsShareFunc double epicsStrtod(const char *str, char **endp);
 #if !defined(_MINGW) && (_MSC_VER < 1800)
 #  define strtoll _strtoi64
 #  define strtoull _strtoui64
+#endif
+
+#if (_MSC_VER < 1800) && defined(_MINGW)
+/*
+ * epicsStrtod() for systems with broken strtod() routine
+ */
+epicsShareFunc double epicsStrtod(const char *str, char **endp);
+#else
+#  define epicsStrtod strtod
 #endif
 
 #ifdef __cplusplus

--- a/src/libCom/osi/os/WIN32/osdStrtod.h
+++ b/src/libCom/osi/os/WIN32/osdStrtod.h
@@ -24,7 +24,11 @@ extern "C" {
 #  define strtoull _strtoui64
 #endif
 
-#if (_MSC_VER < 1800) && defined(_MINGW)
+/*
+ * strtod works in MSVC 1900 and mingw, use
+ * the OS version in those and our own otherwise
+ */
+#if (_MSC_VER < 1900) && !defined(_MINGW)
 /*
  * epicsStrtod() for systems with broken strtod() routine
  */


### PR DESCRIPTION
Closes #80 

Hopefully i've done this correctly! 

Should now use the OS strtod implementation if using MINGw or MSVC 1900 (2015) or above and still use our own impl if not. 