### PR TITLE
Use waitable timers on WIN32

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -12,6 +12,14 @@ The names of the generated junit xml test output files have been changed
 from `<testname>.xml` to `<testname>-results.xml`, to allow better 
 distinction from other xml files. (I.e., for easy wildcard matching.)
 
+### Use waitable timers on Microsoft Windows
+
+The `epicsEventWaitWithTimeout` and `epicsThreadSleep` functions have
+been changed to use waitable timers. On Windows 10 version 1803 or higher
+they will use high resolution timers for more consistent timing.
+
+See https://groups.google.com/a/chromium.org/g/scheduler-dev/c/0GlSPYreJeY
+for a comparison of the performance of different timers.
 
 ## Changes made between 3.15.7 and 3.15.8
 

--- a/src/libCom/osi/os/WIN32/osdEvent.c
+++ b/src/libCom/osi/os/WIN32/osdEvent.c
@@ -26,6 +26,8 @@
 #include "shareLib.h"
 #include "epicsEvent.h"
 
+#include "osdThreadPvt.h"
+
 typedef struct epicsEventOSD {
     HANDLE handle;
 } epicsEventOSD;
@@ -83,8 +85,6 @@ epicsShareFunc epicsEventStatus epicsEventWait ( epicsEventId pSem )
         return epicsEventError;
     }
 }
-
-extern HANDLE osdThreadGetTimer(void); /* from osdThread.c */
 
 /*
  * epicsEventWaitWithTimeout ()

--- a/src/libCom/osi/os/WIN32/osdEvent.c
+++ b/src/libCom/osi/os/WIN32/osdEvent.c
@@ -84,36 +84,49 @@ epicsShareFunc epicsEventStatus epicsEventWait ( epicsEventId pSem )
     }
 }
 
+extern HANDLE osdThreadGetTimer();
+
 /*
  * epicsEventWaitWithTimeout ()
  */
 epicsShareFunc epicsEventStatus epicsEventWaitWithTimeout (
     epicsEventId pSem, double timeOut )
 { 
-    static const unsigned mSecPerSec = 1000;
+    static const unsigned nSec100PerSec = 10000000;
+    HANDLE handles[2];
     DWORD status;
-    DWORD tmo;
+    LARGE_INTEGER tmo;
+    HANDLE timer;
 
     if ( timeOut <= 0.0 ) {
-        tmo = 0u;
-    }
-    else if ( timeOut >= INFINITE / mSecPerSec ) {
-        tmo = INFINITE - 1;
+        tmo.QuadPart = 0u;
     }
     else {
-        tmo = ( DWORD ) ( ( timeOut * mSecPerSec ) + 0.5 );
-        if ( tmo == 0 ) {
-            tmo = 1;
-        }
+        tmo.QuadPart = -((LONGLONG)(timeOut * nSec100PerSec + 0.5));  // +0.99999999 ?
     }
-    status = WaitForSingleObject ( pSem->handle, tmo );
+
+    if (tmo.QuadPart < 0) {
+        timer = osdThreadGetTimer();
+        if (!SetWaitableTimer(timer, &tmo, 0, NULL, NULL, 0))
+        {
+            printf("event error %d\n", GetLastError());
+            return epicsEventError;
+        }
+        handles[0] = pSem->handle;
+        handles[1] = timer;
+        status = WaitForMultipleObjects (2, handles, FALSE, INFINITE);
+    }
+    else {
+        status = WaitForSingleObject(pSem->handle, 0);
+    }
     if ( status == WAIT_OBJECT_0 ) {
         return epicsEventOK;
     }
-    else if ( status == WAIT_TIMEOUT ) {
+    else if ( status == WAIT_OBJECT_0 + 1 || status == WAIT_TIMEOUT ) {
         return epicsEventWaitTimeout;
     }
     else {
+        printf("event error %d\n", GetLastError());
         return epicsEventError;
     }
 }

--- a/src/libCom/osi/os/WIN32/osdEvent.c
+++ b/src/libCom/osi/os/WIN32/osdEvent.c
@@ -84,7 +84,7 @@ epicsShareFunc epicsEventStatus epicsEventWait ( epicsEventId pSem )
     }
 }
 
