### PR TITLE
Add help for iocsh commands by zioven

### DIFF
--- a/modules/database/src/ioc/as/asIocRegister.c
+++ b/modules/database/src/ioc/as/asIocRegister.c
@@ -120,7 +120,9 @@ static void ascarCallFunc(const iocshArgBuf *args)
 }
 
 /* asDumpHash */
-static const iocshFuncDef asDumpHashFuncDef = {"asDumpHash",0,0};
+static const iocshFuncDef asDumpHashFuncDef = {"asDumpHash",0,0,
+                                               "Show the contents of the hash table used "
+                                               "to locate UAGs and HAGs.\n"};
 static void asDumpHashCallFunc(const iocshArgBuf *args)
 {
     asDumpHash();

--- a/modules/database/src/ioc/rsrv/rsrvIocRegister.c
+++ b/modules/database/src/ioc/rsrv/rsrvIocRegister.c
@@ -20,7 +20,11 @@
 /* casr */
 static const iocshArg casrArg0 = { "level",iocshArgInt};
 static const iocshArg * const casrArgs[1] = {&casrArg0};
-static const iocshFuncDef casrFuncDef = {"casr",1,casrArgs};
+static const iocshFuncDef casrFuncDef = {"casr",1,casrArgs,
+                                         "Channel Access Server Report with following levels:\n"
+                                         "  0 - server’s protocol version level and summary for each attached client\n"
+                                         "  1 - extends report with information about connected clients and beacons\n"
+                                         "  2 - extends report with specific channel names and UDP search requests\n"};
 static void casrCallFunc(const iocshArgBuf *args)
 {
     casr(args[0].ival);

--- a/modules/database/src/ioc/rsrv/rsrvIocRegister.c
+++ b/modules/database/src/ioc/rsrv/rsrvIocRegister.c
@@ -22,9 +22,10 @@ static const iocshArg casrArg0 = { "level",iocshArgInt};
 static const iocshArg * const casrArgs[1] = {&casrArg0};
 static const iocshFuncDef casrFuncDef = {"casr",1,casrArgs,
                                          "Channel Access Server Report with following levels:\n"
-                                         "  0 - server’s protocol version level and summary for each attached client\n"
-                                         "  1 - extends report with information about connected clients and beacons\n"
-                                         "  2 - extends report with specific channel names and UDP search requests\n"};
+                                         "  0  - server’s protocol version level and summary for each attached client\n"
+                                         "  1  - extends report with information about connected clients and beacons\n"
+                                         "  2  - extends report with specific channel names and UDP search requests\n"
+                                         "  3+ - expert\n"};
 static void casrCallFunc(const iocshArgBuf *args)
 {
     casr(args[0].ival);

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -163,7 +163,12 @@ const iocshCmdDef * epicsStdCall iocshFindCommand(const char *name)
 static const iocshArg varCmdArg0 = { "[variable", iocshArgString};
 static const iocshArg varCmdArg1 = { "[value]]", iocshArgString};
 static const iocshArg *varCmdArgs[2] = {&varCmdArg0, &varCmdArg1};
-static const iocshFuncDef varFuncDef = {"var", 2, varCmdArgs};
+static const iocshFuncDef varFuncDef = {"var", 2, varCmdArgs,
+                                        "Print all, print single variable or set value to single variable\n"
+                                        "  (default) - print all variables and their values"
+                                        " defined in database definitions files\n"
+                                        "  variable  - if only parameter print value for this variable\n"
+                                        "  value     - set the value to variable\n"};
 
 void epicsStdCall iocshRegisterVariable (const iocshVarDef *piocshVarDef)
 {
@@ -1139,7 +1144,10 @@ static void varCallFunc(const iocshArgBuf *args)
 /* iocshCmd */
 static const iocshArg iocshCmdArg0 = { "command",iocshArgString};
 static const iocshArg *iocshCmdArgs[1] = {&iocshCmdArg0};
-static const iocshFuncDef iocshCmdFuncDef = {"iocshCmd",1,iocshCmdArgs};
+static const iocshFuncDef iocshCmdFuncDef = {"iocshCmd",1,iocshCmdArgs,
+                                             "Takes a single IOC shell command and executes it\n"
+                                             "  * This function is most useful to execute a single IOC shell command\n"
+                                             "    from vxWorks or RTEMS startup script (or command line)\n"};
 static void iocshCmdCallFunc(const iocshArgBuf *args)
 {
     iocshCmd(args[0].sval);
@@ -1149,7 +1157,9 @@ static void iocshCmdCallFunc(const iocshArgBuf *args)
 static const iocshArg iocshLoadArg0 = { "pathname",iocshArgString};
 static const iocshArg iocshLoadArg1 = { "macros", iocshArgString};
 static const iocshArg *iocshLoadArgs[2] = {&iocshLoadArg0, &iocshLoadArg1};
-static const iocshFuncDef iocshLoadFuncDef = {"iocshLoad",2,iocshLoadArgs};
+static const iocshFuncDef iocshLoadFuncDef = {"iocshLoad",2,iocshLoadArgs,
+                                              "Execute IOC shell commands provided in file from first parameter\n"
+                                              "  * (optional) replace macros within the file with provided values\n"};
 static void iocshLoadCallFunc(const iocshArgBuf *args)
 {
     iocshLoad(args[0].sval, args[1].sval);
@@ -1159,7 +1169,10 @@ static void iocshLoadCallFunc(const iocshArgBuf *args)
 static const iocshArg iocshRunArg0 = { "command",iocshArgString};
 static const iocshArg iocshRunArg1 = { "macros", iocshArgString};
 static const iocshArg *iocshRunArgs[2] = {&iocshRunArg0, &iocshRunArg1};
-static const iocshFuncDef iocshRunFuncDef = {"iocshRun",2,iocshRunArgs};
+static const iocshFuncDef iocshRunFuncDef = {"iocshRun",2,iocshRunArgs,
+                                             "Takes a single IOC shell command, replaces macros and executes it\n"
+                                             "  * This function is most useful to execute a single IOC shell command\n"
+                                             "    from vxWorks or RTEMS startup script (or command line)\n"};
 static void iocshRunCallFunc(const iocshArgBuf *args)
 {
     iocshRun(args[0].sval, args[1].sval);

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -123,7 +123,8 @@ static void epicsEnvSetCallFunc(const iocshArgBuf *args)
 /* epicsEnvUnset */
 static const iocshArg epicsEnvUnsetArg0 = { "name",iocshArgString};
 static const iocshArg * const epicsEnvUnsetArgs[1] = {&epicsEnvUnsetArg0};
-static const iocshFuncDef epicsEnvUnsetFuncDef = {"epicsEnvUnset",1,epicsEnvUnsetArgs};
+static const iocshFuncDef epicsEnvUnsetFuncDef = {"epicsEnvUnset",1,epicsEnvUnsetArgs,
+                                                  "Remove variable name from the environment\n"};
 static void epicsEnvUnsetCallFunc(const iocshArgBuf *args)
 {
     char *name = args[0].sval;
@@ -141,14 +142,16 @@ IOCSH_STATIC_FUNC void epicsParamShow()
     epicsPrtEnvParams ();
 }
 
-static const iocshFuncDef epicsParamShowFuncDef = {"epicsParamShow",0,NULL};
+static const iocshFuncDef epicsParamShowFuncDef = {"epicsParamShow",0,NULL,
+                                                   "Show the environment variable parameters used by iocCore\n"};
 static void epicsParamShowCallFunc(const iocshArgBuf *args)
 {
     epicsParamShow ();
 }
 
 /* epicsPrtEnvParams */
-static const iocshFuncDef epicsPrtEnvParamsFuncDef = {"epicsPrtEnvParams",0,0};
+static const iocshFuncDef epicsPrtEnvParamsFuncDef = {"epicsPrtEnvParams",0,0,
+                                                      "Show the environment variable parameters used by iocCore\n"};
 static void epicsPrtEnvParamsCallFunc(const iocshArgBuf *args)
 {
     epicsPrtEnvParams ();
@@ -157,21 +160,29 @@ static void epicsPrtEnvParamsCallFunc(const iocshArgBuf *args)
 /* epicsEnvShow */
 static const iocshArg epicsEnvShowArg0 = { "[name]",iocshArgString};
 static const iocshArg * const epicsEnvShowArgs[1] = {&epicsEnvShowArg0};
-static const iocshFuncDef epicsEnvShowFuncDef = {"epicsEnvShow",1,epicsEnvShowArgs};
+static const iocshFuncDef epicsEnvShowFuncDef = {"epicsEnvShow",1,epicsEnvShowArgs,
+                                                 "Show environment variables on your system\n"
+                                                 "  (default) - show all environment variables\n"
+                                                 "   name     - show value of specific environment variable\n"};
 static void epicsEnvShowCallFunc(const iocshArgBuf *args)
 {
     epicsEnvShow (args[0].sval);
 }
 
 /* registryDump */
-static const iocshFuncDef registryDumpFuncDef = {"registryDump",0,NULL};
+static const iocshFuncDef registryDumpFuncDef = {"registryDump",0,NULL,
+                                                 "Dump a hash table of EPICS registry\n"};
 static void registryDumpCallFunc(const iocshArgBuf *args)
 {
     registryDump ();
 }
 
 /* iocLogInit */
-static const iocshFuncDef iocLogInitFuncDef = {"iocLogInit",0};
+static const iocshFuncDef iocLogInitFuncDef = {"iocLogInit",0,0,
+                                               "Initialize IOC logging\n"
+                                               "  * EPICS environment variable 'EPICS_IOC_LOG_INET' has to be defined\n"
+                                               "  * Logging controled via 'iocLogDisable' variable\n"
+                                               "       see 'setIocLogDisable' command\n"};
 static void iocLogInitCallFunc(const iocshArgBuf *args)
 {
     iocLogInit ();
@@ -185,7 +196,10 @@ IOCSH_STATIC_FUNC void setIocLogDisable(int val)
 
 static const iocshArg iocLogDisableArg0 = {"(0,1)=>(false,true)",iocshArgInt};
 static const iocshArg * const iocLogDisableArgs[1] = {&iocLogDisableArg0};
-static const iocshFuncDef iocLogDisableFuncDef = {"setIocLogDisable",1,iocLogDisableArgs};
+static const iocshFuncDef iocLogDisableFuncDef = {"setIocLogDisable",1,iocLogDisableArgs,
+                                                  "Controls the 'iocLogDisable' variable\n"
+                                                  "  0 - enable logging\n"
+                                                  "  1 - disable logging\n"};
 static void iocLogDisableCallFunc(const iocshArgBuf *args)
 {
     setIocLogDisable(args[0].ival);
@@ -194,7 +208,8 @@ static void iocLogDisableCallFunc(const iocshArgBuf *args)
 /* iocLogShow */
 static const iocshArg iocLogShowArg0 = {"level",iocshArgInt};
 static const iocshArg * const iocLogShowArgs[1] = {&iocLogShowArg0};
-static const iocshFuncDef iocLogShowFuncDef = {"iocLogShow",1,iocLogShowArgs};
+static const iocshFuncDef iocLogShowFuncDef = {"iocLogShow",1,iocLogShowArgs,
+                                               "Determine if a IOC Log Prefix has been set\n"};
 static void iocLogShowCallFunc(const iocshArgBuf *args)
 {
     iocLogShow (args[0].ival);
@@ -203,17 +218,22 @@ static void iocLogShowCallFunc(const iocshArgBuf *args)
 /* eltc */
 static const iocshArg eltcArg0 = {"(0,1)=>(false,true)",iocshArgInt};
 static const iocshArg * const eltcArgs[1] = {&eltcArg0};
-static const iocshFuncDef eltcFuncDef = {"eltc",1,eltcArgs};
+static const iocshFuncDef eltcFuncDef = {"eltc",1,eltcArgs,
+                                         "Control display of error log messages on console\n"
+                                         "  0 - no\n"
+                                         "  1 - yes (default)\n"};
 static void eltcCallFunc(const iocshArgBuf *args)
 {
     eltc(args[0].ival);
 }
 
 /* errlogInit */
-static const iocshArg errlogInitArg0 = { "bufsize",iocshArgInt};
+static const iocshArg errlogInitArg0 = { "bufSize",iocshArgInt};
 static const iocshArg * const errlogInitArgs[1] = {&errlogInitArg0};
 static const iocshFuncDef errlogInitFuncDef =
-    {"errlogInit",1,errlogInitArgs};
+    {"errlogInit",1,errlogInitArgs,
+     "Initialize error log client buffer size\n"
+     "  bufSize - size of circular buffer (default = 1280 bytes)\n"};
 static void errlogInitCallFunc(const iocshArgBuf *args)
 {
     errlogInit(args[0].ival);
@@ -225,7 +245,10 @@ static const iocshArg errlogInit2Arg1 = { "maxMsgSize",iocshArgInt};
 static const iocshArg * const errlogInit2Args[] =
     {&errlogInit2Arg0, &errlogInit2Arg1};
 static const iocshFuncDef errlogInit2FuncDef =
-    {"errlogInit2", 2, errlogInit2Args};
+    {"errlogInit2", 2, errlogInit2Args,
+     "Initialize error log client buffer size and maximum message size\n"
+     "  bufSize    - size of circular buffer       (default = 1280 bytes)\n"
+     "  maxMsgSize - maximum size of error message (default =  256 bytes)\n"};
 static void errlogInit2CallFunc(const iocshArgBuf *args)
 {
     errlogInit2(args[0].ival, args[1].ival);
@@ -239,7 +262,8 @@ IOCSH_STATIC_FUNC void errlog(const char *message)
 
 static const iocshArg errlogArg0 = { "message",iocshArgString};
 static const iocshArg * const errlogArgs[1] = {&errlogArg0};
-static const iocshFuncDef errlogFuncDef = {"errlog",1,errlogArgs};
+static const iocshFuncDef errlogFuncDef = {"errlog",1,errlogArgs,
+                                           "Send message to errlog\n"};
 static void errlogCallFunc(const iocshArgBuf *args)
 {
     errlog(args[0].sval);
@@ -249,7 +273,8 @@ static void errlogCallFunc(const iocshArgBuf *args)
 /* iocLogPrefix */
 static const iocshArg iocLogPrefixArg0 = { "prefix",iocshArgString};
 static const iocshArg * const iocLogPrefixArgs[1] = {&iocLogPrefixArg0};
-static const iocshFuncDef iocLogPrefixFuncDef = {"iocLogPrefix",1,iocLogPrefixArgs};
+static const iocshFuncDef iocLogPrefixFuncDef = {"iocLogPrefix",1,iocLogPrefixArgs,
+                                                 "Create the prefix for all messages going into IOC log\n"};
 static void iocLogPrefixCallFunc(const iocshArgBuf *args)
 {
     iocLogPrefix(args[0].sval);
@@ -259,7 +284,8 @@ static void iocLogPrefixCallFunc(const iocshArgBuf *args)
 static const iocshArg epicsThreadShowAllArg0 = { "level",iocshArgInt};
 static const iocshArg * const epicsThreadShowAllArgs[1] = {&epicsThreadShowAllArg0};
 static const iocshFuncDef epicsThreadShowAllFuncDef =
-    {"epicsThreadShowAll",1,epicsThreadShowAllArgs};
+    {"epicsThreadShowAll",1,epicsThreadShowAllArgs,
+     "Display info about all threads\n"};
 static void epicsThreadShowAllCallFunc(const iocshArgBuf *args)
 {
     epicsThreadShowAll(args[0].ival);
@@ -268,7 +294,8 @@ static void epicsThreadShowAllCallFunc(const iocshArgBuf *args)
 /* epicsThreadShow */
 static const iocshArg threadArg0 = { "[-level] [thread ...]", iocshArgArgv};
 static const iocshArg * const threadArgs[1] = { &threadArg0 };
-static const iocshFuncDef threadFuncDef = {"epicsThreadShow",1,threadArgs};
+static const iocshFuncDef threadFuncDef = {"epicsThreadShow",1,threadArgs,
+                                           "Display info about the specified thread\n"};
 static void threadCallFunc(const iocshArgBuf *args)
 {
     int i = 1;
@@ -314,7 +341,8 @@ static void threadCallFunc(const iocshArgBuf *args)
 static const iocshArg taskwdShowArg0 = { "level",iocshArgInt};
 static const iocshArg * const taskwdShowArgs[1] = {&taskwdShowArg0};
 static const iocshFuncDef taskwdShowFuncDef =
-    {"taskwdShow",1,taskwdShowArgs};
+    {"taskwdShow",1,taskwdShowArgs,
+     "Show number of tasks and monitors registered\n"};
 static void taskwdShowCallFunc(const iocshArgBuf *args)
 {
     taskwdShow(args[0].ival);

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -46,7 +46,9 @@ void date(const char *format)
 
 static const iocshArg dateArg0 = { "format",iocshArgString};
 static const iocshArg * const dateArgs[] = {&dateArg0};
-static const iocshFuncDef dateFuncDef = {"date", 1, dateArgs};
+static const iocshFuncDef dateFuncDef = {"date", 1, dateArgs,
+                                         "Print current date and time\n"
+                                         "  (default) - '%Y/%m/%d %H:%M:%S.%06f'\n"};
 static void dateCallFunc (const iocshArgBuf *args)
 {
     date(args[0].sval);
@@ -64,7 +66,8 @@ IOCSH_STATIC_FUNC void echo(char* str)
 
 static const iocshArg echoArg0 = { "string",iocshArgString};
 static const iocshArg * const echoArgs[1] = {&echoArg0};
-static const iocshFuncDef echoFuncDef = {"echo",1,echoArgs};
+static const iocshFuncDef echoFuncDef = {"echo",1,echoArgs,
+                                         "Print any string (can aslo print EPICS environment variables)\n"};
 static void echoCallFunc(const iocshArgBuf *args)
 {
     echo(args[0].sval);
@@ -73,7 +76,8 @@ static void echoCallFunc(const iocshArgBuf *args)
 /* chdir */
 static const iocshArg chdirArg0 = { "directory name",iocshArgString};
 static const iocshArg * const chdirArgs[1] = {&chdirArg0};
-static const iocshFuncDef chdirFuncDef = {"cd",1,chdirArgs};
+static const iocshFuncDef chdirFuncDef = {"cd",1,chdirArgs,
+                                          "Change directory to new directory provided as parameter\n"};
 static void chdirCallFunc(const iocshArgBuf *args)
 {
     if (args[0].sval == NULL ||

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -354,7 +354,10 @@ static const iocshArg epicsMutexShowAllArg1 = { "level",iocshArgInt};
 static const iocshArg * const epicsMutexShowAllArgs[2] =
     {&epicsMutexShowAllArg0,&epicsMutexShowAllArg1};
 static const iocshFuncDef epicsMutexShowAllFuncDef =
-    {"epicsMutexShowAll",2,epicsMutexShowAllArgs};
+    {"epicsMutexShowAll",2,epicsMutexShowAllArgs,
+     "Display information about all epicsMutex semaphores\n"
+     "  onlyLocked - non-zero to show only locked semaphores\n"
+     "  level      - desired information level to report\n"};
 static void epicsMutexShowAllCallFunc(const iocshArgBuf *args)
 {
     epicsMutexShowAll(args[0].ival,args[1].ival);
@@ -364,7 +367,8 @@ static void epicsMutexShowAllCallFunc(const iocshArgBuf *args)
 static const iocshArg epicsThreadSleepArg0 = { "seconds",iocshArgDouble};
 static const iocshArg * const epicsThreadSleepArgs[1] = {&epicsThreadSleepArg0};
 static const iocshFuncDef epicsThreadSleepFuncDef =
-    {"epicsThreadSleep",1,epicsThreadSleepArgs};
+    {"epicsThreadSleep",1,epicsThreadSleepArgs,
+     "Pause execution of IOC shell for <seconds> seconds\n"};
 static void epicsThreadSleepCallFunc(const iocshArgBuf *args)
 {
     epicsThreadSleep(args[0].dval);
@@ -373,7 +377,10 @@ static void epicsThreadSleepCallFunc(const iocshArgBuf *args)
 /* epicsThreadResume */
 static const iocshArg epicsThreadResumeArg0 = { "[thread ...]", iocshArgArgv};
 static const iocshArg * const epicsThreadResumeArgs[1] = { &epicsThreadResumeArg0 };
-static const iocshFuncDef epicsThreadResumeFuncDef = {"epicsThreadResume",1,epicsThreadResumeArgs};
+static const iocshFuncDef epicsThreadResumeFuncDef = {"epicsThreadResume",1,epicsThreadResumeArgs,
+                                                      "Resume a suspended thread.\n"
+                                                      "Only do this if you know that it is safe to "
+                                                      "resume a suspended thread\n"};
 static void epicsThreadResumeCallFunc(const iocshArgBuf *args)
 {
     int i;
@@ -415,14 +422,19 @@ static void epicsThreadResumeCallFunc(const iocshArgBuf *args)
 /* generalTimeReport */
 static const iocshArg generalTimeReportArg0 = { "interest_level", iocshArgArgv};
 static const iocshArg * const generalTimeReportArgs[1] = { &generalTimeReportArg0 };
-static const iocshFuncDef generalTimeReportFuncDef = {"generalTimeReport",1,generalTimeReportArgs};
+static const iocshFuncDef generalTimeReportFuncDef = {"generalTimeReport",1,generalTimeReportArgs,
+                                                      "Display time providers and their priority levels"
+                                                      " for current and event times\n"};
 static void generalTimeReportCallFunc(const iocshArgBuf *args)
 {
     generalTimeReport(args[0].ival);
 }
 
 /* installLastResortEventProvider */
-static const iocshFuncDef installLastResortEventProviderFuncDef = {"installLastResortEventProvider", 0, NULL};
+static const iocshFuncDef installLastResortEventProviderFuncDef = {"installLastResortEventProvider", 0, NULL,
+                                                                   "Installs the optional Last Resort event provider"
+                                                                   " at priority 999,\nwhich returns the current time"
+                                                                   " for every event number\n"};
 static void installLastResortEventProviderCallFunc(const iocshArgBuf *args)
 {
     installLastResortEventProvider();

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -87,7 +87,8 @@ static void chdirCallFunc(const iocshArgBuf *args)
 }
 
 /* print current working directory */
-static const iocshFuncDef pwdFuncDef = { "pwd", 0, 0 };
+static const iocshFuncDef pwdFuncDef = {"pwd", 0, 0,
+                                        "Print name of current/working directory\n"};
 static void pwdCallFunc (const iocshArgBuf *args)
 {
     char buf[256];
@@ -101,7 +102,8 @@ static void pwdCallFunc (const iocshArgBuf *args)
 static const iocshArg epicsEnvSetArg0 = { "name",iocshArgString};
 static const iocshArg epicsEnvSetArg1 = { "value",iocshArgString};
 static const iocshArg * const epicsEnvSetArgs[2] = {&epicsEnvSetArg0,&epicsEnvSetArg1};
-static const iocshFuncDef epicsEnvSetFuncDef = {"epicsEnvSet",2,epicsEnvSetArgs};
+static const iocshFuncDef epicsEnvSetFuncDef = {"epicsEnvSet",2,epicsEnvSetArgs,
+                                                "Set environment variable name to value\n"};
 static void epicsEnvSetCallFunc(const iocshArgBuf *args)
 {
     char *name = args[0].sval;

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -67,7 +67,7 @@ IOCSH_STATIC_FUNC void echo(char* str)
 static const iocshArg echoArg0 = { "string",iocshArgString};
 static const iocshArg * const echoArgs[1] = {&echoArg0};
 static const iocshFuncDef echoFuncDef = {"echo",1,echoArgs,
-                                         "Print any string (can aslo print EPICS environment variables)\n"};
+                                         "Print string after expanding macros and environment variables\n"};
 static void echoCallFunc(const iocshArgBuf *args)
 {
     echo(args[0].sval);

--- a/modules/libcom/src/osi/osiClockTime.c
+++ b/modules/libcom/src/osi/osiClockTime.c
@@ -58,14 +58,26 @@ static void ClockTimeSync(void *dummy);
 /* ClockTime_Report iocsh command */
 static const iocshArg ReportArg0 = { "interest_level", iocshArgArgv};
 static const iocshArg * const ReportArgs[1] = { &ReportArg0 };
-static const iocshFuncDef ReportFuncDef = {"ClockTime_Report", 1, ReportArgs};
+static const iocshFuncDef ReportFuncDef = {"ClockTime_Report", 1, ReportArgs,
+                                           "Reports clock synchronization status:\n"
+                                           "  - On vxWorks and RTEMS:\n"
+                                           "      * synchronization state\n"
+                                           "      * last synchronization time with provider\n"
+                                           "      * synchronization interval\n"
+                                           "  - On workstation (WIN,*NIX):\n"
+                                           "      * minimal report\n"};
 static void ReportCallFunc(const iocshArgBuf *args)
 {
     ClockTime_Report(args[0].ival);
 }
 
 /* ClockTime_Shutdown iocsh command */
-static const iocshFuncDef ShutdownFuncDef = {"ClockTime_Shutdown", 0, NULL};
+static const iocshFuncDef ShutdownFuncDef = {"ClockTime_Shutdown", 0, NULL,
+                                             "Stops the OS synchronization thread\n"
+                                             "  - On vxWorks and RTEMS:\n"
+                                             "     * OS clock will free run\n"
+                                             "  - On workstation (WIN,*NIX):\n"
+                                             "     * no change\n"};
 static void ShutdownCallFunc(const iocshArgBuf *args)
 {
     ClockTime_Shutdown(NULL);

--- a/modules/libcom/src/osi/osiNTPTime.c
+++ b/modules/libcom/src/osi/osiNTPTime.c
@@ -64,14 +64,21 @@ static void NTPTimeSync(void *dummy);
 /* NTPTime_Report iocsh command */
 static const iocshArg ReportArg0 = { "interest_level", iocshArgArgv};
 static const iocshArg * const ReportArgs[1] = { &ReportArg0 };
-static const iocshFuncDef ReportFuncDef = {"NTPTime_Report", 1, ReportArgs};
+static const iocshFuncDef ReportFuncDef = {"NTPTime_Report", 1, ReportArgs,
+                                           "Display time provider synchronization state\n"
+                                           "  interest_level - with level 1 it also shows:\n"
+                                           "                    * synchronization interval\n"
+                                           "                    * time when last synchronized\n"
+                                           "                    * nominal and measured system tick rates\n"
+                                           "                    * server address (vxWorks only)\n"};
 static void ReportCallFunc(const iocshArgBuf *args)
 {
     NTPTime_Report(args[0].ival);
 }
 
 /* NTPTime_Shutdown iocsh command */
-static const iocshFuncDef ShutdownFuncDef = {"NTPTime_Shutdown", 0, NULL};
+static const iocshFuncDef ShutdownFuncDef = {"NTPTime_Shutdown", 0, NULL,
+                                             "Shuts down NTP time synchronization thread\n"};
 static void ShutdownCallFunc(const iocshArgBuf *args)
 {
     NTPTime_Shutdown(NULL);


### PR DESCRIPTION
Hi,

This is a pull request for the changes to iocSh help done during the EPICS code-a-thon March 2021 done by me
(there is a [pull request](https://github.com/epics-base/epics-base/pull/136) by @oksanagit and I believe there is one incoming from @ebernalru)

Below is a list of functions implemented in this pull request (information mostly gathered from AppDevGuide and some from source code or behavioir on `iocsh`) .

Please review and comment: 

**NOTES:**
`[OK]` - happy with solution OK (copy paste from AppDevGuide)
`[OK*]` - should be OK, but please check 
`[PART]` - documented to the best of my knowledge/understanding, please review and comment

---

```
[OK*]   modules/database/src/ioc/rsrv/rsrvIocRegister.c casr

[PART]  modules/database/src/ioc/as/asIocRegister.c     asDumpHash

[PART]  modules/libcom/src/osi/osiNTPTime.c             Report
[PART]  modules/libcom/src/osi/osiNTPTime.c             Shutdown
[PART]  modules/libcom/src/osi/osiClockTime.c           Report
[PART]  modules/libcom/src/osi/osiClockTime.c           Shutdown

[OK]    modules/libcom/src/iocsh/iocsh.cpp              var
[OK]    modules/libcom/src/iocsh/iocsh.cpp              help
[OK]    modules/libcom/src/iocsh/iocsh.cpp              iocshCmd
[PART]  modules/libcom/src/iocsh/iocsh.cpp              iocshLoad
[OK]    modules/libcom/src/iocsh/iocsh.cpp              iocshRun
[OK]    modules/libcom/src/iocsh/iocsh.cpp              on
[OK]    modules/libcom/src/iocsh/iocsh.cpp              comment

[OK]    modules/libcom/src/iocsh/libComRegister.c       date
[OK]    modules/libcom/src/iocsh/libComRegister.c       echo
[OK]    modules/libcom/src/iocsh/libComRegister.c       chdir
[OK]    modules/libcom/src/iocsh/libComRegister.c       pwd
[OK]    modules/libcom/src/iocsh/libComRegister.c       epicsEnvSet
[OK]    modules/libcom/src/iocsh/libComRegister.c       epicsEnvUnset
[OK]    modules/libcom/src/iocsh/libComRegister.c       epicsParamShow
[OK]    modules/libcom/src/iocsh/libComRegister.c       epicsPrtEnvParams
[OK]    modules/libcom/src/iocsh/libComRegister.c       epicsEnvShow
[PART]  modules/libcom/src/iocsh/libComRegister.c       registryDump
[OK]    modules/libcom/src/iocsh/libComRegister.c       iocLogInit
[OK]    modules/libcom/src/iocsh/libComRegister.c       iocLogDisable
[PART]  modules/libcom/src/iocsh/libComRegister.c       iocLogShow
[OK]    modules/libcom/src/iocsh/libComRegister.c       eltc
[OK]    modules/libcom/src/iocsh/libComRegister.c       errlogInit
[OK]    modules/libcom/src/iocsh/libComRegister.c       errlogInit2
[OK]    modules/libcom/src/iocsh/libComRegister.c       errlog
[OK]    modules/libcom/src/iocsh/libComRegister.c       iocLogPrefix
[OK]    modules/libcom/src/iocsh/libComRegister.c       epicsThreadShowAll
[OK]    modules/libcom/src/iocsh/libComRegister.c       thread
[PART]  modules/libcom/src/iocsh/libComRegister.c       taskwdShow
[OK]    modules/libcom/src/iocsh/libComRegister.c       epicsMutexShowAll
[OK]    modules/libcom/src/iocsh/libComRegister.c       epicsThreadSleep
[OK]    modules/libcom/src/iocsh/libComRegister.c       epicsThreadResume
[OK]    modules/libcom/src/iocsh/libComRegister.c       generalTimeReport
[OK]    modules/libcom/src/iocsh/libComRegister.c       installLastResortEventProvider
```