### PR TITLE
Make C implicit function declarations an error on win32

### DIFF
--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -32,12 +32,16 @@ HDEPENDS_METHOD = MKMF
 
 #
 # -W<d> display warnings at level d
+#    -Wall is -W4 plus some additional warnings that are
+#          off by default (https://docs.microsoft.com/en-us/cpp/preprocessor/compiler-warnings-that-are-off-by-default?view=msvc-160)
 #    -W4 is for maximum (lint type) warnings
 #    -W3 is for production quality warnings
 #    -W2 displays significant warnings
 #    -W1 is the default and shows severe warnings only
-# -w<d><n> Set warning C<n> to be shown at level <d>
-WARN_CFLAGS_YES = -W3
+# -we<n> Make warning C<n> an error
+# -wd<n> Disable warning C<n>
+# -we4013 makes it an error to implicitly define a function
+WARN_CFLAGS_YES = -W3 -we4013
 WARN_CFLAGS_NO  = -W1
 
 #
@@ -101,6 +105,8 @@ CODE_CPPFLAGS += -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
 #
 # -W<n> disable warnings from levels > n
 # -w<n><m> set warning m to level n
+# -we<n> Make warning C<n> an error
+# -wd<n> Disable warning C<n>
 # -w44355 "'this' used in the base initializer list"
 # -w44344 "behavior change: use of explicit template arguments results in ..."
 # -w44251 "class needs to have dll-interface to be used by clients of ..."


### PR DESCRIPTION
Make C implicit function declarations an error on win32