### PR TITLE
Use DBCORE_API

### DIFF
--- a/modules/database/src/ioc/as/asCa.c
+++ b/modules/database/src/ioc/as/asCa.c
@@ -33,7 +33,6 @@
 #include "caerr.h"
 #include "caeventmask.h"
 
-#define epicsExportSharedSymbols
 #include "asCa.h"
 #include "asDbLib.h"
 #include "callback.h"

--- a/modules/database/src/ioc/as/asCa.h
+++ b/modules/database/src/ioc/as/asCa.h
@@ -14,17 +14,17 @@
 
 #include <stdio.h>
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc void asCaStart(void);
-epicsShareFunc void asCaStop(void);
-epicsShareFunc int ascar(int level);
-epicsShareFunc int ascarFP(FILE *fp, int level);
-epicsShareFunc void ascaStats(int *pchans, int *pdiscon);
+DBCORE_API void asCaStart(void);
+DBCORE_API void asCaStop(void);
+DBCORE_API int ascar(int level);
+DBCORE_API int ascarFP(FILE *fp, int level);
+DBCORE_API void ascaStats(int *pchans, int *pdiscon);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/as/asDbLib.c
+++ b/modules/database/src/ioc/as/asDbLib.c
@@ -25,7 +25,6 @@
 
 #include "caeventmask.h"
 
-#define epicsExportSharedSymbols
 #include "asCa.h"
 #include "asDbLib.h"
 #include "callback.h"

--- a/modules/database/src/ioc/as/asDbLib.h
+++ b/modules/database/src/ioc/as/asDbLib.h
@@ -15,7 +15,7 @@
 #include <stdio.h>
 
 #include "callback.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 typedef struct {
     epicsCallback   callback;