-extern HANDLE osdThreadGetTimer();
+extern HANDLE osdThreadGetTimer(void); /* from osdThread.c */
 
 /*
  * epicsEventWaitWithTimeout ()
@@ -92,7 +92,7 @@ extern HANDLE osdThreadGetTimer();
 epicsShareFunc epicsEventStatus epicsEventWaitWithTimeout (
     epicsEventId pSem, double timeOut )
 { 
-    static const unsigned nSec100PerSec = 10000000;
+    static const unsigned nSec100PerSec = 10000000u;
     HANDLE handles[2];
     DWORD status;
     LARGE_INTEGER tmo;
@@ -102,14 +102,12 @@ epicsShareFunc epicsEventStatus epicsEventWaitWithTimeout (
         tmo.QuadPart = 0u;
     }
     else {
-        tmo.QuadPart = -((LONGLONG)(timeOut * nSec100PerSec + 0.5));  // +0.99999999 ?
+        tmo.QuadPart = -((LONGLONG)(timeOut * nSec100PerSec + 0.5));
     }
 
     if (tmo.QuadPart < 0) {
         timer = osdThreadGetTimer();
-        if (!SetWaitableTimer(timer, &tmo, 0, NULL, NULL, 0))
-        {
-            printf("event error %d\n", GetLastError());
+        if (!SetWaitableTimer(timer, &tmo, 0, NULL, NULL, 0)) {
             return epicsEventError;
         }
         handles[0] = pSem->handle;
@@ -123,10 +121,11 @@ epicsShareFunc epicsEventStatus epicsEventWaitWithTimeout (
         return epicsEventOK;
     }
     else if ( status == WAIT_OBJECT_0 + 1 || status == WAIT_TIMEOUT ) {
+        /* WaitForMultipleObjects will trigger WAIT_OBJECT_0 + 1,
+           WaitForSingleObject will trigger WAIT_TIMEOUT */
         return epicsEventWaitTimeout;
     }
     else {
-        printf("event error %d\n", GetLastError());
         return epicsEventError;
     }
 }

--- a/src/libCom/osi/os/WIN32/osdThread.c
+++ b/src/libCom/osi/os/WIN32/osdThread.c
@@ -18,9 +18,6 @@
 
 #define VC_EXTRALEAN
 #define STRICT
-#ifndef _WIN32_WINNT
-#   define _WIN32_WINNT 0x400 /* No support for W95 */
-#endif
 #include <windows.h>
 #include <process.h> /* for _endthread() etc */
 
@@ -53,6 +50,7 @@ typedef struct epicsThreadOSD {
     DWORD id;
     unsigned epicsPriority;
     char isSuspended;
+    HANDLE timer; /* waitable timer */
 } win32ThreadParam;
 
 typedef struct epicsThreadPrivateOSD {
@@ -244,6 +242,8 @@ static void epicsParmCleanupWIN32 ( win32ThreadParam * pParm )
         LeaveCriticalSection ( & pGbl->mutex );
 
         CloseHandle ( pParm->handle );
+        CloseHandle ( pParm->timer );
+        pParm->timer = NULL;
         free ( pParm );
         TlsSetValue ( pGbl->tlsIndexThreadLibraryEPICS, 0 );
     }
@@ -526,6 +526,11 @@ static win32ThreadParam * epicsThreadParmCreate ( const char *pName )
         pParmWIN32->pName = (char *) ( pParmWIN32 + 1 );
         strcpy ( pParmWIN32->pName, pName );
         pParmWIN32->isSuspended = 0;
+#ifdef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+        pParmWIN32->timer = CreateWaitableTimerEx(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+#else
+        pParmWIN32->timer = CreateWaitableTimer(NULL, 0, NULL);
+#endif
     }
     return pParmWIN32;
 }
@@ -764,24 +769,50 @@ epicsShareFunc int epicsShareAPI epicsThreadIsSuspended ( epicsThreadId id )
     }
 }
 
