### PR TITLE
Timer improvements

### DIFF
--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -188,7 +188,9 @@ RES=.res
 
 # MS Visual C++ doesn't recognize *.cc as a C++ source file,
 # so C++ compiles get the flag -TP
-COMPILER_CXXFLAGS = -TP
+# We want MSVC to report a reasonable C++ version in the __cplusplus macro so
+# we need to set -Zc:__cplusplus (this is at least required for MSVC 19.xx).
+COMPILER_CXXFLAGS = -TP -Zc:__cplusplus
 
 # Operating system flags
 OP_SYS_CFLAGS =

--- a/modules/libcom/src/osi/Makefile
+++ b/modules/libcom/src/osi/Makefile
@@ -39,6 +39,7 @@ INC += epicsGeneralTime.h
 INC += osdTime.h
 INC += generalTimeSup.h
 INC += osiClockTime.h
+INC += osdTimer.h
 INC += epicsSignal.h
 INC += osiProcess.h
 INC += osiUnistd.h

--- a/modules/libcom/src/osi/os/Linux/osdTimer.h
+++ b/modules/libcom/src/osi/os/Linux/osdTimer.h
@@ -1,0 +1,14 @@
+/*************************************************************************\
+* Copyright (c) 2021 Facility for Rare Isotope Beams
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef osdTimerh
+#define osdTimerh
+
+/* Linux supports high-precision timers (in contrast to quantized timers which
+ * only support sleeping for a multiple of the quantum). */
+#define HAS_HIGH_PREC_TIMERS
+
+#endif /* osdTimerh */

--- a/modules/libcom/src/osi/os/WIN32/osdEvent.c
+++ b/modules/libcom/src/osi/os/WIN32/osdEvent.c
@@ -26,6 +26,8 @@
 #include "libComAPI.h"
 #include "epicsEvent.h"
 
+#include "osdThreadPvt.h"
+
 typedef struct epicsEventOSD {
     HANDLE handle;
 } epicsEventOSD;
@@ -83,8 +85,6 @@ LIBCOM_API epicsEventStatus epicsEventWait ( epicsEventId pSem )
         return epicsEventError;
     }
 }
