### PR TITLE
epicsUnitTest timeout

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,6 +53,7 @@ environment:
   SETUP_PATH: .ci-local:.ci
   BASE: SELF
   EPICS_TEST_IMPRECISE_TIMING: YES
+  EPICS_TEST_TIMEOUT: 720
 
   matrix:
   - CMP: vs2019

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -22,6 +22,7 @@ env:
     SETUP_PATH: .ci-local:.ci
     BASE: SELF
     EPICS_TEST_IMPRECISE_TIMING: YES
+    EPICS_TEST_TIMEOUT: 1200 # 20 min (RTEMS is slowest)
 
 jobs:
   build-base:


### PR DESCRIPTION
An external timeout like #146 seems to me a better solution.  So this change is redundant, and so may be unnecessary.