+HANDLE osdThreadGetTimer()
+{
+    win32ThreadGlobal * pGbl = fetchWin32ThreadGlobal ();
+    win32ThreadParam * pParm;
+
+    assert ( pGbl );
+
+    pParm = ( win32ThreadParam * )
+        TlsGetValue ( pGbl->tlsIndexThreadLibraryEPICS );
+
+    return pParm->timer;
+}
+
 /*
  * epicsThreadSleep ()
  */
 epicsShareFunc void epicsShareAPI epicsThreadSleep ( double seconds )
 {
-    static const unsigned mSecPerSec = 1000;
-    DWORD milliSecDelay;
+    static const unsigned nSec100PerSec = 10000000;
+    LARGE_INTEGER tmo;
+    HANDLE timer;
 
-    if ( seconds > 0.0 ) {
-        seconds *= mSecPerSec;
-        seconds += 0.99999999;  /* 8 9s here is optimal */
-        milliSecDelay = ( seconds >= INFINITE ) ?
-            INFINITE - 1 : ( DWORD ) seconds;
+    if ( seconds <= 0.0 ) {
+        tmo.QuadPart = 0u;
     }
-    else {  /* seconds <= 0 or NAN */
-        milliSecDelay = 0u;
+    else {
+        tmo.QuadPart = -((LONGLONG)(seconds * nSec100PerSec + 0.5)); // +0.99999999 ?
     }
-    Sleep ( milliSecDelay );
+
+    if (tmo.QuadPart == 0) {
+        Sleep ( 0 );
+    }
+    else {
+        timer = osdThreadGetTimer();
+        if (!SetWaitableTimer(timer, &tmo, 0, NULL, NULL, 0))
+        {
+            printf("timer error %d\n", GetLastError());
+            return;
+        }
+        if (WaitForSingleObject(timer, INFINITE) != WAIT_OBJECT_0)
+        {
+            printf("timer error %d\n", GetLastError());
+        }
+    }
 }
 
 /*

--- a/src/libCom/osi/os/WIN32/osdThread.c
+++ b/src/libCom/osi/os/WIN32/osdThread.c
@@ -528,6 +528,9 @@ static win32ThreadParam * epicsThreadParmCreate ( const char *pName )
         pParmWIN32->isSuspended = 0;
 #ifdef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
         pParmWIN32->timer = CreateWaitableTimerEx(NULL, NULL, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, TIMER_ALL_ACCESS);
+        if (pParmWIN32->timer == NULL) {
+            pParmWIN32->timer = CreateWaitableTimer(NULL, 0, NULL);
+        }
 #else
         pParmWIN32->timer = CreateWaitableTimer(NULL, 0, NULL);
 #endif
@@ -769,6 +772,10 @@ epicsShareFunc int epicsShareAPI epicsThreadIsSuspended ( epicsThreadId id )
     }
 }
 
+/**
+ * osdThreadGetTimer ()
+ * return stored waitable timer object for thread
+ */
 HANDLE osdThreadGetTimer()
 {
     win32ThreadGlobal * pGbl = fetchWin32ThreadGlobal ();
@@ -787,7 +794,7 @@ HANDLE osdThreadGetTimer()
  */
 epicsShareFunc void epicsShareAPI epicsThreadSleep ( double seconds )
 {
-    static const unsigned nSec100PerSec = 10000000;
+    static const unsigned nSec100PerSec = 10000000u;
     LARGE_INTEGER tmo;
     HANDLE timer;
 
@@ -795,7 +802,7 @@ epicsShareFunc void epicsShareAPI epicsThreadSleep ( double seconds )
         tmo.QuadPart = 0u;
     }
     else {
-        tmo.QuadPart = -((LONGLONG)(seconds * nSec100PerSec + 0.5)); // +0.99999999 ?
+        tmo.QuadPart = -((LONGLONG)(seconds * nSec100PerSec + 0.5));
     }
 
     if (tmo.QuadPart == 0) {
@@ -803,14 +810,12 @@ epicsShareFunc void epicsShareAPI epicsThreadSleep ( double seconds )
     }
     else {
         timer = osdThreadGetTimer();
-        if (!SetWaitableTimer(timer, &tmo, 0, NULL, NULL, 0))
-        {
-            printf("timer error %d\n", GetLastError());
+        if (!SetWaitableTimer(timer, &tmo, 0, NULL, NULL, 0)) {
+            fprintf ( stderr, "epicsThreadSleep: SetWaitableTimer failed %lu\n", GetLastError() );
             return;
         }
-        if (WaitForSingleObject(timer, INFINITE) != WAIT_OBJECT_0)
-        {
-            printf("timer error %d\n", GetLastError());
+        if (WaitForSingleObject(timer, INFINITE) != WAIT_OBJECT_0) {
+            fprintf ( stderr, "epicsThreadSleep: WaitForSingleObject failed %lu\n", GetLastError() );
         }
     }
 }

--- a/src/libCom/osi/os/WIN32/osdThreadPvt.h
+++ b/src/libCom/osi/os/WIN32/osdThreadPvt.h
@@ -1,0 +1,14 @@
+#ifndef osdThreadPvth
+#define osdThreadPvth
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern HANDLE osdThreadGetTimer(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* osdThreadPvth */


### PR DESCRIPTION
Use waitable timers, potentially a high resolution version, to try and avoid early wakeups.

Probably missing some additional timer cleanup code at the moment, also need to check on older windows versions.

See #106



