### PR TITLE
Add DBR_VFIELD

### DIFF
--- a/configure/CONFIG_DATABASE_MODULE
+++ b/configure/CONFIG_DATABASE_MODULE
@@ -26,3 +26,4 @@ MSI3_15                    = $(EPICS_DATABASE_HOST_BIN)/msi$(HOSTEXE)
 EPICS_BASE_IOC_LIBS = dbRecStd dbCore ca Com
 
 HAS_registerAllRecordDeviceDrivers=YES
+HAS_DBR_VFIELD=YES

--- a/modules/database/src/ioc/db/dbAddr.h
+++ b/modules/database/src/ioc/db/dbAddr.h
@@ -11,14 +11,19 @@
 #ifndef dbAddrh
 #define dbAddrh
 
+#include <ellLib.h>
+
 struct dbCommon;
 struct dbFldDes;
+struct VFieldType;
 
 typedef struct dbAddr {
         struct dbCommon *precord;   /* address of record                     */
         void    *pfield;            /* address of field                      */
         struct dbFldDes *pfldDes;   /* address of struct fldDes              */
+        const ELLLIST* vfields;     /* list of VFieldTypeNode, vtypes to try with rset::get/put_vfield  */
         long    no_elements;        /* number of elements (arrays)           */
+        unsigned ro:1;              /* dbPut permitted? */
         short   field_type;         /* type of database field                */
         short   field_size;         /* size of the field being accessed      */
         short   special;            /* special processing                    */

--- a/modules/database/src/ioc/db/dbChannel.h
+++ b/modules/database/src/ioc/db/dbChannel.h
@@ -199,6 +199,9 @@ DBCORE_API extern unsigned short dbDBRnewToDBRold[];
 /* evaluates to short */
 #define dbChannelSpecial(pChan) ((pChan)->addr.special)
 
+/* evaluates to const ELLLIST* containing VFieldTypeNode::node */
+#define dbChannelVFields(pChan) ((pChan)->addr.vfields)
+
 /* Channel filters do not get to interpose here since there are many
  * places where the field pointer is compared with the address of a
  * specific record field, so they can't modify the pointer value.

--- a/modules/database/src/ioc/db/dbDbLink.c
+++ b/modules/database/src/ioc/db/dbDbLink.c
@@ -191,6 +191,8 @@ static long dbDbGetValue(struct link *plink, short dbrType, void *pbuffer,
         /* simple scalar: set up shortcut */
         unsigned short dbfType = dbChannelFinalFieldType(chan);
 
+        if (dbrType==DBR_VFIELD && paddr->vfields) {}
+        else
         if (dbrType < 0 || dbrType > DBR_ENUM || dbfType > DBF_DEVICE)
             return S_db_badDbrtype;
 

--- a/modules/database/src/ioc/db/dbUnitTest.c
+++ b/modules/database/src/ioc/db/dbUnitTest.c
@@ -107,6 +107,7 @@ union anybuf {
     epicsAny val;
     char valStr[MAX_STRING_SIZE];
     char bytes[sizeof(epicsAny)];
+    void *ptr;
 };
 
 long testdbVPutField(const char* pv, short dbrType, va_list ap)
@@ -149,6 +150,9 @@ long testdbVPutField(const char* pv, short dbrType, va_list ap)
     OP(DBR_DOUBLE, double, float64);
     OP(DBR_ENUM, int, enum16);
 #undef OP
+    case DBR_VFIELD:
+        ret = dbChannelPutField(chan, dbrType, va_arg(ap, void*), 1);
+        break;
     default:
         testFail("invalid DBR: dbPutField(\"%s\", %d, ...)",
                   dbChannelName(chan), dbrType);

--- a/modules/database/src/ioc/dbStatic/dbFldTypes.h
+++ b/modules/database/src/ioc/dbStatic/dbFldTypes.h
@@ -15,10 +15,24 @@
 #define INCdbFldTypesh 1
 
 #include "dbCoreAPI.h"
+#include "ellLib.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef struct VFieldType {
+    const char* name;
+} VFieldType;
+
+typedef struct VFieldTypeNode {
+    ELLNODE node;
+    const VFieldType* vtype;
+} VFieldTypeNode;
+
+typedef struct VField {
+    const VFieldType* vtype;
+} VField;
 
 /* field types */
 typedef enum {
@@ -87,6 +101,7 @@ mapdbfType pamapdbfType[DBF_NTYPES] = {
 #define DBR_ENUM        DBF_ENUM
 #define DBR_PUT_ACKT    DBR_ENUM+1
 #define DBR_PUT_ACKS    DBR_PUT_ACKT+1
+#define DBR_VFIELD      (DBR_PUT_ACKS+1)
 #define DBR_NOACCESS    DBF_NOACCESS
 #define VALID_DB_REQ(x) ((x >= 0) && (x <= DBR_ENUM))
 #define INVALID_DB_REQ(x)       ((x < 0) || (x > DBR_ENUM))

--- a/modules/database/src/ioc/dbStatic/recSup.h
+++ b/modules/database/src/ioc/dbStatic/recSup.h
@@ -32,6 +32,7 @@ struct dbr_enumStrs;
 struct dbr_grDouble;
 struct dbr_ctrlDouble;
 struct dbr_alDouble;
+struct VField;
 
 /* record support entry table */
 struct typed_rset {
@@ -53,6 +54,8 @@ struct typed_rset {
     long (*get_graphic_double)(struct dbAddr *paddr, struct dbr_grDouble *p);
     long (*get_control_double)(struct dbAddr *paddr, struct dbr_ctrlDouble *p);
     long (*get_alarm_double)(struct dbAddr *paddr, struct dbr_alDouble *p);
+    long (*get_vfield)(struct dbAddr *paddr, struct VField *p);
+    long (*put_vfield)(struct dbAddr *paddr, const struct VField *p);
 };
 
 #ifdef USE_TYPED_RSET
@@ -84,13 +87,15 @@ struct rset {   /* record support entry table */
     long (*get_graphic_double)();
     long (*get_control_double)();
     long (*get_alarm_double)();
+    long (*get_vfield)(struct dbAddr *paddr, struct VField *p);
+    long (*put_vfield)(struct dbAddr *paddr, const struct VField *p);
 } EPICS_DEPRECATED;
 
 typedef struct rset rset EPICS_DEPRECATED;
 
 #endif
 
-#define RSETNUMBER 17
+#define RSETNUMBER 19
 
 #define S_rec_noRSET     (M_recSup| 1) /*Missing record support entry table*/
 #define S_rec_noSizeOffset (M_recSup| 2) /*Missing SizeOffset Routine*/

--- a/modules/database/src/std/dev/Makefile
+++ b/modules/database/src/std/dev/Makefile
@@ -48,6 +48,8 @@ dbRecStd_SRCS += devSiSoft.c
 dbRecStd_SRCS += devSoSoft.c
 dbRecStd_SRCS += devWfSoft.c
 
+dbRecStd_SRCS += devSSiSoft.c
+
 dbRecStd_SRCS += devAiSoftCallback.c
 dbRecStd_SRCS += devBiSoftCallback.c
 dbRecStd_SRCS += devI64inSoftCallback.c

--- a/modules/database/src/std/dev/devSSiSoft.cpp
+++ b/modules/database/src/std/dev/devSSiSoft.cpp
@@ -1,0 +1,91 @@
+/*************************************************************************\
+* Copyright (c) 2020 Michael Davidsaver
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef USE_TYPED_DSET
+#  define USE_TYPED_DSET
+#endif
+
+#include <dbAccess.h>
+#include <recGbl.h>
+
+// include by stdstringinRecord.h
+#include "epicsTypes.h"
+#include "link.h"
+#include "epicsMutex.h"
+#include "ellLib.h"
+#include "devSup.h"
+#include "epicsTime.h"
+
+#define epicsExportSharedSymbols
+
+#include "stdstringinRecord.h"
+#include <epicsExport.h>
+
+namespace {
+
+long init_record(struct dbCommon *pcommon)
+{
+    stdstringinRecord *prec = (stdstringinRecord *)pcommon;
+    VString ival;
+    ival.vtype = &vfStdString;
+
+    if (recGblInitConstantLink(&prec->inp, DBR_VFIELD, &ival)) {
+        prec->udf = FALSE;
+        prec->val = ival.value;
+    }
+
+    return 0;
+}
+
+long readLocked(struct link *pinp, void *dummy)
+{
+    stdstringinRecord *prec = (stdstringinRecord *) pinp->precord;
+
+    VString ival;
+    ival.vtype = &vfStdString;
+
+    long status;
+    if(!(status = dbGetLink(pinp, DBR_VFIELD, &ival, 0, 0))) {
+        prec->val = ival.value;
+
+    } else if (status==S_db_badDbrtype) {
+        char str[MAX_STRING_SIZE];
+        if(!(status = dbGetLink(pinp, DBR_STRING, str, 0, 0))) {
+            str[MAX_STRING_SIZE-1] = '\0';
+            prec->val = str;
+        }
+    }
+    if (status) return status;
+
+    if (dbLinkIsConstant(&prec->tsel) &&
+        prec->tse == epicsTimeEventDeviceTime)
+        dbGetTimeStamp(pinp, &prec->time);
+
+    return status;
+}
+
+long read_ssi(stdstringinRecord* prec)
+{
+    long status = dbLinkDoLocked(&prec->inp, readLocked, NULL);
+
+    if (status == S_db_noLSET)
+        status = readLocked(&prec->inp, NULL);
+
+    if (!status && !dbLinkIsConstant(&prec->inp))
+        prec->udf = FALSE;
+
+    return status;
+}
+
+stdstringindset devSSiSoft = {
+    {5, NULL, NULL, &init_record, NULL},
+    &read_ssi
+};
+
+}
+extern "C" {
+epicsExportAddress(dset, devSSiSoft);
+}

--- a/modules/database/src/std/dev/devSoft.dbd
+++ b/modules/database/src/std/dev/devSoft.dbd
@@ -25,6 +25,8 @@ device(stringout,CONSTANT,devSoSoft,"Soft Channel")
 device(subArray,CONSTANT,devSASoft,"Soft Channel")
 device(waveform,CONSTANT,devWfSoft,"Soft Channel")
 
+device(stdstringin,CONSTANT,devSSiSoft,"Soft Channel")
+
 device(ai,CONSTANT,devAiSoftRaw,"Raw Soft Channel")
 device(ao,CONSTANT,devAoSoftRaw,"Raw Soft Channel")
 device(bi,CONSTANT,devBiSoftRaw,"Raw Soft Channel")

--- a/modules/database/src/std/rec/Makefile
+++ b/modules/database/src/std/rec/Makefile
@@ -46,6 +46,8 @@ stdRecords += subRecord
 stdRecords += subArrayRecord
 stdRecords += waveformRecord
 
+stdRecords += stdstringinRecord
+
 DBDINC += $(stdRecords)
 
 # Generate stdRecords.dbd, not really by concatenation, see RULES

--- a/modules/database/src/std/rec/stdstringinRecord.cpp
+++ b/modules/database/src/std/rec/stdstringinRecord.cpp
@@ -1,0 +1,240 @@
+/*************************************************************************\
+* Copyright (c) 2020 Michael Davidsaver
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef USE_TYPED_RSET
+#  define USE_TYPED_RSET
+#endif
+#ifndef USE_TYPED_DSET
+#  define USE_TYPED_DSET
+#endif
+
+#include <dbAccess.h>
+#include <recSup.h>
+#include <recGbl.h>
+#include <dbEvent.h>
+
+// include by stdstringinRecord.h
+#include "epicsTypes.h"
+#include "link.h"
+#include "epicsMutex.h"
+#include "ellLib.h"
+#include "devSup.h"
+#include "epicsTime.h"
+
+#define epicsExportSharedSymbols
+
+#define GEN_SIZE_OFFSET
+#include <stdstringinRecord.h>
+#undef  GEN_SIZE_OFFSET
+#include <epicsExport.h>
+
+extern "C" {
+VFieldType vfStdString = {"std::string"};
+}
+
+namespace  {
+
+ELLLIST vfList = ELLLIST_INIT;
+VFieldTypeNode vfStrNode;
+
+long initialize()
+{
+    vfStrNode.vtype = &vfStdString;
+    ellAdd(&vfList, &vfStrNode.node);
+    return 0;
+}
+
+long init_record(struct dbCommon *pcommon, int pass)
+{
+    stdstringinRecord *prec = (stdstringinRecord*)pcommon;
+    stdstringindset *pdset = (stdstringindset *)(prec->dset);
+
+    if (!pdset) {
+        recGblRecordError(S_dev_noDSET, prec, "stdstringin: init_record");
+        return S_dev_noDSET;
+    }
+
+    if(pass==0) {
+        new (&prec->val) std::string();
+        new (&prec->oval) std::string();
+
+        if(pdset->common.init_record) {
+            long ret = pdset->common.init_record(pcommon);
+            if(ret)
+                return ret;
+
+            prec->oval = prec->val;
+        }
+    }
+    return 0;
+}
+
+long readValue(stdstringinRecord *prec,
+               stdstringindset *pdset)
+{
+    return pdset->read_stdstringin(prec);
+}
+
+void monitor(stdstringinRecord *prec)
+{
+    int monitor_mask = recGblResetAlarms(prec);
+
+    if (prec->oval != prec->val) {
+        monitor_mask |= DBE_VALUE | DBE_LOG;
+        prec->oval = prec->val;
+    }
+
+    if (monitor_mask) {
+        db_post_events(prec, &prec->val, monitor_mask);
+        db_post_events(prec, &prec->oval, monitor_mask);
+    }
+}
+
+long process(struct dbCommon *pcommon)
+{
+    stdstringinRecord *prec = (stdstringinRecord*)pcommon;
+    stdstringindset *pdset = (stdstringindset *)(prec->dset);
+    unsigned char    pact=prec->pact;
+    long status;
+
+    if( (pdset==NULL) || (pdset->read_stdstringin==NULL) ) {
+        prec->pact=TRUE;
+        recGblRecordError(S_dev_missingSup,(void *)prec,"read_stdstringin");
+        return(S_dev_missingSup);
+    }
+
+    status=readValue(prec, pdset); /* read the new value */
+    /* check if device support set pact */
+    if ( !pact && prec->pact ) return(0);
+
+    prec->pact = TRUE;
+    recGblGetTimeStamp(prec);
+
+    /* check event list */
+    monitor(prec);
+    /* process the forward scan link record */
+    recGblFwdLink(prec);
+
+    prec->pact=FALSE;
+    return status;
+}
+
+long cvt_dbaddr(DBADDR *paddr)
+{
+    // for both VAL and OVAL
+
+    // we don't allow dbPut() via DBF_CHAR.
+    // std::string::c_str() warns of dire consequences following modifications
+    paddr->ro = 1;
+    // we provide vfield access
+    paddr->vfields = &vfList;
+    // arbitrary limit
+    paddr->no_elements = 128;
+
+    paddr->field_type = paddr->dbr_field_type = DBF_CHAR;
+    paddr->field_size = 1;
+
+
+    return 0;
+}
+
+long get_array_info(DBADDR *paddr, long *no_elements, long *offset)
+{
+    stdstringinRecord *prec = (stdstringinRecord*)paddr->precord;
+
+    *offset = 0;
+    if(dbGetFieldIndex(paddr)==stdstringinRecordVAL) {
+        paddr->pfield = (void*)prec->val.c_str();
+        *no_elements = prec->val.empty() ? 0u : prec->val.size()+1u;
+        return 0;
+
+    } else if(dbGetFieldIndex(paddr)==stdstringinRecordOVAL) {
+        paddr->pfield = (void*)prec->oval.c_str();
+        *no_elements = prec->oval.empty() ? 0u : prec->oval.size()+1u;
+        return 0;
+    }
+    return S_db_badField;
+}
+
+long put_array_info(DBADDR *paddr, long nNew)
+{
+    return S_db_noMod;
+}
+
+long get_vfield(struct dbAddr *paddr, struct VField *p)
+{
+    stdstringinRecord *prec = (stdstringinRecord*)paddr->precord;
+
+    if(p->vtype==&vfStdString) {
+        VString *pstr = (VString*)p;
+        if(dbGetFieldIndex(paddr)==stdstringinRecordVAL) {
+            pstr->value = prec->val;
+            return 0;
+        } else if(dbGetFieldIndex(paddr)==stdstringinRecordOVAL) {
+            pstr->value = prec->oval;
+            return 0;
+        }
+    }
+    return S_db_badChoice;
+}
+
+long put_vfield(struct dbAddr *paddr, const struct VField *p)
+{
+    stdstringinRecord *prec = (stdstringinRecord*)paddr->precord;
+
+    if(p->vtype==&vfStdString) {
+        const VString *pstr = (const VString*)p;
+        if(dbGetFieldIndex(paddr)==stdstringinRecordVAL) {
+            prec->val = pstr->value;
+            return 0;
+        } else if(dbGetFieldIndex(paddr)==stdstringinRecordOVAL) {
+            prec->oval = pstr->value;
+            return 0;
+        }
+    }
+    return S_db_badChoice;
+}
+
+#define report NULL
+#define special NULL
+#define get_value NULL
+#define get_units NULL
+#define get_precision NULL
+#define get_enum_str NULL
+#define get_enum_strs NULL
+#define put_enum_str NULL
+#define get_graphic_double NULL
+#define get_control_double NULL
+#define get_alarm_double NULL
+
+rset stdstringinRSET={
+    RSETNUMBER,
+    report,
+    initialize,
+    init_record,
+    process,
+    special,
+    get_value,
+    cvt_dbaddr,
+    get_array_info,
+    put_array_info,
+    get_units,
+    get_precision,
+    get_enum_str,
+    get_enum_strs,
+    put_enum_str,
+    get_graphic_double,
+    get_control_double,
+    get_alarm_double,
+    get_vfield,
+    put_vfield,
+};
+
+} // namespace
+
+extern "C" {
+epicsExportAddress(rset,stdstringinRSET);
+}

--- a/modules/database/src/std/rec/stdstringinRecord.dbd
+++ b/modules/database/src/std/rec/stdstringinRecord.dbd
@@ -1,0 +1,49 @@
+#*************************************************************************
+# Copyright (c) 2020 Michael Davidsaver
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution.
+#*************************************************************************
+
+recordtype(stdstringin) {
+    include "dbCommon.dbd"
+    %/* Declare Device Support Entry Table */
+    %#include <string>
+    %#include <dbAccess.h>
+    %#include <shareLib.h>
+    %#ifdef __cplusplus
+    %extern "C" {
+    %#endif
+    %struct stdstringinRecord;
+    %epicsShareExtern VFieldType vfStdString;
+    %struct VString {
+    %    const VFieldType* vtype;
+    %    std::string value;
+    %};
+    %typedef struct stdstringindset {
+    %    dset common; /*init_record returns: (-1,0)=>(failure,success)*/
+    %    long (*read_stdstringin)(struct stdstringinRecord *prec); /*returns: (-1,0)=>(failure,success)*/
+    %} stdstringindset;
+    %#define HAS_stdstringindset
+    %#ifdef __cplusplus
+    %}
+    %#endif
+    field(VAL,DBF_NOACCESS) {
+            prompt("Current Value")
+            promptgroup("40 - Input")
+            asl(ASL0)
+            pp(TRUE)
+            special(SPC_DBADDR)
+            extra("std::string val")
+    }
+    field(OVAL,DBF_NOACCESS) {
+            prompt("Previous Value")
+            interest(3)
+            special(SPC_DBADDR)
+            extra("std::string oval")
+    }
+    field(INP,DBF_INLINK) {
+            prompt("Input Specification")
+            promptgroup("40 - Input")
+            interest(1)
+    }
+}

--- a/modules/database/test/std/rec/Makefile
+++ b/modules/database/test/std/rec/Makefile
@@ -87,6 +87,12 @@ testHarness_SRCS += seqTest.c
 TESTFILES += ../seqTest.db
 TESTS += seqTest
 
+TESTPROD_HOST += testVField
+testVField_SRCS += testVField.cpp
+testVField_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
+TESTFILES += ../ssiTest.db
+TESTS += testVField
+
 TARGETS += $(COMMON_DIR)/asTestIoc.dbd
 DBDDEPENDS_FILES += asTestIoc.dbd$(DEP)
 asTestIoc_DBD += base.dbd

--- a/modules/database/test/std/rec/ssiTest.db
+++ b/modules/database/test/std/rec/ssiTest.db
@@ -1,0 +1,5 @@
+record(stdstringin, "recsrc") {
+}
+record(stdstringin, "recdst") {
+    field(INP , "recsrc")
+}

--- a/modules/database/test/std/rec/testVField.cpp
+++ b/modules/database/test/std/rec/testVField.cpp
@@ -1,0 +1,76 @@
+/*************************************************************************\
+* Copyright (c) 2020 Michael Davidsaver
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include <dbUnitTest.h>
+#include <testMain.h>
+
+#include <dbAccess.h>
+#include <stdstringinRecord.h>
+
+extern "C" {
+void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
+}
+
+namespace {
+
+void testGetPut()
+{
+    DBADDR addr;
+    stdstringinRecord *psrc = (stdstringinRecord*)testdbRecordPtr("recsrc");
+    stdstringinRecord *pdst = (stdstringinRecord*)testdbRecordPtr("recdst");
+
+    if(!testOk1(!dbNameToAddr("recsrc", &addr))) {
+        testAbort("Unable to create DBADDR to vfield");
+    }
+
+    VString sval;
+    sval.vtype = &vfStdString;
+    sval.value = "This is a long test value to ensure std::string allocates";
+
+    testdbPutFieldOk("recsrc", DBR_VFIELD, &sval);
+
+    dbScanLock((dbCommon*)psrc);
+    testOk1(psrc->val==sval.value);
+    dbScanUnlock((dbCommon*)psrc);
+
+    VString sval2;
+    sval2.vtype = &vfStdString;
+
+    testOk1(!dbGetField(&addr, DBR_VFIELD, &sval2, 0, 0, 0));
+    testOk1(sval2.value==sval.value);
+
+    testdbPutFieldOk("recdst.PROC", DBF_LONG, 1);
+
+    dbScanLock((dbCommon*)pdst);
+    testOk1(pdst->val==sval.value);
+    dbScanUnlock((dbCommon*)pdst);
+
+    testdbGetArrFieldEqual("recsrc", DBF_CHAR, sval.value.size()+1, sval.value.size()+1, sval.value.c_str());
+}
+
+}
+
+MAIN(testVField)
+{
+    testPlan(8);
+
+    testdbPrepare();
+
+    testdbReadDatabase("recTestIoc.dbd", 0, 0);
+    recTestIoc_registerRecordDeviceDriver(pdbbase);
+
+    testdbReadDatabase("ssiTest.db", 0, 0);
+
+    testIocInitOk();
+
+    testGetPut();
+
+    testIocShutdownOk();
+
+    testdbCleanup();
+
+    return  testDone();
+}


### PR DESCRIPTION
While not acceptable in it present form, I would like to get feedback before another iteration as I would like to see a solution merged.

The problem I'm trying to solve is how to usefully access complex types as database fields.  My immediate application is to the PVA data containers `shared_vector` and `PVStructure`, although there are others (eg. areaDetector's NDArray).

I'd like to be able to move these types through `dbGet()` and `dbPut()`, and by extension the derivative interfaces like links.

I want to do this in a way which would avoid allocating a new `DBF_*` code for every possible data type to avoid close coupling of currently external types with the database code.  My solution to this is to add one new `DBR_*` code, and use it to pass extra arguments around most of the existing code of `dbGet()` and `dbPut()`.  The logic to handle this is split between the caller, and record support.

So a caller would look like:

```c++
DBADDR *paddress = ...;
shared_vector<const void> aval;
struct VField {
    const VFieldType *vtype;
    shared_vector<const void> *aval;
} varg = {&vfSharedVector, &aval};
dbGet(paddress, DBR_VFIELD, NULL, &varg, NULL);
```

So in effect, `DBR_VFIELD` indicates that additional arguments are passed through the existing 'pbuffer' argument.  At present this ugliness is left exposed, though could eventually be hidden in a wrapper.

The other side of `dbGet()` is one of two new record support functions

```c++
long get_vfield(struct dbAddr *paddr, struct VField *p)
{
    stdstringinRecord *prec = (stdstringinRecord*)paddr->precord;

    if(p->vtype==&vfStdString) {
        VString *pstr = (VString*)p;
        if(dbGetFieldIndex(paddr)==stdstringinRecordVAL) {
            pstr->value = prec->val;
            return 0;
        } else if(dbGetFieldIndex(paddr)==stdstringinRecordOVAL) {
            pstr->value = prec->oval;
            return 0;
        }
    }
    return S_db_badChoice;
}
```

This PR supersedes https://github.com/mdavidsaver/epics-base/pull/1 now that the pre-requisite #71 is merged.