@@ -28,25 +28,25 @@ struct dbChannel;
 extern "C" {
 #endif
 
-epicsShareFunc int asSetFilename(const char *acf);
-epicsShareFunc int asSetSubstitutions(const char *substitutions);
-epicsShareFunc int asInit(void);
-epicsShareFunc int asInitAsyn(ASDBCALLBACK *pcallback);
-epicsShareFunc int asShutdown(void);
-epicsShareFunc int asDbGetAsl(struct dbChannel *chan);
-epicsShareFunc void * asDbGetMemberPvt(struct dbChannel *chan);
-epicsShareFunc int asdbdump(void);
-epicsShareFunc int asdbdumpFP(FILE *fp);
-epicsShareFunc int aspuag(const char *uagname);
-epicsShareFunc int aspuagFP(FILE *fp,const char *uagname);
-epicsShareFunc int asphag(const char *hagname);
-epicsShareFunc int asphagFP(FILE *fp,const char *hagname);
-epicsShareFunc int asprules(const char *asgname);
-epicsShareFunc int asprulesFP(FILE *fp,const char *asgname);
-epicsShareFunc int aspmem(const char *asgname,int clients);
-epicsShareFunc int aspmemFP(
+DBCORE_API int asSetFilename(const char *acf);
+DBCORE_API int asSetSubstitutions(const char *substitutions);
+DBCORE_API int asInit(void);
+DBCORE_API int asInitAsyn(ASDBCALLBACK *pcallback);
+DBCORE_API int asShutdown(void);
+DBCORE_API int asDbGetAsl(struct dbChannel *chan);
+DBCORE_API void * asDbGetMemberPvt(struct dbChannel *chan);
+DBCORE_API int asdbdump(void);
+DBCORE_API int asdbdumpFP(FILE *fp);
+DBCORE_API int aspuag(const char *uagname);
+DBCORE_API int aspuagFP(FILE *fp,const char *uagname);
+DBCORE_API int asphag(const char *hagname);
+DBCORE_API int asphagFP(FILE *fp,const char *hagname);
+DBCORE_API int asprules(const char *asgname);
+DBCORE_API int asprulesFP(FILE *fp,const char *asgname);
+DBCORE_API int aspmem(const char *asgname,int clients);
+DBCORE_API int aspmemFP(
     FILE *fp,const char *asgname,int clients);
-epicsShareFunc int astac(
+DBCORE_API int astac(
     const char *recordname,const char *user,const char *location);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/as/asIocRegister.c
+++ b/modules/database/src/ioc/as/asIocRegister.c
@@ -11,7 +11,6 @@
 #include "asLib.h"
 #include "iocsh.h"
 
-#define epicsExportSharedSymbols
 #include "asCa.h"
 #include "asDbLib.h"
 #include "asIocRegister.h"

--- a/modules/database/src/ioc/as/asIocRegister.h
+++ b/modules/database/src/ioc/as/asIocRegister.h
@@ -11,13 +11,13 @@
 #ifndef INC_asIocRegister_H
 #define INC_asIocRegister_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc void asIocRegister(void);
+DBCORE_API void asIocRegister(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/bpt/cvtTable.h
+++ b/modules/database/src/ioc/bpt/cvtTable.h
@@ -17,17 +17,17 @@
 #ifndef INCcvtTableh
 #define INCcvtTableh    1
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Global Routines*/
-epicsShareFunc long cvtEngToRawBpt(
+DBCORE_API long cvtEngToRawBpt(
     double *pval,short linr,short init,void **ppbrk,short *plbrk);
 
-epicsShareFunc long cvtRawToEngBpt(
+DBCORE_API long cvtRawToEngBpt(
     double *pval,short linr,short init,void **ppbrk, short *plbrk);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/db/callback.c
+++ b/modules/database/src/ioc/db/callback.c
@@ -34,7 +34,6 @@
 #include "errMdef.h"
 #include "taskwd.h"
 
-#define epicsExportSharedSymbols
 #include "callback.h"
 #include "dbAccessDefs.h"
 #include "dbAddr.h"

--- a/modules/database/src/ioc/db/callback.h
+++ b/modules/database/src/ioc/db/callback.h
@@ -18,7 +18,7 @@
 #ifndef INCcallbackh
 #define INCcallbackh 1
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,23 +69,23 @@ typedef struct callbackQueueStats {
 #define callbackGetUser(USER, PCALLBACK) \
     ( (USER) = (PCALLBACK)->user )
 
-epicsShareFunc void callbackInit(void);
-epicsShareFunc void callbackStop(void);
-epicsShareFunc void callbackCleanup(void);
-epicsShareFunc int callbackRequest(epicsCallback *pCallback);
-epicsShareFunc void callbackSetProcess(
+DBCORE_API void callbackInit(void);
+DBCORE_API void callbackStop(void);
+DBCORE_API void callbackCleanup(void);
+DBCORE_API int callbackRequest(epicsCallback *pCallback);
+DBCORE_API void callbackSetProcess(
     epicsCallback *pcallback, int Priority, void *pRec);
-epicsShareFunc int callbackRequestProcessCallback(
+DBCORE_API int callbackRequestProcessCallback(
     epicsCallback *pCallback,int Priority, void *pRec);
-epicsShareFunc void callbackRequestDelayed(
+DBCORE_API void callbackRequestDelayed(
     epicsCallback *pCallback,double seconds);
-epicsShareFunc void callbackCancelDelayed(epicsCallback *pcallback);
-epicsShareFunc void callbackRequestProcessCallbackDelayed(
+DBCORE_API void callbackCancelDelayed(epicsCallback *pcallback);
+DBCORE_API void callbackRequestProcessCallbackDelayed(
     epicsCallback *pCallback, int Priority, void *pRec, double seconds);
-epicsShareFunc int callbackSetQueueSize(int size);
-epicsShareFunc int callbackQueueStatus(const int reset, callbackQueueStats *result);
-epicsShareFunc void callbackQueueShow(const int reset);
-epicsShareFunc int callbackParallelThreads(int count, const char *prio);
+DBCORE_API int callbackSetQueueSize(int size);
+DBCORE_API int callbackQueueStatus(const int reset, callbackQueueStats *result);
+DBCORE_API void callbackQueueShow(const int reset);
+DBCORE_API int callbackParallelThreads(int count, const char *prio);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/chfPlugin.c
+++ b/modules/database/src/ioc/db/chfPlugin.c
@@ -27,7 +27,6 @@
 #include "epicsTypes.h"
 #include "errlog.h"
 
-#define epicsExportSharedSymbols
 #include "chfPlugin.h"
 #include "dbStaticLib.h"
 

--- a/modules/database/src/ioc/db/chfPlugin.h
+++ b/modules/database/src/ioc/db/chfPlugin.h
@@ -17,7 +17,7 @@
 #ifndef CHFPLUGIN_H
 #define CHFPLUGIN_H
 
-#include <shareLib.h>
+#include <dbCoreAPI.h>
 #include <dbDefs.h>
 #include <epicsTypes.h>
 #include <dbChannel.h>
@@ -302,7 +302,7 @@ typedef struct chfPluginArgDef {
  * @param def String to be returned when 'i' isn't a valid Enum index.
  * @return The string associated with 'i'.
  */
-epicsShareFunc const char* chfPluginEnumString(const chfPluginEnumType *Enums, int i, const char* def);
+DBCORE_API const char* chfPluginEnumString(const chfPluginEnumType *Enums, int i, const char* def);
 
 /** @brief Register a plugin.
  *
@@ -310,7 +310,7 @@ epicsShareFunc const char* chfPluginEnumString(const chfPluginEnumType *Enums, i
  * @param pif Pointer to the plugin's interface.
  * @param opts Pointer to the configuration argument description table.
  */
-epicsShareFunc int chfPluginRegister(const char* key, const chfPluginIf *pif, const chfPluginArgDef* opts);
+DBCORE_API int chfPluginRegister(const char* key, const chfPluginIf *pif, const chfPluginArgDef* opts);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/cvtBpt.c
+++ b/modules/database/src/ioc/db/cvtBpt.c
@@ -17,7 +17,6 @@
 
 #include "epicsPrint.h"
 
-#define epicsExportSharedSymbols
 #include "cvtTable.h"
 #include "dbAccess.h"
 #include "dbBase.h"

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -35,7 +35,6 @@
 #include "errlog.h"
 #include "errMdef.h"
 
-#include "epicsExport.h" /* #define epicsExportSharedSymbols */
 #include "caeventmask.h"
 #include "callback.h"
 #include "dbAccessDefs.h"

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -61,6 +61,7 @@
 #include "recGbl.h"
 #include "recSup.h"
 #include "special.h"
+#include "epicsExport.h"
 
 struct dbBase *pdbbase = 0;
 volatile int interruptAccept=FALSE;

--- a/modules/database/src/ioc/db/dbAccess.h
+++ b/modules/database/src/ioc/db/dbAccess.h
@@ -18,7 +18,7 @@
 #include "dbFldTypes.h"
 #include "link.h"
 #include "dbBase.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 #include "dbAddr.h"
 #include "dbLock.h"
 #include "dbAccessDefs.h"

--- a/modules/database/src/ioc/db/dbAccessDefs.h
+++ b/modules/database/src/ioc/db/dbAccessDefs.h
@@ -12,18 +12,10 @@
 #ifndef INCdbAccessDefsh
 #define INCdbAccessDefsh
 
-#ifdef epicsExportSharedSymbols
-#   define INCLdb_accessh_epicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif
-
 #include "epicsTypes.h"
 #include "epicsTime.h"
 
-#ifdef INCLdb_accessh_epicsExportSharedSymbols
-#   define epicsExportSharedSymbols
-#   include "dbCoreAPI.h"
-#endif
+#include "dbCoreAPI.h"
 
 #include "dbBase.h"
 #include "dbAddr.h"

--- a/modules/database/src/ioc/db/dbAccessDefs.h
+++ b/modules/database/src/ioc/db/dbAccessDefs.h
@@ -22,7 +22,7 @@
 
 #ifdef INCLdb_accessh_epicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#   include "shareLib.h"
+#   include "dbCoreAPI.h"
 #endif
 
 #include "dbBase.h"
@@ -34,9 +34,9 @@ extern "C" {
 #endif
 
 
-epicsShareExtern struct dbBase *pdbbase;
-epicsShareExtern volatile int interruptAccept;
-epicsShareExtern int dbAccessDebugPUTF;
+DBCORE_API extern struct dbBase *pdbbase;
+DBCORE_API extern volatile int interruptAccept;
+DBCORE_API extern int dbAccessDebugPUTF;
 
 /*  The database field and request types are defined in dbFldTypes.h*/
 /* Data Base Request Options    */
@@ -207,67 +207,67 @@ struct dbr_alDouble     {DBRalDouble};
 
 struct dbEntry;
 
-epicsShareFunc long dbPutSpecial(struct dbAddr *paddr,int pass);
-epicsShareFunc rset * dbGetRset(const struct dbAddr *paddr);
-epicsShareFunc long dbPutAttribute(
+DBCORE_API long dbPutSpecial(struct dbAddr *paddr,int pass);
+DBCORE_API rset * dbGetRset(const struct dbAddr *paddr);
+DBCORE_API long dbPutAttribute(
     const char *recordTypename,const char *name,const char*value);
-epicsShareFunc int dbIsValueField(const struct dbFldDes *pdbFldDes);
-epicsShareFunc int dbGetFieldIndex(const struct dbAddr *paddr);
-epicsShareFunc long dbScanPassive(
+DBCORE_API int dbIsValueField(const struct dbFldDes *pdbFldDes);
+DBCORE_API int dbGetFieldIndex(const struct dbAddr *paddr);
+DBCORE_API long dbScanPassive(
     struct dbCommon *pfrom,struct dbCommon *pto);
-epicsShareFunc long dbProcess(struct dbCommon *precord);
-epicsShareFunc long dbNameToAddr(const char *pname, struct dbAddr *paddr);
+DBCORE_API long dbProcess(struct dbCommon *precord);
+DBCORE_API long dbNameToAddr(const char *pname, struct dbAddr *paddr);
 
 /** Initialize DBADDR from a dbEntry
  * Also handles SPC_DBADDR processing. This is really an internal
  * routine for use by dbNameToAddr() and dbChannelCreate().
  */
-epicsShareFunc long dbEntryToAddr(const struct dbEntry *pdbentry,
+DBCORE_API long dbEntryToAddr(const struct dbEntry *pdbentry,
     struct dbAddr *paddr);
 
 /** Initialize DBENTRY from a valid dbAddr*
  * Constant time equivalent of dbInitEntry() then dbFindRecord(),
  * and finally dbFollowAlias().
  */
-epicsShareFunc void dbInitEntryFromAddr(struct dbAddr *paddr,
+DBCORE_API void dbInitEntryFromAddr(struct dbAddr *paddr,
     struct dbEntry *pdbentry);
 
 /** Initialize DBENTRY from a valid record (dbCommon*)
  * Constant time equivalent of dbInitEntry() then dbFindRecord(),
  * and finally dbFollowAlias() when no field is specified.
  */
-epicsShareFunc void dbInitEntryFromRecord(struct dbCommon *prec,
+DBCORE_API void dbInitEntryFromRecord(struct dbCommon *prec,
     struct dbEntry *pdbentry);
 
-epicsShareFunc devSup* dbDTYPtoDevSup(dbRecordType *prdes, int dtyp);
-epicsShareFunc devSup* dbDSETtoDevSup(dbRecordType *prdes, dset *pdset);
-epicsShareFunc long dbGetField(
+DBCORE_API devSup* dbDTYPtoDevSup(dbRecordType *prdes, int dtyp);
+DBCORE_API devSup* dbDSETtoDevSup(dbRecordType *prdes, dset *pdset);
+DBCORE_API long dbGetField(
     struct dbAddr *,short dbrType,void *pbuffer,long *options,
     long *nRequest,void *pfl);
-epicsShareFunc long dbGet(
+DBCORE_API long dbGet(
     struct dbAddr *,short dbrType,void *pbuffer,long *options,
     long *nRequest,void *pfl);
-epicsShareFunc long dbPutField(
+DBCORE_API long dbPutField(
     struct dbAddr *,short dbrType,const void *pbuffer,long nRequest);
-epicsShareFunc long dbPut(
+DBCORE_API long dbPut(
     struct dbAddr *,short dbrType,const void *pbuffer,long nRequest);
 
 typedef void(*SPC_ASCALLBACK)(struct dbCommon *);
 /*dbSpcAsRegisterCallback called by access security */
-epicsShareFunc void dbSpcAsRegisterCallback(SPC_ASCALLBACK func);
-epicsShareFunc long dbBufferSize(
+DBCORE_API void dbSpcAsRegisterCallback(SPC_ASCALLBACK func);
+DBCORE_API long dbBufferSize(
     short dbrType,long options,long nRequest);
-epicsShareFunc long dbValueSize(short dbrType);
+DBCORE_API long dbValueSize(short dbrType);
 
 /* Hook Routine */
 
 typedef void (*DB_LOAD_RECORDS_HOOK_ROUTINE)(const char* filename,
     const char* substitutions);
-epicsShareExtern DB_LOAD_RECORDS_HOOK_ROUTINE dbLoadRecordsHook;
+DBCORE_API extern DB_LOAD_RECORDS_HOOK_ROUTINE dbLoadRecordsHook;
 
-epicsShareFunc int  dbLoadDatabase(
+DBCORE_API int  dbLoadDatabase(
     const char *filename, const char *path, const char *substitutions);
-epicsShareFunc int dbLoadRecords(
+DBCORE_API int dbLoadRecords(
     const char* filename, const char* substitutions);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/db/dbBkpt.c
+++ b/modules/database/src/ioc/db/dbBkpt.c
@@ -53,7 +53,6 @@
 #include "errlog.h"
 #include "errMdef.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbAddr.h"
 #include "dbBase.h"

--- a/modules/database/src/ioc/db/dbBkpt.h
+++ b/modules/database/src/ioc/db/dbBkpt.h
@@ -20,7 +20,7 @@
 #include "epicsEvent.h"
 #include "epicsThread.h"
 #include "epicsTime.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -81,18 +81,18 @@ struct LS_LIST {
 
 #define MAX_EP_COUNT         99999
 
-epicsShareFunc void dbBkptInit(void);
-epicsShareFunc long dbb(const char *recordname);
-epicsShareFunc long dbd(const char *recordname);
-epicsShareFunc long dbc(const char *recordname);
-epicsShareFunc long dbs(const char *recordname);
-epicsShareFunc long dbstat(void);
-epicsShareFunc long dbp(
+DBCORE_API void dbBkptInit(void);
+DBCORE_API long dbb(const char *recordname);
+DBCORE_API long dbd(const char *recordname);
+DBCORE_API long dbc(const char *recordname);
+DBCORE_API long dbs(const char *recordname);
+DBCORE_API long dbstat(void);
+DBCORE_API long dbp(
     const char *record_name, int interest_level);
-epicsShareFunc long dbap(const char *record_name);
-epicsShareFunc int  dbBkpt(struct dbCommon *precord);
-epicsShareFunc void dbPrint(struct dbCommon *precord);
-epicsShareFunc long dbprc(char *record_name);
+DBCORE_API long dbap(const char *record_name);
+DBCORE_API int  dbBkpt(struct dbCommon *precord);
+DBCORE_API void dbPrint(struct dbCommon *precord);
+DBCORE_API long dbprc(char *record_name);
 
 extern long lset_stack_count;
 

--- a/modules/database/src/ioc/db/dbCAC.h
+++ b/modules/database/src/ioc/db/dbCAC.h
@@ -19,11 +19,6 @@
 #ifndef dbCACh
 #define dbCACh
 
-#ifdef epicsExportSharedSymbols
-#   define dbCACh_restore_epicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif
-
 #include "stdlib.h"
 
 #include <memory> // std::auto_ptr
@@ -34,10 +29,7 @@
 #include "cacIO.h"
 #include "compilerDependencies.h"
 
-#ifdef dbCACh_restore_epicsExportSharedSymbols
-#   define epicsExportSharedSymbols
-#   include "dbCoreAPI.h"
-#endif
+#include "dbCoreAPI.h"
 
 #include "db_access.h"
 #include "dbNotify.h"

--- a/modules/database/src/ioc/db/dbCAC.h
+++ b/modules/database/src/ioc/db/dbCAC.h
@@ -36,7 +36,7 @@
 
 #ifdef dbCACh_restore_epicsExportSharedSymbols
 #   define epicsExportSharedSymbols
-#   include "shareLib.h"
+#   include "dbCoreAPI.h"
 #endif
 
 #include "db_access.h"

--- a/modules/database/src/ioc/db/dbCa.c
+++ b/modules/database/src/ioc/db/dbCa.c
@@ -40,7 +40,6 @@
 /* We can't include dbStaticLib.h here */
 #define dbCalloc(nobj,size) callocMustSucceed(nobj,size,"dbCalloc")
 
-#define epicsExportSharedSymbols
 #include "db_access_routines.h"
 #include "dbCa.h"
 #include "dbCaPvt.h"
@@ -233,7 +232,7 @@ void dbCaSync(void)
     epicsEventDestroy(wake);
 }
 
-epicsShareFunc unsigned long dbCaGetUpdateCount(struct link *plink)
+DBCORE_API unsigned long dbCaGetUpdateCount(struct link *plink)
 {
     caLink *pca = (caLink *)plink->value.pv_link.pvt;
     unsigned long ret;

--- a/modules/database/src/ioc/db/dbCa.h
+++ b/modules/database/src/ioc/db/dbCa.h
@@ -19,37 +19,37 @@ extern "C" {
 #endif
 
 typedef void (*dbCaCallback)(void *userPvt);
-epicsShareFunc void dbCaCallbackProcess(void *usrPvt);
+DBCORE_API void dbCaCallbackProcess(void *usrPvt);
 
-epicsShareFunc void dbCaLinkInit(void); /* internal initialization for iocBuild()  */
-epicsShareFunc void dbCaLinkInitIsolated(void); /* internal initialization for iocBuildIsolated()  */
-epicsShareFunc void dbCaRun(void);
-epicsShareFunc void dbCaPause(void);
-epicsShareFunc void dbCaShutdown(void);
+DBCORE_API void dbCaLinkInit(void); /* internal initialization for iocBuild()  */
+DBCORE_API void dbCaLinkInitIsolated(void); /* internal initialization for iocBuildIsolated()  */
+DBCORE_API void dbCaRun(void);
+DBCORE_API void dbCaPause(void);
+DBCORE_API void dbCaShutdown(void);
 
 struct dbLocker;
-epicsShareFunc void dbCaAddLinkCallback(struct link *plink,
+DBCORE_API void dbCaAddLinkCallback(struct link *plink,
     dbCaCallback connect, dbCaCallback monitor, void *userPvt);
-epicsShareFunc long dbCaAddLink(struct dbLocker *locker, struct link *plink, short dbfType);
-epicsShareFunc void dbCaRemoveLink(struct dbLocker *locker, struct link *plink);
+DBCORE_API long dbCaAddLink(struct dbLocker *locker, struct link *plink, short dbfType);
+DBCORE_API void dbCaRemoveLink(struct dbLocker *locker, struct link *plink);
 
-epicsShareFunc long dbCaGetLink(struct link *plink,
+DBCORE_API long dbCaGetLink(struct link *plink,
     short dbrType, void *pbuffer, long *nRequest);
 
-epicsShareFunc long dbCaGetAttributes(const struct link *plink,
+DBCORE_API long dbCaGetAttributes(const struct link *plink,
     dbCaCallback callback, void *userPvt);
 
-epicsShareFunc long dbCaPutLinkCallback(struct link *plink,
+DBCORE_API long dbCaPutLinkCallback(struct link *plink,
     short dbrType, const void *pbuffer,long nRequest,
     dbCaCallback callback, void *userPvt);
-epicsShareFunc long dbCaPutLink(struct link *plink,short dbrType,
+DBCORE_API long dbCaPutLink(struct link *plink,short dbrType,
     const void *pbuffer,long nRequest);
 
 extern struct ca_client_context * dbCaClientContext;
 
 #ifdef EPICS_DBCA_PRIVATE_API
-epicsShareFunc void dbCaSync(void);
-epicsShareFunc unsigned long dbCaGetUpdateCount(struct link *plink);
+DBCORE_API void dbCaSync(void);
+DBCORE_API unsigned long dbCaGetUpdateCount(struct link *plink);
 #endif
 
 /* These macros are for backwards compatibility */

--- a/modules/database/src/ioc/db/dbCaTest.c
+++ b/modules/database/src/ioc/db/dbCaTest.c
@@ -27,7 +27,6 @@
 #include "epicsStdio.h"
 
 #include "dbStaticLib.h"
-#undef epicsExportSharedSymbols
 /*definitions needed because of old vs new database access*/
 #undef DBR_SHORT
 #undef DBR_PUT_ACKT

--- a/modules/database/src/ioc/db/dbCaTest.c
+++ b/modules/database/src/ioc/db/dbCaTest.c
@@ -26,7 +26,6 @@
 #include "epicsPrint.h"
 #include "epicsStdio.h"
 
-#define epicsExportSharedSymbols
 #include "dbStaticLib.h"
 #undef epicsExportSharedSymbols
 /*definitions needed because of old vs new database access*/
@@ -42,7 +41,6 @@
 /*define DB_CONVERT_GBLSOURCE because db_access.c does not include db_access.h*/
 #define DB_CONVERT_GBLSOURCE
 
-#define epicsExportSharedSymbols
 #include "db_access.h"
 #include "db_access_routines.h"
 #include "dbCa.h"

--- a/modules/database/src/ioc/db/dbCaTest.h
+++ b/modules/database/src/ioc/db/dbCaTest.h
@@ -11,14 +11,14 @@
 #ifndef INC_dbCaTest_H
 #define INC_dbCaTest_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc long dbcar(char *recordname,int level);
-epicsShareFunc void dbcaStats(int *pchans, int *pdiscon);
+DBCORE_API long dbcar(char *recordname,int level);
+DBCORE_API void dbcaStats(int *pchans, int *pdiscon);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbChannel.c
+++ b/modules/database/src/ioc/db/dbChannel.c
@@ -29,7 +29,6 @@
 #include "gpHash.h"
 #include "yajl_parse.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbBase.h"
 #include "dbChannel.h"

--- a/modules/database/src/ioc/db/dbChannelIO.cpp
+++ b/modules/database/src/ioc/db/dbChannelIO.cpp
@@ -25,7 +25,6 @@
 #include "db_access.h"
 #include "errlog.h"
 
-#define epicsExportSharedSymbols
 #include "db_access_routines.h"
 #include "dbCAC.h"
 #include "dbChannelIO.h"

--- a/modules/database/src/ioc/db/dbChannelIO.h
+++ b/modules/database/src/ioc/db/dbChannelIO.h
@@ -20,16 +20,7 @@
 #ifndef dbChannelIOh
 #define dbChannelIOh
 
-#ifdef epicsExportSharedSymbols
-#   define dbChannelIOh_restore_epicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif
-
 #include "compilerDependencies.h"
-
-#ifdef dbChannelIOh_restore_epicsExportSharedSymbols
-#   define epicsExportSharedSymbols
-#endif
 
 class dbChannelIO : public cacChannel, public dbContextPrivateListOfIO {
 public:

--- a/modules/database/src/ioc/db/dbConstLink.c
+++ b/modules/database/src/ioc/db/dbConstLink.c
@@ -19,7 +19,6 @@
 #include "dbDefs.h"
 #include "epicsStdlib.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbAddr.h"
 #include "dbCommon.h"

--- a/modules/database/src/ioc/db/dbConstLink.h
+++ b/modules/database/src/ioc/db/dbConstLink.h
@@ -16,7 +16,7 @@
 #ifndef INC_dbConstLink_H
 #define INC_dbConstLink_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -24,8 +24,8 @@ extern "C" {
 
 struct link;
 
-epicsShareFunc void dbConstInitLink(struct link *plink);
-epicsShareFunc void dbConstAddLink(struct link *plink);
+DBCORE_API void dbConstInitLink(struct link *plink);
+DBCORE_API void dbConstAddLink(struct link *plink);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbContext.cpp
+++ b/modules/database/src/ioc/db/dbContext.cpp
@@ -25,7 +25,6 @@
 #include "epicsThread.h"
 #include "errlog.h"
 
-#define epicsExportSharedSymbols
 #include "db_access_routines.h"
 #include "dbCAC.h"
 #include "dbChannel.h"

--- a/modules/database/src/ioc/db/dbContextReadNotifyCache.cpp
+++ b/modules/database/src/ioc/db/dbContextReadNotifyCache.cpp
@@ -20,7 +20,6 @@
 #include "cadef.h" // this can be eliminated when the callbacks use the new interface
 #include "db_access.h" // should be eliminated here in the future
 
-#define epicsExportSharedSymbols
 
 #include "db_access_routines.h"
 #include "dbCAC.h"

--- a/modules/database/src/ioc/db/dbConvert.c
+++ b/modules/database/src/ioc/db/dbConvert.c
@@ -26,7 +26,6 @@
 #include "errlog.h"
 #include "errMdef.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbAddr.h"
 #include "dbBase.h"

--- a/modules/database/src/ioc/db/dbConvert.h
+++ b/modules/database/src/ioc/db/dbConvert.h
@@ -14,7 +14,7 @@
 
 #include "dbFldTypes.h"
 #include "dbAddr.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,8 +25,8 @@ typedef long (*GETCONVERTFUNC)(const DBADDR *paddr, void *pbuffer,
 typedef long (*PUTCONVERTFUNC)(DBADDR *paddr, const void *pbuffer,
     long nRequest, long no_elements, long offset);
 
-epicsShareExtern GETCONVERTFUNC dbGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1];
-epicsShareExtern PUTCONVERTFUNC dbPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1];
+DBCORE_API extern GETCONVERTFUNC dbGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1];
+DBCORE_API extern PUTCONVERTFUNC dbPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1];
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbConvertFast.h
+++ b/modules/database/src/ioc/db/dbConvertFast.h
@@ -13,14 +13,14 @@
 #define INCdbConvertFasth
 
 #include "dbFldTypes.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareExtern long (*dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1])();
-epicsShareExtern long (*dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1])();
+DBCORE_API extern long (*dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1])();
+DBCORE_API extern long (*dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1])();
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbConvertJSON.c
+++ b/modules/database/src/ioc/db/dbConvertJSON.c
@@ -15,7 +15,6 @@
 #include "yajl_alloc.h"
 #include "yajl_parse.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbConvertFast.h"
 #include "dbConvertJSON.h"

--- a/modules/database/src/ioc/db/dbConvertJSON.h
+++ b/modules/database/src/ioc/db/dbConvertJSON.h
@@ -10,16 +10,16 @@
 #ifndef INC_dbConvertJSON_H
 #define INC_dbConvertJSON_H
 
-#include <shareLib.h>
+#include <dbCoreAPI.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* This name should probably be changed to inclue "array" */
-epicsShareFunc long dbPutConvertJSON(const char *json, short dbrType,
+DBCORE_API long dbPutConvertJSON(const char *json, short dbrType,
     void *pdest, long *psize);
-epicsShareFunc long dbLSConvertJSON(const char *json, char *pdest,
+DBCORE_API long dbLSConvertJSON(const char *json, char *pdest,
     epicsUInt32 size, epicsUInt32 *plen);
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbDbLink.c
+++ b/modules/database/src/ioc/db/dbDbLink.c
@@ -52,7 +52,6 @@
 
 #include "caeventmask.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbAddr.h"
 #include "dbBase.h"

--- a/modules/database/src/ioc/db/dbDbLink.h
+++ b/modules/database/src/ioc/db/dbDbLink.h
@@ -16,7 +16,7 @@
 #ifndef INC_dbDbLink_H
 #define INC_dbDbLink_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,8 +25,8 @@ extern "C" {
 struct link;
 struct dbLocker;
 
-epicsShareFunc long dbDbInitLink(struct link *plink, short dbfType);
-epicsShareFunc void dbDbAddLink(struct dbLocker *locker, struct link *plink,
+DBCORE_API long dbDbInitLink(struct link *plink, short dbfType);
+DBCORE_API void dbDbAddLink(struct dbLocker *locker, struct link *plink,
     short dbfType, dbChannel *ptarget);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -37,7 +37,6 @@
 
 #include "caeventmask.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbAddr.h"
 #include "dbBase.h"
@@ -333,7 +332,7 @@ fail:
 }
 
 
-epicsShareFunc void db_cleanup_events(void)
+DBCORE_API void db_cleanup_events(void)
 {
     if(dbevEventUserFreeList) freeListCleanup(dbevEventUserFreeList);
     dbevEventUserFreeList = NULL;

--- a/modules/database/src/ioc/db/dbEvent.h
+++ b/modules/database/src/ioc/db/dbEvent.h
@@ -20,16 +20,7 @@
 #ifndef INCLdbEventh
 #define INCLdbEventh
 
-#ifdef epicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#   define INCLdbEventhExporting
-#endif
-
 #include "epicsThread.h"
-
-#ifdef INCLdbEventhExporting
-#   define epicsExportSharedSymbols
-#endif
 
 #include "dbCoreAPI.h"
 

--- a/modules/database/src/ioc/db/dbEvent.h
+++ b/modules/database/src/ioc/db/dbEvent.h
@@ -31,7 +31,7 @@
 #   define epicsExportSharedSymbols
 #endif
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,50 +41,50 @@ struct dbChannel;
 struct db_field_log;
 struct evSubscrip;
 
-epicsShareFunc int db_event_list (
+DBCORE_API int db_event_list (
     const char *name, unsigned level);
-epicsShareFunc int dbel (
+DBCORE_API int dbel (
     const char *name, unsigned level);
-epicsShareFunc int db_post_events (
+DBCORE_API int db_post_events (
     void *pRecord, void *pField, unsigned caEventMask );
 
 typedef void * dbEventCtx;
 
 typedef void EXTRALABORFUNC (void *extralabor_arg);
-epicsShareFunc dbEventCtx db_init_events (void);
-epicsShareFunc int db_start_events (
+DBCORE_API dbEventCtx db_init_events (void);
+DBCORE_API int db_start_events (
     dbEventCtx ctx, const char *taskname, void (*init_func)(void *),
     void *init_func_arg, unsigned osiPriority );
-epicsShareFunc void db_close_events (dbEventCtx ctx);
-epicsShareFunc void db_event_flow_ctrl_mode_on (dbEventCtx ctx);
-epicsShareFunc void db_event_flow_ctrl_mode_off (dbEventCtx ctx);
-epicsShareFunc int db_add_extra_labor_event (
+DBCORE_API void db_close_events (dbEventCtx ctx);
+DBCORE_API void db_event_flow_ctrl_mode_on (dbEventCtx ctx);
+DBCORE_API void db_event_flow_ctrl_mode_off (dbEventCtx ctx);
+DBCORE_API int db_add_extra_labor_event (
     dbEventCtx ctx, EXTRALABORFUNC *func, void *arg);
-epicsShareFunc void db_flush_extra_labor_event (dbEventCtx);
-epicsShareFunc int db_post_extra_labor (dbEventCtx ctx);
-epicsShareFunc void db_event_change_priority ( dbEventCtx ctx, unsigned epicsPriority );
+DBCORE_API void db_flush_extra_labor_event (dbEventCtx);
+DBCORE_API int db_post_extra_labor (dbEventCtx ctx);
+DBCORE_API void db_event_change_priority ( dbEventCtx ctx, unsigned epicsPriority );
 
 #ifdef EPICS_PRIVATE_API
-epicsShareFunc void db_cleanup_events(void);
-epicsShareFunc void db_init_event_freelists (void);
+DBCORE_API void db_cleanup_events(void);
+DBCORE_API void db_init_event_freelists (void);
 #endif
 
 typedef void EVENTFUNC (void *user_arg, struct dbChannel *chan,
     int eventsRemaining, struct db_field_log *pfl);
 
 typedef void * dbEventSubscription;
-epicsShareFunc dbEventSubscription db_add_event (
+DBCORE_API dbEventSubscription db_add_event (
     dbEventCtx ctx, struct dbChannel *chan,
     EVENTFUNC *user_sub, void *user_arg, unsigned select);
-epicsShareFunc void db_cancel_event (dbEventSubscription es);
-epicsShareFunc void db_post_single_event (dbEventSubscription es);
-epicsShareFunc void db_event_enable (dbEventSubscription es);
-epicsShareFunc void db_event_disable (dbEventSubscription es);
+DBCORE_API void db_cancel_event (dbEventSubscription es);
+DBCORE_API void db_post_single_event (dbEventSubscription es);
+DBCORE_API void db_event_enable (dbEventSubscription es);
+DBCORE_API void db_event_disable (dbEventSubscription es);
 
-epicsShareFunc struct db_field_log* db_create_event_log (struct evSubscrip *pevent);
-epicsShareFunc struct db_field_log* db_create_read_log (struct dbChannel *chan);
-epicsShareFunc void db_delete_field_log (struct db_field_log *pfl);
-epicsShareFunc int db_available_logs(void);
+DBCORE_API struct db_field_log* db_create_event_log (struct evSubscrip *pevent);
+DBCORE_API struct db_field_log* db_create_read_log (struct dbChannel *chan);
+DBCORE_API void db_delete_field_log (struct db_field_log *pfl);
+DBCORE_API int db_available_logs(void);
 
 #define DB_EVENT_OK 0
 #define DB_EVENT_ERROR (-1)

--- a/modules/database/src/ioc/db/dbExtractArray.c
+++ b/modules/database/src/ioc/db/dbExtractArray.c
@@ -23,7 +23,6 @@
 
 #include "epicsTypes.h"
 
-#define epicsExportSharedSymbols
 #include "dbAddr.h"
 #include "dbExtractArray.h"
 

--- a/modules/database/src/ioc/db/dbExtractArray.h
+++ b/modules/database/src/ioc/db/dbExtractArray.h
@@ -16,7 +16,7 @@
 
 #include "dbFldTypes.h"
 #include "dbAddr.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,7 +49,7 @@ extern "C" {
  * @param offset        Wrap-around point in source array.
  * @param increment     Copy only every increment'th element.
  */
-epicsShareFunc void dbExtractArray(const void *pfrom, void *pto,
+DBCORE_API void dbExtractArray(const void *pfrom, void *pto,
     short field_size, long nRequest, long no_elements, long offset,
     long increment);
 

--- a/modules/database/src/ioc/db/dbFastLinkConv.c
+++ b/modules/database/src/ioc/db/dbFastLinkConv.c
@@ -27,7 +27,6 @@
 #include "errlog.h"
 #include "errMdef.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbAddr.h"
 #include "dbBase.h"

--- a/modules/database/src/ioc/db/dbIocRegister.c
+++ b/modules/database/src/ioc/db/dbIocRegister.c
@@ -10,7 +10,6 @@
 
 #include "iocsh.h"
 
-#define epicsExportSharedSymbols
 #include "callback.h"
 #include "dbAccess.h"
 #include "dbBkpt.h"
@@ -26,7 +25,7 @@
 #include "db_test.h"
 #include "dbTest.h"
 
-epicsShareExtern int callbackParallelThreadsDefault;
+DBCORE_API extern int callbackParallelThreadsDefault;
 
 /* dbLoadDatabase */
 static const iocshArg dbLoadDatabaseArg0 = { "file name",iocshArgString};

--- a/modules/database/src/ioc/db/dbIocRegister.h
+++ b/modules/database/src/ioc/db/dbIocRegister.h
@@ -11,13 +11,13 @@
 #ifndef INC_dbIocRegister_H
 #define INC_dbIocRegister_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc void dbIocRegister(void);
+DBCORE_API void dbIocRegister(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbJLink.c
+++ b/modules/database/src/ioc/db/dbJLink.c
@@ -16,7 +16,6 @@
 #include "yajl_alloc.h"
 #include "yajl_parse.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbCommon.h"
 #include "dbStaticLib.h"

--- a/modules/database/src/ioc/db/dbJLink.h
+++ b/modules/database/src/ioc/db/dbJLink.h
@@ -22,7 +22,7 @@ typedef enum {
     jlif_continue = 1
 } jlif_result;
 
-epicsShareExtern const char *jlif_result_name[2];
+DBCORE_API extern const char *jlif_result_name[2];
 
 typedef enum {
     jlif_key_stop = jlif_stop,
@@ -30,7 +30,7 @@ typedef enum {
     jlif_key_child_inlink, jlif_key_child_outlink, jlif_key_child_fwdlink
 } jlif_key_result;
 
-epicsShareExtern const char *jlif_key_result_name[5];
+DBCORE_API extern const char *jlif_key_result_name[5];
 
 struct link;
 struct lset;

--- a/modules/database/src/ioc/db/dbLink.c
+++ b/modules/database/src/ioc/db/dbLink.c
@@ -28,7 +28,6 @@
 
 #include "caeventmask.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbAddr.h"
 #include "dbBase.h"

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -17,7 +17,7 @@
 #define INC_dbLink_H
 
 #include "link.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 #include "epicsTypes.h"
 #include "epicsTime.h"
 #include "dbAddr.h"
@@ -366,59 +366,59 @@ typedef struct lset {
 #define dbGetSevr(link, sevr) \
     dbGetAlarm(link, NULL, sevr)
 
-epicsShareFunc const char * dbLinkFieldName(const struct link *plink);
+DBCORE_API const char * dbLinkFieldName(const struct link *plink);
 
-epicsShareFunc void dbInitLink(struct link *plink, short dbfType);
-epicsShareFunc void dbAddLink(struct dbLocker *locker, struct link *plink,
+DBCORE_API void dbInitLink(struct link *plink, short dbfType);
+DBCORE_API void dbAddLink(struct dbLocker *locker, struct link *plink,
         short dbfType, dbChannel *ptarget);
 
-epicsShareFunc void dbLinkOpen(struct link *plink);
-epicsShareFunc void dbRemoveLink(struct dbLocker *locker, struct link *plink);
+DBCORE_API void dbLinkOpen(struct link *plink);
+DBCORE_API void dbRemoveLink(struct dbLocker *locker, struct link *plink);
 
-epicsShareFunc int dbLinkIsDefined(const struct link *plink);  /* 0 or 1 */
-epicsShareFunc int dbLinkIsConstant(const struct link *plink); /* 0 or 1 */
-epicsShareFunc int dbLinkIsVolatile(const struct link *plink); /* 0 or 1 */
+DBCORE_API int dbLinkIsDefined(const struct link *plink);  /* 0 or 1 */
+DBCORE_API int dbLinkIsConstant(const struct link *plink); /* 0 or 1 */
+DBCORE_API int dbLinkIsVolatile(const struct link *plink); /* 0 or 1 */
 
-epicsShareFunc long dbLoadLink(struct link *plink, short dbrType,
+DBCORE_API long dbLoadLink(struct link *plink, short dbrType,
         void *pbuffer);
-epicsShareFunc long dbLoadLinkArray(struct link *, short dbrType, void *pbuffer,
+DBCORE_API long dbLoadLinkArray(struct link *, short dbrType, void *pbuffer,
         long *pnRequest);
 
-epicsShareFunc long dbGetNelements(const struct link *plink, long *pnElements);
-epicsShareFunc int dbIsLinkConnected(const struct link *plink); /* 0 or 1 */
-epicsShareFunc int dbGetLinkDBFtype(const struct link *plink);
-epicsShareFunc long dbTryGetLink(struct link *, short dbrType, void *pbuffer,
+DBCORE_API long dbGetNelements(const struct link *plink, long *pnElements);
+DBCORE_API int dbIsLinkConnected(const struct link *plink); /* 0 or 1 */
+DBCORE_API int dbGetLinkDBFtype(const struct link *plink);
+DBCORE_API long dbTryGetLink(struct link *, short dbrType, void *pbuffer,
         long *nRequest);
-epicsShareFunc long dbGetLink(struct link *, short dbrType, void *pbuffer,
+DBCORE_API long dbGetLink(struct link *, short dbrType, void *pbuffer,
         long *options, long *nRequest);
-epicsShareFunc long dbGetControlLimits(const struct link *plink, double *low,
+DBCORE_API long dbGetControlLimits(const struct link *plink, double *low,
         double *high);
-epicsShareFunc long dbGetGraphicLimits(const struct link *plink, double *low,
+DBCORE_API long dbGetGraphicLimits(const struct link *plink, double *low,
         double *high);
-epicsShareFunc long dbGetAlarmLimits(const struct link *plink, double *lolo,
+DBCORE_API long dbGetAlarmLimits(const struct link *plink, double *lolo,
         double *low, double *high, double *hihi);
-epicsShareFunc long dbGetPrecision(const struct link *plink, short *precision);
-epicsShareFunc long dbGetUnits(const struct link *plink, char *units,
+DBCORE_API long dbGetPrecision(const struct link *plink, short *precision);
+DBCORE_API long dbGetUnits(const struct link *plink, char *units,
         int unitsSize);
-epicsShareFunc long dbGetAlarm(const struct link *plink, epicsEnum16 *status,
+DBCORE_API long dbGetAlarm(const struct link *plink, epicsEnum16 *status,
         epicsEnum16 *severity);
-epicsShareFunc long dbGetTimeStamp(const struct link *plink,
+DBCORE_API long dbGetTimeStamp(const struct link *plink,
         epicsTimeStamp *pstamp);
-epicsShareFunc long dbPutLink(struct link *plink, short dbrType,
+DBCORE_API long dbPutLink(struct link *plink, short dbrType,
         const void *pbuffer, long nRequest);
-epicsShareFunc void dbLinkAsyncComplete(struct link *plink);
-epicsShareFunc long dbPutLinkAsync(struct link *plink, short dbrType,
+DBCORE_API void dbLinkAsyncComplete(struct link *plink);
+DBCORE_API long dbPutLinkAsync(struct link *plink, short dbrType,
         const void *pbuffer, long nRequest);
-epicsShareFunc void dbScanFwdLink(struct link *plink);
+DBCORE_API void dbScanFwdLink(struct link *plink);
 
-epicsShareFunc long dbLinkDoLocked(struct link *plink, dbLinkUserCallback rtn,
+DBCORE_API long dbLinkDoLocked(struct link *plink, dbLinkUserCallback rtn,
         void *priv);
 
-epicsShareFunc long dbLoadLinkLS(struct link *plink, char *pbuffer,
+DBCORE_API long dbLoadLinkLS(struct link *plink, char *pbuffer,
         epicsUInt32 size, epicsUInt32 *plen);
-epicsShareFunc long dbGetLinkLS(struct link *plink, char *pbuffer,
+DBCORE_API long dbGetLinkLS(struct link *plink, char *pbuffer,
         epicsUInt32 buffer_size, epicsUInt32 *plen);
-epicsShareFunc long dbPutLinkLS(struct link *plink, char *pbuffer,
+DBCORE_API long dbPutLinkLS(struct link *plink, char *pbuffer,
         epicsUInt32 len);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/db/dbLock.c
+++ b/modules/database/src/ioc/db/dbLock.c
@@ -25,7 +25,6 @@
 #include "epicsThread.h"
 #include "errMdef.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbAddr.h"
 #include "dbBase.h"

--- a/modules/database/src/ioc/db/dbLock.h
+++ b/modules/database/src/ioc/db/dbLock.h
@@ -16,7 +16,7 @@
 #include <stddef.h>
 
 #include "ellLib.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -26,38 +26,38 @@ struct dbCommon;
 struct dbBase;
 typedef struct dbLocker dbLocker;
 
-epicsShareFunc void dbScanLock(struct dbCommon *precord);
-epicsShareFunc void dbScanUnlock(struct dbCommon *precord);
+DBCORE_API void dbScanLock(struct dbCommon *precord);
+DBCORE_API void dbScanUnlock(struct dbCommon *precord);
 
-epicsShareFunc dbLocker *dbLockerAlloc(struct dbCommon * const *precs,
+DBCORE_API dbLocker *dbLockerAlloc(struct dbCommon * const *precs,
                                        size_t nrecs,
                                        unsigned int flags);
 
-epicsShareFunc void dbLockerFree(dbLocker *);
+DBCORE_API void dbLockerFree(dbLocker *);
 
-epicsShareFunc void dbScanLockMany(dbLocker*);
-epicsShareFunc void dbScanUnlockMany(dbLocker*);
+DBCORE_API void dbScanLockMany(dbLocker*);
+DBCORE_API void dbScanUnlockMany(dbLocker*);
 
-epicsShareFunc unsigned long dbLockGetLockId(
+DBCORE_API unsigned long dbLockGetLockId(
     struct dbCommon *precord);
 
-epicsShareFunc void dbLockInitRecords(struct dbBase *pdbbase);
-epicsShareFunc void dbLockCleanupRecords(struct dbBase *pdbbase);
+DBCORE_API void dbLockInitRecords(struct dbBase *pdbbase);
+DBCORE_API void dbLockCleanupRecords(struct dbBase *pdbbase);
 
 
 /* Lock Set Report */
-epicsShareFunc long dblsr(char *recordname,int level);
+DBCORE_API long dblsr(char *recordname,int level);
 /* If recordname NULL then all records*/
 /* level = (0,1,2) (lock set state, + recordname, +DB links) */
 
-epicsShareFunc long dbLockShowLocked(int level);
+DBCORE_API long dbLockShowLocked(int level);
 
 /*KLUDGE to support field TPRO*/
-epicsShareFunc int * dbLockSetAddrTrace(struct dbCommon *precord);
+DBCORE_API int * dbLockSetAddrTrace(struct dbCommon *precord);
 
 /* debugging */
-epicsShareFunc unsigned long dbLockGetRefs(struct dbCommon*);
-epicsShareFunc unsigned long dbLockCountSets(void);
+DBCORE_API unsigned long dbLockGetRefs(struct dbCommon*);
+DBCORE_API unsigned long dbLockCountSets(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbLockPvt.h
+++ b/modules/database/src/ioc/db/dbLockPvt.h
@@ -92,9 +92,9 @@ extern "C" {
 #endif
 
 /* These are exported for testing only */
-epicsShareFunc lockSet* dbLockGetRef(lockRecord *lr); /* lookup lockset and increment ref count */
-epicsShareFunc void dbLockIncRef(lockSet* ls);
-epicsShareFunc void dbLockDecRef(lockSet *ls);
+DBCORE_API lockSet* dbLockGetRef(lockRecord *lr); /* lookup lockset and increment ref count */
+DBCORE_API void dbLockIncRef(lockSet* ls);
+DBCORE_API void dbLockDecRef(lockSet *ls);
 
 /* Calling dbLockerPrepare directly is an internal
  * optimization used when dbLocker on the stack.

--- a/modules/database/src/ioc/db/dbNotify.c
+++ b/modules/database/src/ioc/db/dbNotify.c
@@ -33,7 +33,6 @@
 #include "errlog.h"
 #include "errMdef.h"
 
-#define epicsExportSharedSymbols
 #include "callback.h"
 #include "dbAccessDefs.h"
 #include "dbBase.h"

--- a/modules/database/src/ioc/db/dbNotify.h
+++ b/modules/database/src/ioc/db/dbNotify.h
@@ -12,7 +12,7 @@
 #ifndef INCdbNotifyh
 #define INCdbNotifyh
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 #include "ellLib.h"
 
 #ifdef __cplusplus
@@ -70,32 +70,32 @@ typedef struct processNotify {
 
 
 /* dbProcessNotify and dbNotifyCancel are called by user*/
-epicsShareFunc void dbProcessNotify(processNotify *pprocessNotify);
-epicsShareFunc void dbNotifyCancel(processNotify *pprocessNotify);
+DBCORE_API void dbProcessNotify(processNotify *pprocessNotify);
+DBCORE_API void dbNotifyCancel(processNotify *pprocessNotify);
 
 /* dbProcessNotifyInit called by iocInit */
-epicsShareFunc void dbProcessNotifyInit(void);
-epicsShareFunc void dbProcessNotifyExit(void);
+DBCORE_API void dbProcessNotifyInit(void);
+DBCORE_API void dbProcessNotifyExit(void);
 
 /*dbNotifyAdd called by dbScanPassive and dbScanLink*/
-epicsShareFunc void dbNotifyAdd(
+DBCORE_API void dbNotifyAdd(
     struct dbCommon *pfrom,struct dbCommon *pto);
 /*dbNotifyCompletion called by recGblFwdLink  or dbAccess*/
-epicsShareFunc void dbNotifyCompletion(struct dbCommon *precord);
+DBCORE_API void dbNotifyCompletion(struct dbCommon *precord);
 
 /* db_put_process defined here since it requires dbNotify.
  * src_type is the old DBR type
  * This is called by a dbNotify putCallback that uses oldDbr types
  */
-epicsShareFunc int db_put_process(
+DBCORE_API int db_put_process(
     processNotify *processNotify,notifyPutType type,
     int src_type,const void *psrc, int no_elements);
 
 /* dbtpn is test routine for dbNotify putProcessRequest */
-epicsShareFunc long dbtpn(char *recordname,char *value);
+DBCORE_API long dbtpn(char *recordname,char *value);
 
 /* dbNotifyDump is an INVASIVE debug utility. Don't use this needlessly*/
-epicsShareFunc int dbNotifyDump(void);
+DBCORE_API int dbNotifyDump(void);
 
 /* This module provides code to handle process notify.
  * client code semantics are:

--- a/modules/database/src/ioc/db/dbPutNotifyBlocker.cpp
+++ b/modules/database/src/ioc/db/dbPutNotifyBlocker.cpp
@@ -31,7 +31,6 @@
 #include "caerr.h" // this needs to be eliminated
 #include "db_access.h" // this needs to be eliminated
 
-#define epicsExportSharedSymbols
 #include "dbCAC.h"
 #include "dbChannelIO.h"
 #include "dbPutNotifyBlocker.h"

--- a/modules/database/src/ioc/db/dbPutNotifyBlocker.h
+++ b/modules/database/src/ioc/db/dbPutNotifyBlocker.h
@@ -26,7 +26,6 @@
 #include "compilerDependencies.h"
 
 #ifdef dbPutNotifyBlockerh_restore_epicsExportSharedSymbols
-#define epicsExportSharedSymbols
 #endif
 
 class dbPutNotifyBlocker : public dbBaseIO {

--- a/modules/database/src/ioc/db/dbPutNotifyBlocker.h
+++ b/modules/database/src/ioc/db/dbPutNotifyBlocker.h
@@ -17,16 +17,8 @@
 #ifndef dbPutNotifyBlockerh
 #define dbPutNotifyBlockerh
 
-#ifdef epicsExportSharedSymbols
-#define dbPutNotifyBlockerh_restore_epicsExportSharedSymbols
-#undef epicsExportSharedSymbols
-#endif
-
 #include "tsFreeList.h"
 #include "compilerDependencies.h"
-
-#ifdef dbPutNotifyBlockerh_restore_epicsExportSharedSymbols
-#endif
 
 class dbPutNotifyBlocker : public dbBaseIO {
 public:

--- a/modules/database/src/ioc/db/dbScan.c
+++ b/modules/database/src/ioc/db/dbScan.c
@@ -37,7 +37,6 @@
 #include "epicsTime.h"
 #include "taskwd.h"
 
-#define epicsExportSharedSymbols
 #include "callback.h"
 #include "dbAccessDefs.h"
 #include "dbAddr.h"

--- a/modules/database/src/ioc/db/dbScan.h
+++ b/modules/database/src/ioc/db/dbScan.h
@@ -18,7 +18,7 @@
 #include <limits.h>
 
 #include "menuScan.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 #include "compilerDependencies.h"
 #include "devSup.h"
 
@@ -50,37 +50,37 @@ typedef struct scanOnceQueueStats {
     int numOverflow;
 } scanOnceQueueStats;
 
-epicsShareFunc long scanInit(void);
-epicsShareFunc void scanRun(void);
-epicsShareFunc void scanPause(void);
-epicsShareFunc void scanStop(void);
-epicsShareFunc void scanCleanup(void);
+DBCORE_API long scanInit(void);
+DBCORE_API void scanRun(void);
+DBCORE_API void scanPause(void);
+DBCORE_API void scanStop(void);
+DBCORE_API void scanCleanup(void);
 
-epicsShareFunc EVENTPVT eventNameToHandle(const char* event);
-epicsShareFunc void postEvent(EVENTPVT epvt);
-epicsShareFunc void post_event(int event);
-epicsShareFunc void scanAdd(struct dbCommon *);
-epicsShareFunc void scanDelete(struct dbCommon *);
-epicsShareFunc double scanPeriod(int scan);
-epicsShareFunc int scanOnce(struct dbCommon *);
-epicsShareFunc int scanOnceCallback(struct dbCommon *, once_complete cb, void *usr);
-epicsShareFunc int scanOnceSetQueueSize(int size);
-epicsShareFunc int scanOnceQueueStatus(const int reset, scanOnceQueueStats *result);
-epicsShareFunc void scanOnceQueueShow(const int reset);
+DBCORE_API EVENTPVT eventNameToHandle(const char* event);
+DBCORE_API void postEvent(EVENTPVT epvt);
+DBCORE_API void post_event(int event);
+DBCORE_API void scanAdd(struct dbCommon *);
+DBCORE_API void scanDelete(struct dbCommon *);
+DBCORE_API double scanPeriod(int scan);
+DBCORE_API int scanOnce(struct dbCommon *);
+DBCORE_API int scanOnceCallback(struct dbCommon *, once_complete cb, void *usr);
+DBCORE_API int scanOnceSetQueueSize(int size);
+DBCORE_API int scanOnceQueueStatus(const int reset, scanOnceQueueStats *result);
+DBCORE_API void scanOnceQueueShow(const int reset);
 
 /*print periodic lists*/
-epicsShareFunc int scanppl(double rate);
+DBCORE_API int scanppl(double rate);
 
 /*print event lists*/
-epicsShareFunc int scanpel(const char *event_name);
+DBCORE_API int scanpel(const char *event_name);
 
 /*print io_event list*/
-epicsShareFunc int scanpiol(void);
+DBCORE_API int scanpiol(void);
 
-epicsShareFunc void scanIoInit(IOSCANPVT *ppios);
-epicsShareFunc unsigned int scanIoRequest(IOSCANPVT pios);
-epicsShareFunc unsigned int scanIoImmediate(IOSCANPVT pios, int prio);
-epicsShareFunc void scanIoSetComplete(IOSCANPVT, io_scan_complete, void *usr);
+DBCORE_API void scanIoInit(IOSCANPVT *ppios);
+DBCORE_API unsigned int scanIoRequest(IOSCANPVT pios);
+DBCORE_API unsigned int scanIoImmediate(IOSCANPVT pios, int prio);
+DBCORE_API void scanIoSetComplete(IOSCANPVT, io_scan_complete, void *usr);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbServer.c
+++ b/modules/database/src/ioc/db/dbServer.c
@@ -18,7 +18,6 @@
 #include "envDefs.h"
 #include "epicsStdio.h"
 
-#define epicsExportSharedSymbols
 #include "dbServer.h"
 
 static ELLLIST serverList = ELLLIST_INIT;

--- a/modules/database/src/ioc/db/dbServer.h
+++ b/modules/database/src/ioc/db/dbServer.h
@@ -28,7 +28,7 @@
 #include <stddef.h>
 
 #include "ellLib.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -118,14 +118,14 @@ typedef struct dbServer {
  * This should only be called once for each server layer.
  * @param psrv Server information structure for the server
  */
-epicsShareFunc int dbRegisterServer(dbServer *psrv);
+DBCORE_API int dbRegisterServer(dbServer *psrv);
 
 /** @brief Unregister a server layer
  *
  * This should only be called when the servers are inactive.
  * @param psrv Server information structure for the server
  */
-epicsShareFunc int dbUnregisterServer(dbServer *psrv);
+DBCORE_API int dbUnregisterServer(dbServer *psrv);
 
 /** @brief Print dbServer Reports.
 *
@@ -133,7 +133,7 @@ epicsShareFunc int dbUnregisterServer(dbServer *psrv);
  * This routine is provided as an IOC Shell command.
  * @param level Interest level, specifies how much detail to print.
  */
-epicsShareFunc void dbsr(unsigned level);
+DBCORE_API void dbsr(unsigned level);
 
 /** @brief Query servers for client's identity.
  *
@@ -143,31 +143,31 @@ epicsShareFunc void dbsr(unsigned level);
  *  of the calling thread is printed along with the record name whenever
  *  the record is subsequently processed.
  */
-epicsShareFunc int dbServerClient(char *pBuf, size_t bufSize);
+DBCORE_API int dbServerClient(char *pBuf, size_t bufSize);
 
 /** @brief Initialize all registered servers.
  *
  * Calls all dbServer::init() methods.
  */
-epicsShareFunc void dbInitServers(void);
+DBCORE_API void dbInitServers(void);
 
 /** @brief Run all registered servers.
  *
  * Calls all dbServer::run() methods.
  */
-epicsShareFunc void dbRunServers(void);
+DBCORE_API void dbRunServers(void);
 
 /** @brief Pause all registered servers.
  *
  * Calls all dbServer::pause() methods.
  */
-epicsShareFunc void dbPauseServers(void);
+DBCORE_API void dbPauseServers(void);
 
 /** @brief Stop all registered servers.
  *
  * Calls all dbServer::stop() methods.
  */
-epicsShareFunc void dbStopServers(void);
+DBCORE_API void dbStopServers(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbState.c
+++ b/modules/database/src/ioc/db/dbState.c
@@ -19,7 +19,6 @@
 #include "epicsString.h"
 #include "iocsh.h"
 
-#define epicsExportSharedSymbols
 #include "dbDefs.h"
 #include "dbState.h"
 #include "dbStaticLib.h"

--- a/modules/database/src/ioc/db/dbState.h
+++ b/modules/database/src/ioc/db/dbState.h
@@ -14,7 +14,7 @@
 #ifndef INCdbStateH
 #define INCdbStateH
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,14 +45,14 @@ typedef struct dbState *dbStateId;
  * @param name Db state name.
  * @return Id of db state, NULL for failure.
  */
-epicsShareFunc dbStateId dbStateCreate(const char *name);
+DBCORE_API dbStateId dbStateCreate(const char *name);
 
 /** @brief Find db state.
  *
  * @param name Db state name.
  * @return Id of db state, NULL if not found.
  */
-epicsShareFunc dbStateId dbStateFind(const char *name);
+DBCORE_API dbStateId dbStateFind(const char *name);
 
 /** @brief Set db state to TRUE.
  *
@@ -60,7 +60,7 @@ epicsShareFunc dbStateId dbStateFind(const char *name);
  *
  * @param id Db state id.
  */
-epicsShareFunc void dbStateSet(dbStateId id);
+DBCORE_API void dbStateSet(dbStateId id);
 
 /** @brief Set db state to FALSE.
  *
@@ -68,14 +68,14 @@ epicsShareFunc void dbStateSet(dbStateId id);
  *
  * @param id Db state id.
  */
-epicsShareFunc void dbStateClear(dbStateId id);
+DBCORE_API void dbStateClear(dbStateId id);
 
 /** @brief Get db state.
  *
  * @param id Db state id.
  * @return Current db state (0|1).
  */
-epicsShareFunc int dbStateGet(dbStateId id);
+DBCORE_API int dbStateGet(dbStateId id);
 
 /** @brief Print info about db state.
  *
@@ -84,7 +84,7 @@ epicsShareFunc int dbStateGet(dbStateId id);
  * @param id Db state id.
  * @param level Interest level.
  */
-epicsShareFunc void dbStateShow(dbStateId id, unsigned int level);
+DBCORE_API void dbStateShow(dbStateId id, unsigned int level);
 
 /** @brief Print info about all db states.
  *
@@ -92,7 +92,7 @@ epicsShareFunc void dbStateShow(dbStateId id, unsigned int level);
  *
  * @param level Interest level.
  */
-epicsShareFunc void dbStateShowAll(unsigned int level);
+DBCORE_API void dbStateShowAll(unsigned int level);
 
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/db/dbSubscriptionIO.cpp
+++ b/modules/database/src/ioc/db/dbSubscriptionIO.cpp
@@ -27,7 +27,6 @@
 #include "cadef.h" // this can be eliminated when the callbacks use the new interface
 #include "errlog.h"
 
-#define epicsExportSharedSymbols
 #include "dbCAC.h"
 #include "dbChannelIO.h"
 #include "db_access_routines.h"

--- a/modules/database/src/ioc/db/dbTest.c
+++ b/modules/database/src/ioc/db/dbTest.c
@@ -23,7 +23,6 @@
 #include "epicsString.h"
 #include "errlog.h"
 
-#define epicsExportSharedSymbols
 #include "callback.h"
 #include "dbAccessDefs.h"
 #include "dbAddr.h"

--- a/modules/database/src/ioc/db/dbTest.h
+++ b/modules/database/src/ioc/db/dbTest.h
@@ -11,42 +11,42 @@
 #ifndef INC_dbTest_H
 #define INC_dbTest_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /*dbAddr info */
-epicsShareFunc long dba(const char *pname);
+DBCORE_API long dba(const char *pname);
 /*list records*/
-epicsShareFunc long dbl(
+DBCORE_API long dbl(
     const char *precordTypename,const char *fields);
 /*list number of records of each type*/
-epicsShareFunc long dbnr(int verbose);
+DBCORE_API long dbnr(int verbose);
 /* list aliases */
-epicsShareFunc long dbla(const char *pmask);
+DBCORE_API long dbla(const char *pmask);
 /* list infos */
-epicsShareFunc long dbli(const char *patern);
+DBCORE_API long dbli(const char *patern);
 /*list records with mask*/
-epicsShareFunc long dbgrep(const char *pmask);
+DBCORE_API long dbgrep(const char *pmask);
 /*get field value*/
-epicsShareFunc long dbgf(const char *pname);
+DBCORE_API long dbgf(const char *pname);
 /*put field value*/
-epicsShareFunc long dbpf(const char *pname,const char *pvalue);
+DBCORE_API long dbpf(const char *pname,const char *pvalue);
 /*print record*/
-epicsShareFunc long dbpr(const char *pname,int interest_level);
+DBCORE_API long dbpr(const char *pname,int interest_level);
 /*test record*/
-epicsShareFunc long dbtr(const char *pname);
+DBCORE_API long dbtr(const char *pname);
 /*test get field*/
-epicsShareFunc long dbtgf(const char *pname);
+DBCORE_API long dbtgf(const char *pname);
 /*test put field*/
-epicsShareFunc long dbtpf(const char *pname,const char *pvalue);
+DBCORE_API long dbtpf(const char *pname,const char *pvalue);
 /*I/O report */
-epicsShareFunc long dbior(
+DBCORE_API long dbior(
     const char *pdrvName,int interest_level);
 /*Hardware Configuration Report*/
-epicsShareFunc int dbhcr(void);
+DBCORE_API int dbhcr(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbUnitTest.c
+++ b/modules/database/src/ioc/db/dbUnitTest.c
@@ -23,7 +23,6 @@
 #include "epicsEvent.h"
 #include "epicsThread.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccess.h"
 #include "dbBase.h"
 #include "dbChannel.h"

--- a/modules/database/src/ioc/db/dbUnitTest.h
+++ b/modules/database/src/ioc/db/dbUnitTest.h
@@ -22,7 +22,7 @@
 #include "dbAddr.h"
 #include "dbCommon.h"
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,31 +32,31 @@ extern "C" {
  *
  * @see @ref dbtestskel
  */
-epicsShareFunc void testdbPrepare(void);
+DBCORE_API void testdbPrepare(void);
 /** Read .dbd or .db file
  *
  * @see @ref dbtestskel
  */
-epicsShareFunc void testdbReadDatabase(const char* file,
+DBCORE_API void testdbReadDatabase(const char* file,
                                        const char* path,
                                        const char* substitutions);
 /** Assert success of iocInit()
  *
  * @see @ref dbtestskel
  */
-epicsShareFunc void testIocInitOk(void);
+DBCORE_API void testIocInitOk(void);
 /** Shutdown test database processing.
  *
  * eg. Stops scan threads
  *
  * @see @ref dbtestskel
  */
-epicsShareFunc void testIocShutdownOk(void);
+DBCORE_API void testIocShutdownOk(void);
 /** Final step in test database cleanup
  *
  * @see @ref dbtestskel
  */
-epicsShareFunc void testdbCleanup(void);
+DBCORE_API void testdbCleanup(void);
 
 /** Assert that a dbPutField() scalar operation will complete successfully.
  *
@@ -66,19 +66,19 @@ epicsShareFunc void testdbCleanup(void);
  *
  * @see @ref dbtestactions
  */
-epicsShareFunc void testdbPutFieldOk(const char* pv, int dbrType, ...);
+DBCORE_API void testdbPutFieldOk(const char* pv, int dbrType, ...);
 
 /** Assert that a dbPutField() operation will fail with a certain S_\* code
  *
  * @see @ref dbtestactions
  */
-epicsShareFunc void testdbPutFieldFail(long status, const char* pv, int dbrType, ...);
+DBCORE_API void testdbPutFieldFail(long status, const char* pv, int dbrType, ...);
 
 /** Assert that a dbPutField() scalar operation will complete successfully.
  *
  * @see @ref dbtestactions
  */
-epicsShareFunc long testdbVPutField(const char* pv, short dbrType, va_list ap);
+DBCORE_API long testdbVPutField(const char* pv, short dbrType, va_list ap);
 
 /** Assert that a dbGetField() scalar operation will complete successfully, with the provided value.
  *
@@ -88,13 +88,13 @@ epicsShareFunc long testdbVPutField(const char* pv, short dbrType, va_list ap);
  *
  * @see @ref dbtestactions
  */
-epicsShareFunc void testdbGetFieldEqual(const char* pv, int dbrType, ...);
+DBCORE_API void testdbGetFieldEqual(const char* pv, int dbrType, ...);
 
 /** Assert that a dbGetField() scalar operation will complete successfully, with the provided value.
  *
  * @see @ref dbtestactions
  */
-epicsShareFunc void testdbVGetFieldEqual(const char* pv, short dbrType, va_list ap);
+DBCORE_API void testdbVGetFieldEqual(const char* pv, short dbrType, va_list ap);
 
 /** Assert that a dbPutField() array operation will complete successfully.
  *
@@ -110,7 +110,7 @@ epicsShareFunc void testdbVGetFieldEqual(const char* pv, short dbrType, va_list 
  *
  * @see @ref dbtestactions
  */
-epicsShareFunc void testdbPutArrFieldOk(const char* pv, short dbrType, unsigned long count, const void *pbuf);
+DBCORE_API void testdbPutArrFieldOk(const char* pv, short dbrType, unsigned long count, const void *pbuf);
 
 /**
  * @param pv PV name string
@@ -127,7 +127,7 @@ epicsShareFunc void testdbPutArrFieldOk(const char* pv, short dbrType, unsigned 
  * nRequest < pbufcnt always fails.
  * nRequest ==pbufcnt checks prefix (actual may be longer than expected)
  */
-epicsShareFunc void testdbGetArrFieldEqual(const char* pv, short dbfType, long nRequest, unsigned long pbufcnt, const void *pbuf);
+DBCORE_API void testdbGetArrFieldEqual(const char* pv, short dbfType, long nRequest, unsigned long pbufcnt, const void *pbuf);
 
 /** Obtain pointer to record.
  *
@@ -135,19 +135,19 @@ epicsShareFunc void testdbGetArrFieldEqual(const char* pv, short dbfType, long n
  *
  * @note Remember to dbScanLock() when accessing mutable fields.
  */
-epicsShareFunc dbCommon* testdbRecordPtr(const char* pv);
+DBCORE_API dbCommon* testdbRecordPtr(const char* pv);
 
 typedef struct testMonitor testMonitor;
 
 /** Setup monitoring the named PV for changes */
-epicsShareFunc testMonitor* testMonitorCreate(const char* pvname, unsigned dbe_mask, unsigned opt);
+DBCORE_API testMonitor* testMonitorCreate(const char* pvname, unsigned dbe_mask, unsigned opt);
 /** Stop monitoring */
-epicsShareFunc void testMonitorDestroy(testMonitor*);
+DBCORE_API void testMonitorDestroy(testMonitor*);
 /** Return immediately if it has been updated since create, last wait,
  * or reset (count w/ reset=1).
  * Otherwise, block until the value of the target PV is updated.
  */
-epicsShareFunc void testMonitorWait(testMonitor*);
+DBCORE_API void testMonitorWait(testMonitor*);
 /** Return the number of monitor events which have occured since create,
  * or a pervious reset (called reset=1).
  * Calling w/ reset=0 only returns the count.
@@ -155,26 +155,26 @@ epicsShareFunc void testMonitorWait(testMonitor*);
  * wait will block unless subsequent events occur.  Returns the previous
  * count.
  */
-epicsShareFunc unsigned testMonitorCount(testMonitor*, unsigned reset);
+DBCORE_API unsigned testMonitorCount(testMonitor*, unsigned reset);
 
 /** Synchronize the shared callback queues.
  *
  * Block until all callback queue jobs which were queued, or running,
  * have completed.
  */
-epicsShareFunc void testSyncCallback(void);
+DBCORE_API void testSyncCallback(void);
 
 /** Lock Global convenience mutex for use by test code.
  *
  * @see @ref dbtestmutex
  */
-epicsShareFunc void testGlobalLock(void);
+DBCORE_API void testGlobalLock(void);
 
 /** Unlock Global convenience mutex for use by test code.
  *
  * @see @ref dbtestmutex
  */
-epicsShareFunc void testGlobalUnlock(void);
+DBCORE_API void testGlobalUnlock(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/db_access.c
+++ b/modules/database/src/ioc/db/db_access.c
@@ -33,7 +33,6 @@
 #include "db_access.h"
 #undef db_accessHFORdb_accessC
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "db_access_routines.h"
 #include "dbBase.h"

--- a/modules/database/src/ioc/db/db_access_routines.h
+++ b/modules/database/src/ioc/db/db_access_routines.h
@@ -20,21 +20,21 @@
 extern "C" {
 #endif
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
-epicsShareExtern struct dbBase *pdbbase;
-epicsShareExtern volatile int interruptAccept;
+DBCORE_API extern struct dbBase *pdbbase;
+DBCORE_API extern volatile int interruptAccept;
 
 
 /*
  * Adaptors for db_access users
  */
-epicsShareFunc struct dbChannel * dbChannel_create(const char *pname);
-epicsShareFunc int dbChannel_get(struct dbChannel *chan,
+DBCORE_API struct dbChannel * dbChannel_create(const char *pname);
+DBCORE_API int dbChannel_get(struct dbChannel *chan,
     int buffer_type, void *pbuffer, long no_elements, void *pfl);
-epicsShareFunc int dbChannel_put(struct dbChannel *chan, int src_type,
+DBCORE_API int dbChannel_put(struct dbChannel *chan, int src_type,
     const void *psrc, long no_elements);
-epicsShareFunc int dbChannel_get_count(struct dbChannel *chan,
+DBCORE_API int dbChannel_get_count(struct dbChannel *chan,
     int buffer_type, void *pbuffer, long *nRequest, void *pfl);
 
 

--- a/modules/database/src/ioc/db/db_convert.h
+++ b/modules/database/src/ioc/db/db_convert.h
@@ -16,29 +16,29 @@
 extern "C" {
 #endif
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 #include "dbAddr.h"
 
-epicsShareExtern struct dbBase *pdbbase;
-epicsShareExtern volatile int interruptAccept;
+DBCORE_API extern struct dbBase *pdbbase;
+DBCORE_API extern volatile int interruptAccept;
 
 /*Definitions that allow old database access to use new conversion routines*/
 #define newDBF_DEVICE 13
 #define newDBR_ENUM    11
-epicsShareExtern long (*dbGetConvertRoutine[newDBF_DEVICE+1][newDBR_ENUM+1])
+DBCORE_API extern long (*dbGetConvertRoutine[newDBF_DEVICE+1][newDBR_ENUM+1])
     (struct dbAddr *paddr, void *pbuffer,long nRequest,
         long no_elements, long offset);
-epicsShareExtern long (*dbPutConvertRoutine[newDBR_ENUM+1][newDBF_DEVICE+1])
+DBCORE_API extern long (*dbPutConvertRoutine[newDBR_ENUM+1][newDBF_DEVICE+1])
     (struct dbAddr *paddr, const void *pbuffer,long nRequest,
         long no_elements, long offset);
-epicsShareExtern long (*dbFastGetConvertRoutine[newDBF_DEVICE+1][newDBR_ENUM+1])
+DBCORE_API extern long (*dbFastGetConvertRoutine[newDBF_DEVICE+1][newDBR_ENUM+1])
     (const void *from, void *to, dbAddr *paddr);
-epicsShareExtern long (*dbFastPutConvertRoutine[newDBR_ENUM+1][newDBF_DEVICE+1])
+DBCORE_API extern long (*dbFastPutConvertRoutine[newDBR_ENUM+1][newDBF_DEVICE+1])
     (const void *from, void *to, dbAddr *paddr);
 
 /*Conversion between old and new DBR types*/
-epicsShareExtern unsigned short dbDBRoldToDBFnew[DBR_DOUBLE+1];
-epicsShareExtern unsigned short dbDBRnewToDBRold[newDBR_ENUM+1];
+DBCORE_API extern unsigned short dbDBRoldToDBFnew[DBR_DOUBLE+1];
+DBCORE_API extern unsigned short dbDBRnewToDBRold[newDBR_ENUM+1];
 #ifdef DB_CONVERT_GBLSOURCE
 unsigned short dbDBRoldToDBFnew[DBR_DOUBLE+1] = {
     0, /*DBR_STRING to DBF_STRING*/

--- a/modules/database/src/ioc/db/db_test.c
+++ b/modules/database/src/ioc/db/db_test.c
@@ -24,7 +24,6 @@
 #include "errlog.h"
 #include "epicsEvent.h"
 
-#define epicsExportSharedSymbols
 #include "db_access_routines.h"
 #include "dbChannel.h"
 #include "dbCommon.h"

--- a/modules/database/src/ioc/db/db_test.h
+++ b/modules/database/src/ioc/db/db_test.h
@@ -11,15 +11,15 @@
 #ifndef INCLdb_testh
 #define INCLdb_testh
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc int gft(const char *pname);
-epicsShareFunc int pft(const char *pname, const char *pvalue);
-epicsShareFunc int tpn(const char *pname, const char *pvalue);
+DBCORE_API int gft(const char *pname);
+DBCORE_API int pft(const char *pname, const char *pvalue);
+DBCORE_API int tpn(const char *pname, const char *pvalue);
 #ifdef __cplusplus
 }
 #endif

--- a/modules/database/src/ioc/db/recGbl.c
+++ b/modules/database/src/ioc/db/recGbl.c
@@ -29,7 +29,6 @@
 
 #include "caeventmask.h"
 
-#define epicsExportSharedSymbols
 #include "dbAccessDefs.h"
 #include "dbStaticLib.h"
 #include "dbAddr.h"

--- a/modules/database/src/ioc/db/recGbl.h
+++ b/modules/database/src/ioc/db/recGbl.h
@@ -16,7 +16,7 @@
 #define INCrecGblh 1
 
 #include "epicsTypes.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -37,43 +37,43 @@ struct dbCommon;
 
 typedef void (*RECGBL_ALARM_HOOK_ROUTINE)(struct dbCommon *prec,
     epicsEnum16 prev_sevr, epicsEnum16 prev_stat);
-epicsShareExtern RECGBL_ALARM_HOOK_ROUTINE recGblAlarmHook;
+DBCORE_API extern RECGBL_ALARM_HOOK_ROUTINE recGblAlarmHook;
 
 /* Global Record Support Routines */
 
-epicsShareFunc void recGblDbaddrError(long status, const struct dbAddr *paddr,
+DBCORE_API void recGblDbaddrError(long status, const struct dbAddr *paddr,
     const char *pcaller_name);
-epicsShareFunc void recGblRecordError(long status, void *precord,
+DBCORE_API void recGblRecordError(long status, void *precord,
     const char *pcaller_name);
-epicsShareFunc void recGblRecSupError(long status, const struct dbAddr *paddr,
+DBCORE_API void recGblRecSupError(long status, const struct dbAddr *paddr,
     const char *pcaller_name, const char *psupport_name);
-epicsShareFunc void recGblGetGraphicDouble(const struct dbAddr *paddr,
+DBCORE_API void recGblGetGraphicDouble(const struct dbAddr *paddr,
     struct dbr_grDouble *pgd);
-epicsShareFunc void recGblGetControlDouble(
+DBCORE_API void recGblGetControlDouble(
     const struct dbAddr *paddr, struct dbr_ctrlDouble *pcd);
-epicsShareFunc void recGblGetAlarmDouble(const struct dbAddr *paddr,
+DBCORE_API void recGblGetAlarmDouble(const struct dbAddr *paddr,
     struct dbr_alDouble *pad);
-epicsShareFunc void recGblGetPrec(const struct dbAddr *paddr,
+DBCORE_API void recGblGetPrec(const struct dbAddr *paddr,
     long *pprecision);
-epicsShareFunc int  recGblInitConstantLink(struct link *plink,
+DBCORE_API int  recGblInitConstantLink(struct link *plink,
     short dbftype, void *pdest);
-epicsShareFunc unsigned short recGblResetAlarms(void *precord);
-epicsShareFunc int recGblSetSevr(void *precord, epicsEnum16 new_stat,
+DBCORE_API unsigned short recGblResetAlarms(void *precord);
+DBCORE_API int recGblSetSevr(void *precord, epicsEnum16 new_stat,
     epicsEnum16 new_sevr);
-epicsShareFunc void recGblInheritSevr(int msMode, void *precord, epicsEnum16 stat,
+DBCORE_API void recGblInheritSevr(int msMode, void *precord, epicsEnum16 stat,
     epicsEnum16 sevr);
-epicsShareFunc void recGblFwdLink(void *precord);
-epicsShareFunc void recGblGetTimeStamp(void *precord);
-epicsShareFunc void recGblGetTimeStampSimm(void *prec, const epicsEnum16 simm, struct link *siol);
-epicsShareFunc void recGblCheckDeadband(epicsFloat64 *poldval, const epicsFloat64 newval,
+DBCORE_API void recGblFwdLink(void *precord);
+DBCORE_API void recGblGetTimeStamp(void *precord);
+DBCORE_API void recGblGetTimeStampSimm(void *prec, const epicsEnum16 simm, struct link *siol);
+DBCORE_API void recGblCheckDeadband(epicsFloat64 *poldval, const epicsFloat64 newval,
     const epicsFloat64 deadband, unsigned *monitor_mask, const unsigned add_mask);
-epicsShareFunc void recGblSaveSimm(const epicsEnum16 sscn,
+DBCORE_API void recGblSaveSimm(const epicsEnum16 sscn,
     epicsEnum16 *poldsimm, const epicsEnum16 simm);
-epicsShareFunc void recGblCheckSimm(struct dbCommon *prec, epicsEnum16 *psscn,
+DBCORE_API void recGblCheckSimm(struct dbCommon *prec, epicsEnum16 *psscn,
     const epicsEnum16 oldsimm, const epicsEnum16 simm);
-epicsShareFunc void recGblInitSimm(struct dbCommon *prec, epicsEnum16 *psscn,
+DBCORE_API void recGblInitSimm(struct dbCommon *prec, epicsEnum16 *psscn,
     epicsEnum16 *poldsimm, epicsEnum16 *psimm, struct link *psiml);
-epicsShareFunc long recGblGetSimm(struct dbCommon *prec, epicsEnum16 *psscn,
+DBCORE_API long recGblGetSimm(struct dbCommon *prec, epicsEnum16 *psscn,
     epicsEnum16 *poldsimm, epicsEnum16 *psimm, struct link *psiml);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/dbStatic/dbFldTypes.h
+++ b/modules/database/src/ioc/dbStatic/dbFldTypes.h
@@ -14,7 +14,7 @@
 #ifndef INCdbFldTypesh
 #define INCdbFldTypesh 1
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,7 +48,7 @@ typedef struct mapdbfType{
     dbfType value;
 }mapdbfType;
 
-epicsShareExtern mapdbfType pamapdbfType[];
+DBCORE_API extern mapdbfType pamapdbfType[];
 #ifdef DBFLDTYPES_GBLSOURCE
 mapdbfType pamapdbfType[DBF_NTYPES] = {
     {"DBF_STRING",DBF_STRING},

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -28,7 +28,6 @@
 #include "gpHash.h"
 #include "macLib.h"
 
-#define epicsExportSharedSymbols
 #include "dbBase.h"
 #include "dbFldTypes.h"
 #include "dbStaticLib.h"

--- a/modules/database/src/ioc/dbStatic/dbPvdLib.c
+++ b/modules/database/src/ioc/dbStatic/dbPvdLib.c
@@ -21,7 +21,6 @@
 #include "epicsStdio.h"
 #include "epicsString.h"
 
-#define epicsExportSharedSymbols
 #include "dbBase.h"
 #include "dbStaticLib.h"
 #include "dbStaticPvt.h"

--- a/modules/database/src/ioc/dbStatic/dbStaticIocRegister.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticIocRegister.c
@@ -10,7 +10,6 @@
 
 #include "iocsh.h"
 
-#define epicsExportSharedSymbols
 #include "dbStaticIocRegister.h"
 #include "dbStaticLib.h"
 #include "dbStaticPvt.h"

--- a/modules/database/src/ioc/dbStatic/dbStaticIocRegister.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticIocRegister.h
@@ -11,13 +11,13 @@
 #ifndef INC_dbStaticIocRegister_H
 #define INC_dbStaticIocRegister_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc void dbStaticIocRegister(void);
+DBCORE_API void dbStaticIocRegister(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -34,7 +34,6 @@
 #define DBFLDTYPES_GBLSOURCE
 #define SPECIAL_GBLSOURCE
 
-#define epicsExportSharedSymbols
 #include "dbChannel.h"
 #include "dbFldTypes.h"
 #include "dbStaticLib.h"

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.h
@@ -18,7 +18,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 #include "dbFldTypes.h"
 #include "dbBase.h"
 #include "link.h"
@@ -43,192 +43,192 @@ typedef struct dbEntry {
 } DBENTRY;
 
 /* Static database access routines*/
-epicsShareFunc DBBASE * dbAllocBase(void);
-epicsShareFunc void dbFreeBase(DBBASE *pdbbase);
-epicsShareFunc DBENTRY * dbAllocEntry(DBBASE *pdbbase);
-epicsShareFunc void dbFreeEntry(DBENTRY *pdbentry);
-epicsShareFunc void dbInitEntry(DBBASE *pdbbase,
+DBCORE_API DBBASE * dbAllocBase(void);
+DBCORE_API void dbFreeBase(DBBASE *pdbbase);
+DBCORE_API DBENTRY * dbAllocEntry(DBBASE *pdbbase);
+DBCORE_API void dbFreeEntry(DBENTRY *pdbentry);
+DBCORE_API void dbInitEntry(DBBASE *pdbbase,
     DBENTRY *pdbentry);
 
-epicsShareFunc void dbFinishEntry(DBENTRY *pdbentry);
-epicsShareFunc DBENTRY * dbCopyEntry(DBENTRY *pdbentry);
-epicsShareFunc void dbCopyEntryContents(DBENTRY *pfrom,
+DBCORE_API void dbFinishEntry(DBENTRY *pdbentry);
+DBCORE_API DBENTRY * dbCopyEntry(DBENTRY *pdbentry);
+DBCORE_API void dbCopyEntryContents(DBENTRY *pfrom,
     DBENTRY *pto);
 
-epicsShareExtern int dbBptNotMonotonic;
+DBCORE_API extern int dbBptNotMonotonic;
 
-epicsShareFunc long dbReadDatabase(DBBASE **ppdbbase,
+DBCORE_API long dbReadDatabase(DBBASE **ppdbbase,
     const char *filename, const char *path, const char *substitutions);
-epicsShareFunc long dbReadDatabaseFP(DBBASE **ppdbbase,
+DBCORE_API long dbReadDatabaseFP(DBBASE **ppdbbase,
     FILE *fp, const char *path, const char *substitutions);
-epicsShareFunc long dbPath(DBBASE *pdbbase, const char *path);
-epicsShareFunc long dbAddPath(DBBASE *pdbbase, const char *path);
-epicsShareFunc char * dbGetPromptGroupNameFromKey(DBBASE *pdbbase,
+DBCORE_API long dbPath(DBBASE *pdbbase, const char *path);
+DBCORE_API long dbAddPath(DBBASE *pdbbase, const char *path);
+DBCORE_API char * dbGetPromptGroupNameFromKey(DBBASE *pdbbase,
     const short key);
-epicsShareFunc short dbGetPromptGroupKeyFromName(DBBASE *pdbbase,
+DBCORE_API short dbGetPromptGroupKeyFromName(DBBASE *pdbbase,
     const char *name);
-epicsShareFunc long dbWriteRecord(DBBASE *ppdbbase,
+DBCORE_API long dbWriteRecord(DBBASE *ppdbbase,
     const char *filename, const char *precordTypename, int level);
-epicsShareFunc long dbWriteRecordFP(DBBASE *ppdbbase,
+DBCORE_API long dbWriteRecordFP(DBBASE *ppdbbase,
     FILE *fp, const char *precordTypename, int level);
-epicsShareFunc long dbWriteMenu(DBBASE *pdbbase,
+DBCORE_API long dbWriteMenu(DBBASE *pdbbase,
     const char *filename, const char *menuName);
-epicsShareFunc long dbWriteMenuFP(DBBASE *pdbbase,
+DBCORE_API long dbWriteMenuFP(DBBASE *pdbbase,
     FILE *fp, const char *menuName);
-epicsShareFunc long dbWriteRecordType(DBBASE *pdbbase,
+DBCORE_API long dbWriteRecordType(DBBASE *pdbbase,
     const char *filename, const char *recordTypeName);
-epicsShareFunc long dbWriteRecordTypeFP(DBBASE *pdbbase,
+DBCORE_API long dbWriteRecordTypeFP(DBBASE *pdbbase,
     FILE *fp, const char *recordTypeName);
-epicsShareFunc long dbWriteDevice(DBBASE *pdbbase,
+DBCORE_API long dbWriteDevice(DBBASE *pdbbase,
     const char *filename);
-epicsShareFunc long dbWriteDeviceFP(DBBASE *pdbbase, FILE *fp);
-epicsShareFunc long dbWriteDriver(DBBASE *pdbbase,
+DBCORE_API long dbWriteDeviceFP(DBBASE *pdbbase, FILE *fp);
+DBCORE_API long dbWriteDriver(DBBASE *pdbbase,
     const char *filename);
-epicsShareFunc long dbWriteDriverFP(DBBASE *pdbbase, FILE *fp);
-epicsShareFunc long dbWriteLinkFP(DBBASE *pdbbase, FILE *fp);
-epicsShareFunc long dbWriteRegistrarFP(DBBASE *pdbbase, FILE *fp);
-epicsShareFunc long dbWriteFunctionFP(DBBASE *pdbbase, FILE *fp);
-epicsShareFunc long dbWriteVariableFP(DBBASE *pdbbase, FILE *fp);
-epicsShareFunc long dbWriteBreaktable(DBBASE *pdbbase,
+DBCORE_API long dbWriteDriverFP(DBBASE *pdbbase, FILE *fp);
+DBCORE_API long dbWriteLinkFP(DBBASE *pdbbase, FILE *fp);
+DBCORE_API long dbWriteRegistrarFP(DBBASE *pdbbase, FILE *fp);
+DBCORE_API long dbWriteFunctionFP(DBBASE *pdbbase, FILE *fp);
+DBCORE_API long dbWriteVariableFP(DBBASE *pdbbase, FILE *fp);
+DBCORE_API long dbWriteBreaktable(DBBASE *pdbbase,
     const char *filename);
-epicsShareFunc long dbWriteBreaktableFP(DBBASE *pdbbase,
+DBCORE_API long dbWriteBreaktableFP(DBBASE *pdbbase,
     FILE *fp);
 
-epicsShareFunc long dbFindRecordType(DBENTRY *pdbentry,
+DBCORE_API long dbFindRecordType(DBENTRY *pdbentry,
     const char *recordTypename);
-epicsShareFunc long dbFirstRecordType(DBENTRY *pdbentry);
-epicsShareFunc long dbNextRecordType(DBENTRY *pdbentry);
-epicsShareFunc char * dbGetRecordTypeName(DBENTRY *pdbentry);
-epicsShareFunc int  dbGetNRecordTypes(DBENTRY *pdbentry);
-epicsShareFunc long dbPutRecordAttribute(DBENTRY *pdbentry,
+DBCORE_API long dbFirstRecordType(DBENTRY *pdbentry);
+DBCORE_API long dbNextRecordType(DBENTRY *pdbentry);
+DBCORE_API char * dbGetRecordTypeName(DBENTRY *pdbentry);
+DBCORE_API int  dbGetNRecordTypes(DBENTRY *pdbentry);
+DBCORE_API long dbPutRecordAttribute(DBENTRY *pdbentry,
     const char *name, const char*value);
-epicsShareFunc long dbGetRecordAttribute(DBENTRY *pdbentry,
+DBCORE_API long dbGetRecordAttribute(DBENTRY *pdbentry,
     const char *name);
-epicsShareFunc long dbGetAttributePart(DBENTRY *pdbentry,
+DBCORE_API long dbGetAttributePart(DBENTRY *pdbentry,
     const char **ppname);
 
-epicsShareFunc long dbFirstField(DBENTRY *pdbentry, int dctonly);
-epicsShareFunc long dbNextField(DBENTRY *pdbentry, int dctonly);
-epicsShareFunc int  dbGetNFields(DBENTRY *pdbentry, int dctonly);
-epicsShareFunc char * dbGetFieldName(DBENTRY *pdbentry);
-epicsShareFunc int dbGetFieldDbfType(DBENTRY *pdbentry);
-epicsShareFunc char * dbGetDefault(DBENTRY *pdbentry);
-epicsShareFunc char * dbGetPrompt(DBENTRY *pdbentry);
-epicsShareFunc int dbGetPromptGroup(DBENTRY *pdbentry);
+DBCORE_API long dbFirstField(DBENTRY *pdbentry, int dctonly);
+DBCORE_API long dbNextField(DBENTRY *pdbentry, int dctonly);
+DBCORE_API int  dbGetNFields(DBENTRY *pdbentry, int dctonly);
+DBCORE_API char * dbGetFieldName(DBENTRY *pdbentry);
+DBCORE_API int dbGetFieldDbfType(DBENTRY *pdbentry);
+DBCORE_API char * dbGetDefault(DBENTRY *pdbentry);
+DBCORE_API char * dbGetPrompt(DBENTRY *pdbentry);
+DBCORE_API int dbGetPromptGroup(DBENTRY *pdbentry);
 
-epicsShareFunc long dbCreateRecord(DBENTRY *pdbentry,
+DBCORE_API long dbCreateRecord(DBENTRY *pdbentry,
     const char *pname);
-epicsShareFunc long dbDeleteRecord(DBENTRY *pdbentry);
-epicsShareFunc long dbFreeRecords(DBBASE *pdbbase);
-epicsShareFunc long dbFindRecordPart(DBENTRY *pdbentry,
+DBCORE_API long dbDeleteRecord(DBENTRY *pdbentry);
+DBCORE_API long dbFreeRecords(DBBASE *pdbbase);
+DBCORE_API long dbFindRecordPart(DBENTRY *pdbentry,
     const char **ppname);
-epicsShareFunc long dbFindRecord(DBENTRY *pdbentry,
+DBCORE_API long dbFindRecord(DBENTRY *pdbentry,
     const char *pname);
 
-epicsShareFunc long dbFirstRecord(DBENTRY *pdbentry);
-epicsShareFunc long dbNextRecord(DBENTRY *pdbentry);
-epicsShareFunc int  dbGetNRecords(DBENTRY *pdbentry);
-epicsShareFunc int  dbGetNAliases(DBENTRY *pdbentry);
-epicsShareFunc char * dbGetRecordName(DBENTRY *pdbentry);
-epicsShareFunc long dbCopyRecord(DBENTRY *pdbentry,
+DBCORE_API long dbFirstRecord(DBENTRY *pdbentry);
+DBCORE_API long dbNextRecord(DBENTRY *pdbentry);
+DBCORE_API int  dbGetNRecords(DBENTRY *pdbentry);
+DBCORE_API int  dbGetNAliases(DBENTRY *pdbentry);
+DBCORE_API char * dbGetRecordName(DBENTRY *pdbentry);
+DBCORE_API long dbCopyRecord(DBENTRY *pdbentry,
     const char *newRecordName, int overWriteOK);
 
-epicsShareFunc long dbVisibleRecord(DBENTRY *pdbentry);
-epicsShareFunc long dbInvisibleRecord(DBENTRY *pdbentry);
-epicsShareFunc int dbIsVisibleRecord(DBENTRY *pdbentry);
+DBCORE_API long dbVisibleRecord(DBENTRY *pdbentry);
+DBCORE_API long dbInvisibleRecord(DBENTRY *pdbentry);
+DBCORE_API int dbIsVisibleRecord(DBENTRY *pdbentry);
 
-epicsShareFunc long dbCreateAlias(DBENTRY *pdbentry,
+DBCORE_API long dbCreateAlias(DBENTRY *pdbentry,
     const char *paliasName);
-epicsShareFunc int dbIsAlias(DBENTRY *pdbentry);
+DBCORE_API int dbIsAlias(DBENTRY *pdbentry);
 /* Follow alias to actual record */
-epicsShareFunc int dbFollowAlias(DBENTRY *pdbentry);
-epicsShareFunc long dbDeleteAliases(DBENTRY *pdbentry);
+DBCORE_API int dbFollowAlias(DBENTRY *pdbentry);
+DBCORE_API long dbDeleteAliases(DBENTRY *pdbentry);
 
-epicsShareFunc long dbFindFieldPart(DBENTRY *pdbentry,
+DBCORE_API long dbFindFieldPart(DBENTRY *pdbentry,
     const char **ppname);
-epicsShareFunc long dbFindField(DBENTRY *pdbentry,
+DBCORE_API long dbFindField(DBENTRY *pdbentry,
     const char *pfieldName);
-epicsShareFunc int dbFoundField(DBENTRY *pdbentry);
-epicsShareFunc char * dbGetString(DBENTRY *pdbentry);
-epicsShareFunc long dbPutString(DBENTRY *pdbentry,
+DBCORE_API int dbFoundField(DBENTRY *pdbentry);
+DBCORE_API char * dbGetString(DBENTRY *pdbentry);
+DBCORE_API long dbPutString(DBENTRY *pdbentry,
     const char *pstring);
-epicsShareFunc char * dbVerify(DBENTRY *pdbentry,
+DBCORE_API char * dbVerify(DBENTRY *pdbentry,
     const char *pstring);
-epicsShareFunc int  dbIsDefaultValue(DBENTRY *pdbentry);
+DBCORE_API int  dbIsDefaultValue(DBENTRY *pdbentry);
 
-epicsShareFunc long dbFirstInfo(DBENTRY *pdbentry);
-epicsShareFunc long dbNextInfo(DBENTRY *pdbentry);
-epicsShareFunc long dbFindInfo(DBENTRY *pdbentry,
+DBCORE_API long dbFirstInfo(DBENTRY *pdbentry);
+DBCORE_API long dbNextInfo(DBENTRY *pdbentry);
+DBCORE_API long dbFindInfo(DBENTRY *pdbentry,
     const char *name);
-epicsShareFunc long dbNextMatchingInfo(DBENTRY *pdbentry,
+DBCORE_API long dbNextMatchingInfo(DBENTRY *pdbentry,
     const char *pattern);
-epicsShareFunc long dbDeleteInfo(DBENTRY *pdbentry);
-epicsShareFunc const char * dbGetInfoName(DBENTRY *pdbentry);
-epicsShareFunc const char * dbGetInfoString(DBENTRY *pdbentry);
-epicsShareFunc long dbPutInfoString(DBENTRY *pdbentry,
+DBCORE_API long dbDeleteInfo(DBENTRY *pdbentry);
+DBCORE_API const char * dbGetInfoName(DBENTRY *pdbentry);
+DBCORE_API const char * dbGetInfoString(DBENTRY *pdbentry);
+DBCORE_API long dbPutInfoString(DBENTRY *pdbentry,
     const char *string);
-epicsShareFunc long dbPutInfoPointer(DBENTRY *pdbentry,
+DBCORE_API long dbPutInfoPointer(DBENTRY *pdbentry,
     void *pointer);
-epicsShareFunc void * dbGetInfoPointer(DBENTRY *pdbentry);
-epicsShareFunc const char * dbGetInfo(DBENTRY *pdbentry,
+DBCORE_API void * dbGetInfoPointer(DBENTRY *pdbentry);
+DBCORE_API const char * dbGetInfo(DBENTRY *pdbentry,
     const char *name);
-epicsShareFunc long dbPutInfo(DBENTRY *pdbentry,
+DBCORE_API long dbPutInfo(DBENTRY *pdbentry,
     const char *name, const char *string);
 
-epicsShareFunc brkTable * dbFindBrkTable(DBBASE *pdbbase,
+DBCORE_API brkTable * dbFindBrkTable(DBBASE *pdbbase,
     const char *name);
 
-epicsShareFunc const char * dbGetFieldTypeString(int dbfType);
-epicsShareFunc int dbFindFieldType(const char *type);
+DBCORE_API const char * dbGetFieldTypeString(int dbfType);
+DBCORE_API int dbFindFieldType(const char *type);
 
-epicsShareFunc dbMenu * dbFindMenu(DBBASE *pdbbase,
+DBCORE_API dbMenu * dbFindMenu(DBBASE *pdbbase,
     const char *name);
-epicsShareFunc char ** dbGetMenuChoices(DBENTRY *pdbentry);
-epicsShareFunc int  dbGetMenuIndex(DBENTRY *pdbentry);
-epicsShareFunc long dbPutMenuIndex(DBENTRY *pdbentry, int index);
-epicsShareFunc int  dbGetNMenuChoices(DBENTRY *pdbentry);
-epicsShareFunc char * dbGetMenuStringFromIndex(DBENTRY *pdbentry,
+DBCORE_API char ** dbGetMenuChoices(DBENTRY *pdbentry);
+DBCORE_API int  dbGetMenuIndex(DBENTRY *pdbentry);
+DBCORE_API long dbPutMenuIndex(DBENTRY *pdbentry, int index);
+DBCORE_API int  dbGetNMenuChoices(DBENTRY *pdbentry);
+DBCORE_API char * dbGetMenuStringFromIndex(DBENTRY *pdbentry,
     int index);
-epicsShareFunc int dbGetMenuIndexFromString(DBENTRY *pdbentry,
+DBCORE_API int dbGetMenuIndexFromString(DBENTRY *pdbentry,
     const char *choice);
 
-epicsShareFunc drvSup * dbFindDriver(dbBase *pdbbase,
+DBCORE_API drvSup * dbFindDriver(dbBase *pdbbase,
     const char *name);
-epicsShareFunc char * dbGetRelatedField(DBENTRY *pdbentry);
+DBCORE_API char * dbGetRelatedField(DBENTRY *pdbentry);
 
-epicsShareFunc linkSup * dbFindLinkSup(dbBase *pdbbase,
+DBCORE_API linkSup * dbFindLinkSup(dbBase *pdbbase,
     const char *name);
 
-epicsShareFunc int  dbGetNLinks(DBENTRY *pdbentry);
-epicsShareFunc long dbGetLinkField(DBENTRY *pdbentry, int index);
+DBCORE_API int  dbGetNLinks(DBENTRY *pdbentry);
+DBCORE_API long dbGetLinkField(DBENTRY *pdbentry, int index);
 
 /* Dump routines */
-epicsShareFunc void dbDumpPath(DBBASE *pdbbase);
-epicsShareFunc void dbDumpRecord(DBBASE *pdbbase,
+DBCORE_API void dbDumpPath(DBBASE *pdbbase);
+DBCORE_API void dbDumpRecord(DBBASE *pdbbase,
     const char *precordTypename, int level);
-epicsShareFunc void dbDumpMenu(DBBASE *pdbbase,
+DBCORE_API void dbDumpMenu(DBBASE *pdbbase,
     const char *menuName);
-epicsShareFunc void dbDumpRecordType(DBBASE *pdbbase,
+DBCORE_API void dbDumpRecordType(DBBASE *pdbbase,
     const char *recordTypeName);
-epicsShareFunc void dbDumpField(DBBASE *pdbbase,
+DBCORE_API void dbDumpField(DBBASE *pdbbase,
     const char *recordTypeName, const char *fname);
-epicsShareFunc void dbDumpDevice(DBBASE *pdbbase,
+DBCORE_API void dbDumpDevice(DBBASE *pdbbase,
     const char *recordTypeName);
-epicsShareFunc void dbDumpDriver(DBBASE *pdbbase);
-epicsShareFunc void dbDumpLink(DBBASE *pdbbase);
-epicsShareFunc void dbDumpRegistrar(DBBASE *pdbbase);
-epicsShareFunc void dbDumpFunction(DBBASE *pdbbase);
-epicsShareFunc void dbDumpVariable(DBBASE *pdbbase);
-epicsShareFunc void dbDumpBreaktable(DBBASE *pdbbase,
+DBCORE_API void dbDumpDriver(DBBASE *pdbbase);
+DBCORE_API void dbDumpLink(DBBASE *pdbbase);
+DBCORE_API void dbDumpRegistrar(DBBASE *pdbbase);
+DBCORE_API void dbDumpFunction(DBBASE *pdbbase);
+DBCORE_API void dbDumpVariable(DBBASE *pdbbase);
+DBCORE_API void dbDumpBreaktable(DBBASE *pdbbase,
     const char *name);
-epicsShareFunc void dbPvdDump(DBBASE *pdbbase, int verbose);
-epicsShareFunc void dbReportDeviceConfig(DBBASE *pdbbase,
+DBCORE_API void dbPvdDump(DBBASE *pdbbase, int verbose);
+DBCORE_API void dbReportDeviceConfig(DBBASE *pdbbase,
     FILE *report);
 
 /* Misc useful routines*/
 #define dbCalloc(nobj,size) callocMustSucceed(nobj,size,"dbCalloc")
 #define dbMalloc(size) mallocMustSucceed(size,"dbMalloc")
-epicsShareFunc void dbCatString(char **string, int *stringLength,
+DBCORE_API void dbCatString(char **string, int *stringLength,
     char *pnew, char *separator);
 
 extern int dbStaticDebug;

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -66,7 +66,7 @@ long dbInitRecordLinks(dbRecordType *rtyp, struct dbCommon *prec);
 /* Parse link string.  no record locks needed.
  * on success caller must free pinfo->target
  */
-epicsShareFunc long dbParseLink(const char *str, short ftype, dbLinkInfo *pinfo);
+DBCORE_API long dbParseLink(const char *str, short ftype, dbLinkInfo *pinfo);
 /* Check if link type allow the parsed link value pinfo
  * to be assigned to the given link.
  * Record containing plink must be locked.
@@ -79,7 +79,7 @@ long dbCanSetLink(DBLINK *plink, dbLinkInfo *pinfo, devSup *devsup);
  */
 long dbSetLink(DBLINK *plink, dbLinkInfo *pinfo, devSup *dset);
 /* Free dbLinkInfo storage */
-epicsShareFunc void dbFreeLinkInfo(dbLinkInfo *pinfo);
+DBCORE_API void dbFreeLinkInfo(dbLinkInfo *pinfo);
 
 /* The following is for path */
 typedef struct dbPathNode {
@@ -101,7 +101,7 @@ typedef struct{
     dbRecordType    *precordType;
     dbRecordNode    *precnode;
 }PVDENTRY;
-epicsShareFunc int dbPvdTableSize(int size);
+DBCORE_API int dbPvdTableSize(int size);
 extern int dbStaticDebug;
 void dbPvdInitPvt(DBBASE *pdbbase);
 PVDENTRY *dbPvdFind(DBBASE *pdbbase,const char *name,size_t lenname);

--- a/modules/database/src/ioc/dbStatic/dbStaticRun.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticRun.c
@@ -30,6 +30,7 @@
 #include "dbAccess.h"
 #include "devSup.h"
 #include "special.h"
+#include "epicsExport.h"
 
 int dbConvertStrict = 0;
 epicsExportAddress(int, dbConvertStrict);

--- a/modules/database/src/ioc/dbStatic/dbStaticRun.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticRun.c
@@ -23,7 +23,6 @@
 #include "epicsTypes.h"
 #include "errMdef.h"
 
-#include "epicsExport.h" /* #define epicsExportSharedSymbols */
 #include "dbBase.h"
 #include "dbCommonPvt.h"
 #include "dbStaticLib.h"
@@ -217,7 +216,7 @@ char *dbRecordName(DBENTRY *pdbentry)
 
 int dbIsMacroOk(DBENTRY *pdbentry) { return(FALSE); }
 
-epicsShareFunc int dbIsDefaultValue(DBENTRY *pdbentry)
+DBCORE_API int dbIsDefaultValue(DBENTRY *pdbentry)
 {
     dbFldDes *pflddes = pdbentry->pflddes;
     void *pfield = pdbentry->pfield;
@@ -508,7 +507,7 @@ long dbPutStringNum(DBENTRY *pdbentry, const char *pstring)
     }
 }
 
-epicsShareFunc int dbGetMenuIndex(DBENTRY *pdbentry)
+DBCORE_API int dbGetMenuIndex(DBENTRY *pdbentry)
 {
     dbFldDes *pflddes = pdbentry->pflddes;
     void *pfield = pdbentry->pfield;
@@ -527,7 +526,7 @@ epicsShareFunc int dbGetMenuIndex(DBENTRY *pdbentry)
     return -1;
 }
 
-epicsShareFunc long dbPutMenuIndex(DBENTRY *pdbentry, int index)
+DBCORE_API long dbPutMenuIndex(DBENTRY *pdbentry, int index)
 {
     dbFldDes *pflddes = pdbentry->pflddes;
     epicsEnum16 *pfield = pdbentry->pfield;

--- a/modules/database/src/ioc/dbStatic/devSup.h
+++ b/modules/database/src/ioc/dbStatic/devSup.h
@@ -21,7 +21,7 @@
 #define INCdevSuph 1
 
 #include "errMdef.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 /* structures defined elsewhere */
 struct dbCommon;
@@ -158,12 +158,12 @@ typedef dset unambiguous_dset;
  *
  * Recommended for use in device support init_record()
  */
-epicsShareFunc struct link* dbGetDevLink(struct dbCommon* prec);
+DBCORE_API struct link* dbGetDevLink(struct dbCommon* prec);
 
-epicsShareExtern dsxt devSoft_DSXT;  /* Allow anything table */
+DBCORE_API extern dsxt devSoft_DSXT;  /* Allow anything table */
 
-epicsShareFunc void devExtend(dsxt *pdsxt);
-epicsShareFunc void dbInitDevSup(struct devSup *pdevSup, dset *pdset);
+DBCORE_API void devExtend(dsxt *pdsxt);
+DBCORE_API void dbInitDevSup(struct devSup *pdevSup, dset *pdset);
 
 
 #define S_dev_noDevSup      (M_devSup| 1) /*SDR_DEVSUP: Device support missing*/

--- a/modules/database/src/ioc/dbStatic/link.h
+++ b/modules/database/src/ioc/dbStatic/link.h
@@ -18,7 +18,7 @@
 
 #include "dbDefs.h"
 #include "ellLib.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,7 +47,7 @@ typedef struct maplinkType {
     int  value;
 } maplinkType;
 
-epicsShareExtern maplinkType pamaplinkType[];
+DBCORE_API extern maplinkType pamaplinkType[];
 
 #define VXIDYNAMIC      0
 #define VXISTATIC       1

--- a/modules/database/src/ioc/dbtemplate/dbLoadTemplate.h
+++ b/modules/database/src/ioc/dbtemplate/dbLoadTemplate.h
@@ -12,13 +12,13 @@
 #ifndef INCdbLoadTemplateh
 #define INCdbLoadTemplateh
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc int dbLoadTemplate(
+DBCORE_API int dbLoadTemplate(
     const char *sub_file, const char *cmd_collect);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/dbtemplate/dbtoolsIocRegister.c
+++ b/modules/database/src/ioc/dbtemplate/dbtoolsIocRegister.c
@@ -8,7 +8,6 @@
 
 #include "iocsh.h"
 
-#define epicsExportSharedSymbols
 #include "dbtoolsIocRegister.h"
 #include "dbLoadTemplate.h"
 

--- a/modules/database/src/ioc/dbtemplate/dbtoolsIocRegister.h
+++ b/modules/database/src/ioc/dbtemplate/dbtoolsIocRegister.h
@@ -9,13 +9,13 @@
 #ifndef INC_dbtoolsIocRegister_H
 #define INC_dbtoolsIocRegister_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc void dbtoolsIocRegister(void);
+DBCORE_API void dbtoolsIocRegister(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/misc/epicsRelease.c
+++ b/modules/database/src/ioc/misc/epicsRelease.c
@@ -15,11 +15,10 @@
 #include "epicsStdio.h"
 #include "epicsVersion.h"
 
-#define epicsExportSharedSymbols
 #include "epicsRelease.h"
 #include "epicsVCS.h"
 
-epicsShareFunc int coreRelease(void)
+DBCORE_API int coreRelease(void)
 {
     printf ( "############################################################################\n" );
     printf ( "## %s\n", epicsReleaseVersion );

--- a/modules/database/src/ioc/misc/epicsRelease.h
+++ b/modules/database/src/ioc/misc/epicsRelease.h
@@ -16,8 +16,8 @@
 extern "C" {
 #endif
 
-#include "shareLib.h"
-epicsShareFunc int coreRelease(void);
+#include "dbCoreAPI.h"
+DBCORE_API int coreRelease(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/misc/iocInit.h
+++ b/modules/database/src/ioc/misc/iocInit.h
@@ -12,7 +12,7 @@
 #ifndef INCiocInith
 #define INCiocInith
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 enum iocStateEnum {
     iocVoid, iocBuilding, iocBuilt, iocRunning, iocPaused
@@ -22,13 +22,13 @@ enum iocStateEnum {
 extern "C" {
 #endif
 
-epicsShareFunc enum iocStateEnum getIocState(void);
-epicsShareFunc int iocInit(void);
-epicsShareFunc int iocBuild(void);
-epicsShareFunc int iocBuildIsolated(void);
-epicsShareFunc int iocRun(void);
-epicsShareFunc int iocPause(void);
-epicsShareFunc int iocShutdown(void);
+DBCORE_API enum iocStateEnum getIocState(void);
+DBCORE_API int iocInit(void);
+DBCORE_API int iocBuild(void);
+DBCORE_API int iocBuildIsolated(void);
+DBCORE_API int iocRun(void);
+DBCORE_API int iocPause(void);
+DBCORE_API int iocShutdown(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/misc/iocshRegisterCommon.c
+++ b/modules/database/src/ioc/misc/iocshRegisterCommon.c
@@ -13,7 +13,6 @@
 #include "iocsh.h"
 #include "libComRegister.h"
 
-#define epicsExportSharedSymbols
 #include "asIocRegister.h"
 #include "dbAccess.h"
 #include "dbIocRegister.h"

--- a/modules/database/src/ioc/misc/iocshRegisterCommon.h
+++ b/modules/database/src/ioc/misc/iocshRegisterCommon.h
@@ -13,7 +13,7 @@
 #ifndef INCiocshRegisterCommonH
 #define INCiocshRegisterCommonH
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,19 +22,19 @@ extern "C" {
 struct dbBase;
 
 /* register many useful commands */
-epicsShareFunc void iocshRegisterCommon(void);
+DBCORE_API void iocshRegisterCommon(void);
 
 #define HAS_registerAllRecordDeviceDrivers
 
-epicsShareFunc
+DBCORE_API
 long
 registerAllRecordDeviceDrivers(struct dbBase *pdbbase);
 
-epicsShareFunc
+DBCORE_API
 void runRegistrarOnce(void (*reg_func)(void));
 
 #ifdef EPICS_PRIVATE_API
-epicsShareFunc
+DBCORE_API
 void clearRegistrarOnce(void);
 #endif
 

--- a/modules/database/src/ioc/misc/miscIocRegister.c
+++ b/modules/database/src/ioc/misc/miscIocRegister.c
@@ -13,7 +13,6 @@
 #include "iocsh.h"
 #include "errlog.h"
 
-#define epicsExportSharedSymbols
 #include "iocInit.h"
 #include "epicsExport.h"
 #include "epicsRelease.h"

--- a/modules/database/src/ioc/misc/miscIocRegister.h
+++ b/modules/database/src/ioc/misc/miscIocRegister.h
@@ -11,13 +11,13 @@
 #ifndef INC_miscIocRegister_H
 #define INC_miscIocRegister_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc void miscIocRegister(void);
+DBCORE_API void miscIocRegister(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
+++ b/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
@@ -17,7 +17,6 @@
 
 #include <epicsStdio.h>
 #include <epicsFindSymbol.h>
-#define epicsExportSharedSymbols
 #include <registryRecordType.h>
 #include <registryDeviceSupport.h>
 #include <registryDriverSupport.h>

--- a/modules/database/src/ioc/registry/registryCommon.c
+++ b/modules/database/src/ioc/registry/registryCommon.c
@@ -16,7 +16,6 @@
 
 #include "errlog.h"
 
-#define epicsExportSharedSymbols
 #include "registryCommon.h"
 #include "registryDeviceSupport.h"
 #include "registryDriverSupport.h"

--- a/modules/database/src/ioc/registry/registryCommon.h
+++ b/modules/database/src/ioc/registry/registryCommon.h
@@ -15,22 +15,22 @@
 #include "devSup.h"
 #include "dbJLink.h"
 #include "registryRecordType.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc void registerRecordTypes(
+DBCORE_API void registerRecordTypes(
     DBBASE *pbase, int nRecordTypes,
     const char * const *recordTypeNames, const recordTypeLocation *rtl);
-epicsShareFunc void registerDevices(
+DBCORE_API void registerDevices(
     DBBASE *pbase, int nDevices,
     const char * const *deviceSupportNames, const dset * const *devsl);
-epicsShareFunc void registerDrivers(
+DBCORE_API void registerDrivers(
     DBBASE *pbase, int nDrivers,
     const char * const *driverSupportNames, struct drvet * const *drvsl);
-epicsShareFunc void registerJLinks(
+DBCORE_API void registerJLinks(
     DBBASE *pbase, int nDrivers, jlif * const *jlifsl);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/registry/registryDeviceSupport.c
+++ b/modules/database/src/ioc/registry/registryDeviceSupport.c
@@ -11,20 +11,19 @@
 
 /* Author:  Marty Kraimer Date:    08JUN99 */
 
-#define epicsExportSharedSymbols
 #include "registry.h"
 #include "registryDeviceSupport.h"
 
 static void *registryID = "device support";
 
 
-epicsShareFunc int registryDeviceSupportAdd(
+DBCORE_API int registryDeviceSupportAdd(
     const char *name, const dset *pdset)
 {
     return registryAdd(registryID, name, (void *)pdset);
 }
 
-epicsShareFunc dset * registryDeviceSupportFind(
+DBCORE_API dset * registryDeviceSupportFind(
     const char *name)
 {
     return registryFind(registryID, name);

--- a/modules/database/src/ioc/registry/registryDeviceSupport.h
+++ b/modules/database/src/ioc/registry/registryDeviceSupport.h
@@ -12,15 +12,15 @@
 #define INC_registryDeviceSupport_H
 
 #include "devSup.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc int registryDeviceSupportAdd(
+DBCORE_API int registryDeviceSupportAdd(
     const char *name, const dset *pdset);
-epicsShareFunc dset * registryDeviceSupportFind(
+DBCORE_API dset * registryDeviceSupportFind(
     const char *name);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/registry/registryDriverSupport.c
+++ b/modules/database/src/ioc/registry/registryDriverSupport.c
@@ -11,20 +11,19 @@
 
 /* Author:  Marty Kraimer Date:    08JUN99 */
 
-#define epicsExportSharedSymbols
 #include "registry.h"
 #include "registryDriverSupport.h"
 
 static void *registryID = "driver support";
 
 
-epicsShareFunc int registryDriverSupportAdd(
+DBCORE_API int registryDriverSupportAdd(
     const char *name, struct drvet *pdrvet)
 {
     return registryAdd(registryID, name, pdrvet);
 }
 
-epicsShareFunc struct drvet * registryDriverSupportFind(
+DBCORE_API struct drvet * registryDriverSupportFind(
     const char *name)
 {
     return registryFind(registryID, name);

--- a/modules/database/src/ioc/registry/registryDriverSupport.h
+++ b/modules/database/src/ioc/registry/registryDriverSupport.h
@@ -12,15 +12,15 @@
 #define INC_registryDriverSupport_H
 
 #include "drvSup.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc int registryDriverSupportAdd(
+DBCORE_API int registryDriverSupportAdd(
     const char *name, struct drvet *pdrvet);
-epicsShareFunc struct drvet * registryDriverSupportFind(
+DBCORE_API struct drvet * registryDriverSupportFind(
     const char *name);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/registry/registryFunction.c
+++ b/modules/database/src/ioc/registry/registryFunction.c
@@ -13,20 +13,19 @@
 
 #include <stdio.h>
 
-#define epicsExportSharedSymbols
 #include "registry.h"
 #include "registryFunction.h"
 
 static void * const registryID = "function";
 
 
-epicsShareFunc int registryFunctionAdd(
+DBCORE_API int registryFunctionAdd(
     const char *name, REGISTRYFUNCTION func)
 {
     return registryAdd(registryID, name, func);
 }
 
-epicsShareFunc REGISTRYFUNCTION registryFunctionFind(
+DBCORE_API REGISTRYFUNCTION registryFunctionFind(
     const char *name)
 {
     REGISTRYFUNCTION func = registryFind(registryID, name);
@@ -38,7 +37,7 @@ epicsShareFunc REGISTRYFUNCTION registryFunctionFind(
     return func;
 }
 
-epicsShareFunc int registryFunctionRefAdd(
+DBCORE_API int registryFunctionRefAdd(
    registryFunctionRef ref[], int nfunctions)
 {
     int i;

--- a/modules/database/src/ioc/registry/registryFunction.h
+++ b/modules/database/src/ioc/registry/registryFunction.h
@@ -11,7 +11,7 @@
 #ifndef INC_registryFunction_H
 #define INC_registryFunction_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,11 +25,11 @@ typedef struct registryFunctionRef {
 } registryFunctionRef;
 
 
-epicsShareFunc int registryFunctionAdd(
+DBCORE_API int registryFunctionAdd(
     const char *name, REGISTRYFUNCTION func);
-epicsShareFunc REGISTRYFUNCTION registryFunctionFind(
+DBCORE_API REGISTRYFUNCTION registryFunctionFind(
     const char *name);
-epicsShareFunc int registryFunctionRefAdd(
+DBCORE_API int registryFunctionRefAdd(
    registryFunctionRef ref[], int nfunctions);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/registry/registryIocRegister.c
+++ b/modules/database/src/ioc/registry/registryIocRegister.c
@@ -10,7 +10,6 @@
 
 #include "iocsh.h"
 
-#define epicsExportSharedSymbols
 #include "registryDeviceSupport.h"
 #include "registryDriverSupport.h"
 #include "registryFunction.h"

--- a/modules/database/src/ioc/registry/registryIocRegister.h
+++ b/modules/database/src/ioc/registry/registryIocRegister.h
@@ -11,13 +11,13 @@
 #ifndef INC_registryIocRegister_H
 #define INC_registryIocRegister_H
 
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc void registryIocRegister(void);
+DBCORE_API void registryIocRegister(void);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/registry/registryJLinks.c
+++ b/modules/database/src/ioc/registry/registryJLinks.c
@@ -8,13 +8,12 @@
 /* registryJLinks.c */
 
 #include "registry.h"
-#define epicsExportSharedSymbols
 #include "dbBase.h"
 #include "dbStaticLib.h"
 #include "registryJLinks.h"
 #include "dbJLink.h"
 
-epicsShareFunc int registryJLinkAdd(DBBASE *pbase, struct jlif *pjlif)
+DBCORE_API int registryJLinkAdd(DBBASE *pbase, struct jlif *pjlif)
 {
     linkSup *plinkSup = dbFindLinkSup(pbase, pjlif->name);
 

--- a/modules/database/src/ioc/registry/registryJLinks.h
+++ b/modules/database/src/ioc/registry/registryJLinks.h
@@ -13,13 +13,13 @@
 
 #include "dbBase.h"
 #include "dbJLink.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-epicsShareFunc int registryJLinkAdd(DBBASE *pbase, jlif *pjlif);
+DBCORE_API int registryJLinkAdd(DBBASE *pbase, jlif *pjlif);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/registry/registryRecordType.c
+++ b/modules/database/src/ioc/registry/registryRecordType.c
@@ -11,20 +11,19 @@
 
 /* Author:  Marty Kraimer Date:    08JUN99 */
 
-#define epicsExportSharedSymbols
 #include "registry.h"
 #include "registryRecordType.h"
 
 static void * const registryID = "record type";
 
 
-epicsShareFunc int registryRecordTypeAdd(
+DBCORE_API int registryRecordTypeAdd(
     const char *name, const recordTypeLocation *prtl)
 {
     return registryAdd(registryID, name, (void *)prtl);
 }
 
-epicsShareFunc recordTypeLocation * registryRecordTypeFind(
+DBCORE_API recordTypeLocation * registryRecordTypeFind(
     const char *name)
 {
     return registryFind(registryID, name);

--- a/modules/database/src/ioc/registry/registryRecordType.h
+++ b/modules/database/src/ioc/registry/registryRecordType.h
@@ -12,7 +12,7 @@
 #define INC_registryRecordType_H
 
 #include "recSup.h"
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,9 +28,9 @@ typedef struct recordTypeLocation {
     computeSizeOffset sizeOffset;
 }recordTypeLocation;
 
-epicsShareFunc int registryRecordTypeAdd(
+DBCORE_API int registryRecordTypeAdd(
     const char *name, const recordTypeLocation *prtl);
-epicsShareFunc recordTypeLocation * registryRecordTypeFind(
+DBCORE_API recordTypeLocation * registryRecordTypeFind(
     const char *name);
 
 int registerRecordDeviceDriver(struct dbBase *pdbbase);

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -38,7 +38,6 @@
 #include "caerr.h"
 #include "net_convert.h"
 
-#define epicsExportSharedSymbols
 #include "asDbLib.h"
 #include "callback.h"
 #include "db_access.h"

--- a/modules/database/src/ioc/rsrv/camsgtask.c
+++ b/modules/database/src/ioc/rsrv/camsgtask.c
@@ -29,7 +29,6 @@
 
 #include "caerr.h"
 
-#define epicsExportSharedSymbols
 #include "db_access.h"
 #include "rsrv.h"
 #include "server.h"

--- a/modules/database/src/ioc/rsrv/caserverio.c
+++ b/modules/database/src/ioc/rsrv/caserverio.c
@@ -30,7 +30,6 @@
 #include "caerr.h"
 #include "net_convert.h"
 
-#define epicsExportSharedSymbols
 #include "server.h"
 
 /*

--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -37,7 +37,6 @@
 
 #include "epicsExport.h"
 
-#define epicsExportSharedSymbols
 #include "dbChannel.h"
 #include "dbCommon.h"
 #include "dbEvent.h"

--- a/modules/database/src/ioc/rsrv/cast_server.c
+++ b/modules/database/src/ioc/rsrv/cast_server.c
@@ -46,7 +46,6 @@
 #include "osiSock.h"
 #include "taskwd.h"
 
-#define epicsExportSharedSymbols
 #include "rsrv.h"
 #include "server.h"
 

--- a/modules/database/src/ioc/rsrv/online_notify.c
+++ b/modules/database/src/ioc/rsrv/online_notify.c
@@ -31,7 +31,6 @@
 #include "osiSock.h"
 #include "taskwd.h"
 
-#define epicsExportSharedSymbols
 #include "server.h"
 
 /*

--- a/modules/database/src/ioc/rsrv/rsrv.h
+++ b/modules/database/src/ioc/rsrv/rsrv.h
@@ -19,7 +19,7 @@
 #define rsrvh
 
 #include <stddef.h>
-#include "shareLib.h"
+#include "dbCoreAPI.h"
 
 #define RSRV_OK 0
 #define RSRV_ERROR (-1)
@@ -28,12 +28,12 @@
 extern "C" {
 #endif
 
-epicsShareFunc void rsrv_register_server(void);
+DBCORE_API void rsrv_register_server(void);
 
-epicsShareFunc void casr (unsigned level);
-epicsShareFunc int casClientInitiatingCurrentThread (
+DBCORE_API void casr (unsigned level);
+DBCORE_API int casClientInitiatingCurrentThread (
                         char * pBuf, size_t bufSize );
-epicsShareFunc void casStatsFetch (
+DBCORE_API void casStatsFetch (
                         unsigned *pChanCount, unsigned *pConnCount );
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/rsrv/rsrvIocRegister.c
+++ b/modules/database/src/ioc/rsrv/rsrvIocRegister.c
@@ -11,7 +11,6 @@
 #include "osiSock.h"
 #include "iocsh.h"
 
-#define epicsExportSharedSymbols
 #include "rsrv.h"
 #include "server.h"
 #include "epicsExport.h"

--- a/modules/database/src/ioc/rsrv/server.h
+++ b/modules/database/src/ioc/rsrv/server.h
@@ -36,7 +36,6 @@
 #include "osiSock.h"
 
 #ifdef rsrvRestore_epicsExportSharedSymbols
-#define epicsExportSharedSymbols
 #endif
 
 /* a modified ca header with capacity for large arrays */

--- a/modules/database/src/ioc/rsrv/server.h
+++ b/modules/database/src/ioc/rsrv/server.h
@@ -16,11 +16,6 @@
 #ifndef INCLserverh
 #define INCLserverh
 
-#ifdef epicsExportSharedSymbols
-#   define rsrvRestore_epicsExportSharedSymbols
-#   undef epicsExportSharedSymbols
-#endif /* ifdef epicsExportSharedSymbols */
-
 #include "epicsThread.h"
 #include "epicsMutex.h"
 #include "epicsEvent.h"
@@ -34,9 +29,6 @@
 #include "epicsTime.h"
 #include "epicsAssert.h"
 #include "osiSock.h"
-
-#ifdef rsrvRestore_epicsExportSharedSymbols
-#endif
 
 /* a modified ca header with capacity for large arrays */
 typedef struct caHdrLargeArray {

--- a/modules/database/src/tools/registerRecordDeviceDriver.pl
+++ b/modules/database/src/tools/registerRecordDeviceDriver.pl
@@ -77,6 +77,7 @@ print $out (<< "END");
 #include "iocshRegisterCommon.h"
 #include "registryCommon.h"
 #include "recSup.h"
+#include "shareLib.h"
 
 END
 

--- a/modules/database/test/ioc/db/dbCaLinkTest.c
+++ b/modules/database/test/ioc/db/dbCaLinkTest.c
@@ -27,6 +27,7 @@
 #include "dbAccess.h"
 #include "epicsStdio.h"
 #include "dbEvent.h"
+#include "shareLib.h"
 
 /* Declarations from cadef.h and db_access.h which we can't include here */
 typedef void * chid;

--- a/modules/database/test/std/rec/asTest.c
+++ b/modules/database/test/std/rec/asTest.c
@@ -37,6 +37,8 @@
 
 #include "testMain.h"
 
+#include "shareLib.h"
+
 epicsShareFunc void testRestore(void);
 
 #include "epicsExport.h"


### PR DESCRIPTION
Great big mechanical change from `epicsShare*` to `DBCORE_API`.  Some manual fixups after:

```sh
git ls-files modules/database/src/ioc|egrep '\.[hc]p*$' | xargs sed -i \
     -e 's|epicsShareFunc|DBCORE_API|g' \
     -e 's|epicsShareClass|DBCORE_API|g' \
     -e 's|epicsShareExtern|DBCORE_API extern|g' \
     -e 's|epicsShareDef\s*||g' \
     -e 's|shareLib\.h|dbCoreAPI.h|g' \
     -e 's|epicsShareAPI|epicsStdCall|g' \
     -e '/#define\s*epicsExportSharedSymbols/d'
```