-
-extern HANDLE osdThreadGetTimer(void); /* from osdThread.c */
 
 /*
  * epicsEventWaitWithTimeout ()

--- a/modules/libcom/src/osi/os/WIN32/osdEvent.c
+++ b/modules/libcom/src/osi/os/WIN32/osdEvent.c
@@ -84,36 +84,49 @@ LIBCOM_API epicsEventStatus epicsEventWait ( epicsEventId pSem )
     }
 }
 
+extern HANDLE osdThreadGetTimer();
+
 /*
  * epicsEventWaitWithTimeout ()
  */
 LIBCOM_API epicsEventStatus epicsEventWaitWithTimeout (
     epicsEventId pSem, double timeOut )
 {
-    static const unsigned mSecPerSec = 1000;
+    static const unsigned nSec100PerSec = 10000000;
+    HANDLE handles[2];
     DWORD status;
-    DWORD tmo;
+    LARGE_INTEGER tmo;
+    HANDLE timer;
 
     if ( timeOut <= 0.0 ) {
-        tmo = 0u;
-    }
-    else if ( timeOut >= INFINITE / mSecPerSec ) {
-        tmo = INFINITE - 1;
+        tmo.QuadPart = 0u;
     }
     else {
-        tmo = ( DWORD ) ( ( timeOut * mSecPerSec ) + 0.5 );
-        if ( tmo == 0 ) {
-            tmo = 1;
-        }
+        tmo.QuadPart = -((LONGLONG)(timeOut * nSec100PerSec + 0.5));  // +0.99999999 ?
     }
-    status = WaitForSingleObject ( pSem->handle, tmo );
+
+    if (tmo.QuadPart < 0) {
+        timer = osdThreadGetTimer();
+        if (!SetWaitableTimer(timer, &tmo, 0, NULL, NULL, 0))
+        {
+            printf("event error %d\n", GetLastError());
+            return epicsEventError;
+        }
+        handles[0] = pSem->handle;
+        handles[1] = timer;
+        status = WaitForMultipleObjects (2, handles, FALSE, INFINITE);
+    }
+    else {
+        status = WaitForSingleObject(pSem->handle, 0);
+    }
     if ( status == WAIT_OBJECT_0 ) {
         return epicsEventOK;
     }
-    else if ( status == WAIT_TIMEOUT ) {
+    else if ( status == WAIT_OBJECT_0 + 1 || status == WAIT_TIMEOUT ) {
         return epicsEventWaitTimeout;
     }
     else {
+        printf("event error %d\n", GetLastError());
         return epicsEventError;
     }
 }

--- a/modules/libcom/src/osi/os/WIN32/osdTimer.h
+++ b/modules/libcom/src/osi/os/WIN32/osdTimer.h
@@ -1,0 +1,14 @@
+/*************************************************************************\
+* Copyright (c) 2021 Facility for Rare Isotope Beams
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef osdTimerh
+#define osdTimerh
+
+/* Windows supports high-precision timers (in contrast to quantized timers
+ * which only support sleeping for a multiple of the quantum). */
+#define HAS_HIGH_PREC_TIMERS
+
+#endif /* osdTimerh */

--- a/modules/libcom/src/osi/os/default/osdThreadPvt.h
+++ b/modules/libcom/src/osi/os/default/osdThreadPvt.h
@@ -1,0 +1,14 @@
+#ifndef osdThreadPvth
+#define osdThreadPvth
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern HANDLE osdThreadGetTimer(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* osdThreadPvth */

--- a/modules/libcom/src/osi/os/default/osdTimer.h
+++ b/modules/libcom/src/osi/os/default/osdTimer.h
@@ -1,0 +1,12 @@
+/*************************************************************************\
+* Copyright (c) 2021 Facility for Rare Isotope Beams
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef osdTimerh
+#define osdTimerh
+
+/* For systems other than Linux we do not define HAS_HIGH_PREC_TIMERS. */
+
+#endif /* osdTimerh */

--- a/modules/libcom/src/timer/epicsTimer.h
+++ b/modules/libcom/src/timer/epicsTimer.h
@@ -19,6 +19,7 @@
 #include "libComAPI.h"
 #include "epicsTime.h"
 #include "epicsThread.h"
+#include "osdTimer.h"
 
 #ifdef __cplusplus
 

--- a/modules/libcom/src/timer/timer.cpp
+++ b/modules/libcom/src/timer/timer.cpp
@@ -20,6 +20,7 @@
 #include <stdio.h>
 
 #include "epicsGuard.h"
+#include "osdTimer.h"
 #include "timerPrivate.h"
 #include "errlog.h"
 
@@ -65,7 +66,11 @@ void timer::start ( epicsTimerNotify & notify, const epicsTime & expire )
 void timer::privateStart ( epicsTimerNotify & notify, const epicsTime & expire )
 {
     this->pNotify = & notify;
+#ifdef HAS_HIGH_PREC_TIMERS
+    this->exp = expire;
+#else
     this->exp = expire - ( this->queue.notify.quantum () / 2.0 );
+# endif
 
     bool reschedualNeeded = false;
     if ( this->curState == stateActive ) {

--- a/modules/libcom/test/epicsEventTest.cpp
+++ b/modules/libcom/test/epicsEventTest.cpp
@@ -172,7 +172,7 @@ static double eventWaitCheckDelayError( const epicsEventId &id, const double & d
 #define WAITCOUNT 21
 static void eventWaitTest()
 {
-#if defined(_WIN32) || defined(__rtems__) || defined(vxWorks)
+#if defined(__rtems__) || defined(vxWorks)
     testTodoBegin("Known issue with delay calculation");
 #endif
 
@@ -184,7 +184,7 @@ static void eventWaitTest()
         errorSum += eventWaitCheckDelayError ( event, delay );
     }
     double meanError = errorSum / WAITCOUNT;
-    testOk(meanError < 0.05, "Mean delay error was %.6f sec", meanError);
+    testOk(testImpreciseTiming() || meanError < 0.05, "Mean delay error was %.6f sec", meanError);
 
     testTodoEnd();
 

--- a/modules/libcom/test/epicsTimerTest.cpp
+++ b/modules/libcom/test/epicsTimerTest.cpp
@@ -37,7 +37,11 @@
     epicsAssert(__FILE__, __LINE__, #exp, epicsAssertAuthor))
 
 #if __cplusplus >= 201103L
+#ifdef HAS_HIGH_PREC_TIMERS
+const double timeTolerance { 1e-3 };
+#else
 const double timeTolerance { 1e-3 + epicsThreadSleepQuantum() };
+#endif
 
 class handler : public epicsTimerNotify
 {

--- a/modules/libcom/test/epicsTimerTest.cpp
+++ b/modules/libcom/test/epicsTimerTest.cpp
@@ -65,12 +65,12 @@ private:
   std::function<void()> expireFct;
 };
 
-void verifyExpirationTime(double delta_t, double tolerance) {
-  if (!testOk(std::abs(delta_t) < tolerance, "timer expired at the expected "
-              "time (error = %f ms, tolerance = +/-%f ms)", 1000.0 * delta_t,
-              1000.0 * tolerance)) {
-    const char * msg = delta_t < 0.0 ? "early" : "late";
-    testDiag("delta t = %g ms (timer expired too %s)", 1000.0 * delta_t, msg);
+void verifyExpirationTime(double delta, double tolerance) {
+  if (!testOk(delta >= 0.0 && delta < tolerance, "timer expired at the expected"
+              " time (error = %f ms, tolerance = +%f/-0.0 ms)",
+              1000.0 * delta, 1000.0 * tolerance)) {
+    const char * msg = delta < 0.0 ? "early" : "late";
+    testDiag("delta t = %g ms (timer expired too %s)", 1000.0 * delta, msg);
   }
 }
 

--- a/modules/libcom/test/epicsTimerTest.cpp
+++ b/modules/libcom/test/epicsTimerTest.cpp
@@ -70,9 +70,9 @@ private:
 };
 
 void verifyExpirationTime(double delta, double tolerance) {
-  if (!testOk(delta >= 0.0 && delta < tolerance, "timer expired at the expected"
-              " time (error = %f ms, tolerance = +%f/-0.0 ms)",
-              1000.0 * delta, 1000.0 * tolerance)) {
+  if (!testOk(delta >= 0.0 && (testImpreciseTiming() || delta < tolerance),
+              "timer expired at the expected time (error = %f ms, "
+              "tolerance = +%f/-0.0 ms)", 1000.0 * delta, 1000.0 * tolerance)) {
     const char * msg = delta < 0.0 ? "early" : "late";
     testDiag("delta t = %g ms (timer expired too %s)", 1000.0 * delta, msg);
   }

--- a/modules/libcom/test/epicsTimerTest.cpp
+++ b/modules/libcom/test/epicsTimerTest.cpp
@@ -1,4 +1,5 @@
 /*************************************************************************\
+* Copyright (c) 2021 Facility for Rare Isotope Beams.
 * Copyright (c) 2006 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
@@ -16,6 +17,13 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#if __cplusplus >= 201103L
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <functional>
+#include <atomic>
+#endif
 
 #include "epicsTimer.h"
 #include "epicsEvent.h"
@@ -27,6 +35,154 @@
 
 #define verify(exp) ((exp) ? (void)0 : \
     epicsAssert(__FILE__, __LINE__, #exp, epicsAssertAuthor))
+
+#if __cplusplus >= 201103L
+const double timeTolerance { 1e-3 + epicsThreadSleepQuantum() };
+
+class handler : public epicsTimerNotify
+{
+public:
+  handler(epicsTimerQueue& queue, std::function<void()> expireFctIn = [] {}) : timer(queue.createTimer()), expireFct(expireFctIn) {}
+  ~handler() { timer.destroy(); }
+  void start(double delay) {
+    startTime = epicsTime::getCurrent();
+    timer.start(*this, delay);
+  }
+  void cancel() { timer.cancel(); }
+  expireStatus expire(const epicsTime& currentTime) {
+    expireTime = epicsTime::getCurrent();
+    expireCount++;
+    expireFct();
+    return expireStatus(noRestart);
+  }
+  int getExpireCount() const { return expireCount; }
+  double getDelay() const { return expireTime - startTime; }
+private:
+  epicsTimer &timer;
+  int expireCount { 0 };
+  epicsTime startTime;
+  epicsTime expireTime;
+  std::function<void()> expireFct;
+};
+
+void verifyExpirationTime(double delta_t, double tolerance) {
+  if (!testOk(std::abs(delta_t) < tolerance, "timer expired at the expected "
+              "time (error = %f ms, tolerance = +/-%f ms)", 1000.0 * delta_t,
+              1000.0 * tolerance)) {
+    const char * msg = delta_t < 0.0 ? "early" : "late";
+    testDiag("delta t = %g ms (timer expired too %s)", 1000.0 * delta_t, msg);
+  }
+}
+
+void testTimerExpires() {
+  testDiag("Timer expires");
+  epicsTimerQueueActive &queue = epicsTimerQueueActive::allocate(false);
+  {
+    epicsEvent waitForExpire;
+    handler h1(queue, [&] { waitForExpire.trigger(); } );
+    const double arbitrary_time { 0.3 };
+    h1.start(arbitrary_time);
+
+    waitForExpire.wait();
+
+    verifyExpirationTime(h1.getDelay() - arbitrary_time, timeTolerance);
+  } // destroy timer
+  queue.release();
+}
+
+void testMultipleTimersExpire(std::vector<double> && sleepTime) {
+  epicsTimerQueueActive &queue = epicsTimerQueueActive::allocate(false);
+  {
+    std::atomic<int> count { 3 };
+    epicsEvent all_timers_expired;
+    std::vector<handler> hv;
+    hv.reserve(3);
+    for (unsigned i = 0; i < 3; i++) {
+      hv.emplace_back(queue, [&] {
+        if (!--count) { all_timers_expired.trigger(); }
+      });
+    }
+    for (unsigned i = 0; i < hv.size(); i++) {
+      hv[i].start(sleepTime[i]);
+    }
+
+    all_timers_expired.wait();
+
+    for (unsigned i = 0; i < hv.size(); i++) {
+      testOk(hv[i].getExpireCount() == 1, "timer expired exactly once");
+      verifyExpirationTime(hv[i].getDelay() - sleepTime[i], timeTolerance);
+    }
+  } // destroy timers
+  queue.release();
+}
+
+void testMultipleTimersExpireFirstTimerExpiresFirst() {
+  testDiag("Multiple timers expire - first timer expires first");
+  testMultipleTimersExpire({ 1.0, 1.2, 1.1 });
+}
+
+void testMultipleTimersExpireLastTimerExpiresFirst() {
+  testDiag("Multiple timers expire - last timer expires first");
+  testMultipleTimersExpire({ 1.1, 1.2, 1.0 });
+}
+
+void testTimerReschedule() {
+  testDiag("Reschedule timer");
+  epicsTimerQueueActive &queue = epicsTimerQueueActive::allocate(false);
+  {
+    epicsEvent waitForExpire;
+    handler h1(queue, [&] { waitForExpire.trigger(); } );
+    double arbitrary_time { 10.0 };
+    h1.start(arbitrary_time);
+    arbitrary_time = 0.3;
+    h1.start(arbitrary_time);
+
+    waitForExpire.wait();
+
+    verifyExpirationTime(h1.getDelay() - arbitrary_time, timeTolerance);
+  } // destroy timer
+  queue.release();
+}
+
+void testCancelTimer() {
+  testDiag("Cancel timer");
+  epicsTimerQueueActive &queue = epicsTimerQueueActive::allocate(false);
+  {
+    handler h1(queue);
+    h1.start(0.1);
+    h1.cancel();
+
+    epicsThreadSleep(0.2);
+
+    testOk(h1.getExpireCount() == 0, "timer expired exactly 0 times");
+  } // destroy timer
+  queue.release();
+}
+
+void testCancelTimerWhileExpireIsRunning() {
+  testDiag("Cancel timer while expire handler is running");
+  epicsTimerQueueActive &queue = epicsTimerQueueActive::allocate(false);
+  {
+    epicsEvent expireStarted;
+    std::atomic_flag endOfExpireReached = ATOMIC_FLAG_INIT;
+    auto longRunningFct = [&] {
+      expireStarted.trigger();
+      epicsThreadSleep(0.1);
+      endOfExpireReached.test_and_set();
+    };
+    handler h1(queue, longRunningFct);
+    h1.start(0.0);
+    expireStarted.wait(); // wait for expire() to be called
+
+    h1.cancel(); // cancel while expire() is running
+    bool cancelBlocked = endOfExpireReached.test_and_set();
+
+    testOk(h1.getExpireCount() == 1, "timer expired exactly once");
+    testOk(cancelBlocked, "cancel() blocks until all expire() calls are finished");
+  } // destroy timer
+  queue.release();
+}
+#endif
 
 class notified : public epicsTimerNotify
 {
@@ -40,6 +196,7 @@ public:
 
 void testRefCount()
 {
+    testDiag("Reference counting");
     notified action;
 
     epicsTimerQueueActive *Q1, *Q2;
@@ -456,7 +613,17 @@ void testPeriodic ()
 
 MAIN(epicsTimerTest)
 {
-    testPlan(41);
+    testPlan(58);
+#if __cplusplus >= 201103L
+    testTimerExpires();
+    testMultipleTimersExpireFirstTimerExpiresFirst();
+    testMultipleTimersExpireLastTimerExpiresFirst();
+    testTimerReschedule();
+    testCancelTimer();
+    testCancelTimerWhileExpireIsRunning();
+#else
+    testSkip(17, "Test requires a compiler which supports C++11");
+#endif
     testRefCount();
     testAccuracy ();
     testCancel ();


### PR DESCRIPTION
- Use high-resolution timers on WIN32 (waitable timers)
- Additional tests (in case the compiler is C++11 compatible)
- Fix a bug which often caused timers to expire half a quantum early on Linux and WIN32 (even if high-precision timers were used)

This PR fixes #106. It supersedes #107 and #108.