### PR TITLE
Fix type comparison on msi.cpp

### DIFF
--- a/src/ioc/dbtemplate/msi.cpp
+++ b/src/ioc/dbtemplate/msi.cpp
@@ -300,11 +300,11 @@ static void makeSubstitutions(inputData * const inputPvt,
             char *pstart;
             char *pend;
             int  cmdind=-1;
-            long unsigned int  i;
+            size_t  i;
 
             for (i = 0; i < NELEMENTS(cmdNames); i++) {
                 if (strstr(command, cmdNames[i])) {
-                    cmdind = i;
+                    cmdind = (int)i;
                 }
             }
             if (cmdind < 0) goto endcmd;

--- a/src/ioc/dbtemplate/msi.cpp
+++ b/src/ioc/dbtemplate/msi.cpp
@@ -300,7 +300,7 @@ static void makeSubstitutions(inputData * const inputPvt,
             char *pstart;
             char *pend;
             int  cmdind=-1;
-            int  i;
+            long unsigned int  i;
 
             for (i = 0; i < NELEMENTS(cmdNames); i++) {
                 if (strstr(command, cmdNames[i])) {


### PR DESCRIPTION
This change fix the comparison of different signedness (int and long unsigned int).
The pull request is on 3.15 so it can be propagated to 7.0 also.