### PR TITLE
Fix the 3.15 'make inc' build target

### DIFF
--- a/configure/RULES.Db
+++ b/configure/RULES.Db
@@ -187,7 +187,8 @@ endif
 
 #####################################################  build dependancies, clean rule
 
-inc : $(COMMON_INC) $(INSTALL_INC)
+inc : $(COMMON_INC) $(INSTALL_INC) $(COMMON_DBDS) $(COMMON_DBDCATS) \
+	$(INSTALL_DBDS) $(INSTALL_DBD_INSTALLS)
 
 build : $(COMMON_DBDS) $(COMMON_DBS) $(COMMON_DBDCATS) \
 	$(INSTALL_DBDS) $(INSTALL_DBS) \

--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -93,9 +93,11 @@ include $(CONFIG)/RULES_TARGET
 #---------------------------------------------------------------
 # Read dependency files
 
+ifneq (inc,$(strip $(MAKECMDGOALS)))
 ifneq (,$(strip $(HDEPENDS_FILES)))
 $(filter-out $(wildcard *$(DEP)), $(HDEPENDS_FILES)): | $(COMMON_INC)
 -include $(HDEPENDS_FILES)
+endif
 endif
 
 #---------------------------------------------------------------
@@ -144,14 +146,14 @@ build: inc
 build: $(OBJSNAME) $(LIBTARGETS) $(PRODTARGETS) $(TESTPRODTARGETS) \
 	$(TARGETS) $(TESTSCRIPTS) $(INSTALL_LIB_INSTALLS)
 
-inc : $(COMMON_INC) $(INSTALL_INC) $(INSTALL_CONFIGS)
+inc : $(COMMON_INC) $(INSTALL_INC) $(INSTALL_CONFIGS) \
+	$(INSTALL_HTMLS)
 
 buildInstall : \
 	$(INSTALL_SCRIPTS) $(INSTALL_PROD) $(INSTALL_MUNCHS) \
 	$(INSTALL_TCLLIBS) $(INSTALL_TCLINDEX) \
 	$(INSTALL_OBJS) \
 	$(INSTALL_DOCS) \
-	$(INSTALL_HTMLS) \
 	$(INSTALL_TEMPLATE) \
 	$(INSTALL_BIN_INSTALLS)
 

--- a/configure/RULES_TOP
+++ b/configure/RULES_TOP
@@ -45,7 +45,7 @@ help:
 	@echo "Usage: gnumake [options] [target] ..."
 	@echo "Targets supported by all Makefiles:"
 	@echo "     all            - Same as install (default rule)"
-	@echo "     inc            - Installs header files"
+	@echo "     inc            - Installs header, dbd and html files"
 	@echo "     build          - Builds and installs all targets"
 	@echo "     install        - Builds and installs all targets"
 	@echo "     buildInstall   - Same as install (deprecated)"

--- a/src/ioc/bpt/Makefile
+++ b/src/ioc/bpt/Makefile
@@ -19,7 +19,10 @@ BPT_DBD += bptTypeJdegC.dbd
 BPT_DBD += bptTypeJdegF.dbd
 BPT_DBD += bptTypeKdegC.dbd
 BPT_DBD += bptTypeKdegF.dbd
+
+ifneq (inc,$(strip $(MAKECMDGOALS)))
 DBD += $(BPT_DBD)
+endif
 
 PROD_HOST += makeBpt
 

--- a/src/tools/Makefile
+++ b/src/tools/Makefile
@@ -86,6 +86,8 @@ CLEANS += epics-base-$(T_A).pc@
 
 include $(TOP)/configure/RULES
 
+inc: $(INSTALLS_PERL_MODULES) $(INSTALL_SCRIPTS)
+
 epics-base-$(T_A).pc@: ../epics-base-arch.pc@
 	@$(RM) $@
 	@$(CP) $< $@


### PR DESCRIPTION
Now `make inc` generates and installs dbd, header and html files.
No compilation involved/required.