### PR TITLE
`dbChannel_get_count()`unlocked

### DIFF
--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -623,6 +623,7 @@ all_done:
 
 long dbEntryToAddr(const DBENTRY *pdbentry, DBADDR *paddr)
 {
+    long ret = 0;
     dbFldDes *pflddes = pdbentry->pflddes;
     short dbfType = pflddes->field_type;
 
@@ -640,10 +641,11 @@ long dbEntryToAddr(const DBENTRY *pdbentry, DBADDR *paddr)
 
         /* Let record type modify paddr */
         if (prset && prset->cvt_dbaddr) {
-            return prset->cvt_dbaddr(paddr);
+            ret = prset->cvt_dbaddr(paddr);
         }
     }
-    return 0;
+    paddr->compare = paddr->pfield;
+    return ret;
 }
 
 /*
@@ -911,7 +913,6 @@ long dbGet(DBADDR *paddr, short dbrType,
     void *pbuffer, long *options, long *nRequest, void *pflin)
 {
     char *pbuf = pbuffer;
-    void *pfieldsave = paddr->pfield;
     db_field_log *pfl = (db_field_log *)pflin;
     short field_type;
     long capacity, no_elements, offset;
@@ -1044,7 +1045,6 @@ long dbGet(DBADDR *paddr, short dbrType,
         }
     }
 done:
-    paddr->pfield = pfieldsave;
     return status;
 }
 
@@ -1322,7 +1322,6 @@ long dbPut(DBADDR *paddr, short dbrType,
     short field_type  = paddr->field_type;
     long no_elements  = paddr->no_elements;
     long special      = paddr->special;
-    void *pfieldsave  = paddr->pfield;
     rset *prset = dbGetRset(paddr);
     long status = 0;
     long offset;
@@ -1387,7 +1386,7 @@ long dbPut(DBADDR *paddr, short dbrType,
     if (isValueField) precord->udf = FALSE;
     if (precord->mlis.count &&
         !(isValueField && pfldDes->process_passive))
-        db_post_events(precord, pfieldsave, DBE_VALUE | DBE_LOG);
+        db_post_events(precord, paddr->compare, DBE_VALUE | DBE_LOG);
     /* If this field is a property (metadata) field,
      * then post a property change event (even if the field
      * didn't change).
@@ -1395,6 +1394,5 @@ long dbPut(DBADDR *paddr, short dbrType,
     if (precord->mlis.count && pfldDes->prop)
         db_post_events(precord, NULL, DBE_PROPERTY);
 done:
-    paddr->pfield = pfieldsave;
     return status;
 }

--- a/modules/database/src/ioc/db/dbAddr.h
+++ b/modules/database/src/ioc/db/dbAddr.h
@@ -17,6 +17,7 @@ struct dbFldDes;
 typedef struct dbAddr {
         struct dbCommon *precord;   /* address of record                     */
         void    *pfield;            /* address of field                      */
+        void    *compare;           /* use only for equality/order test between instances */
         struct dbFldDes *pfldDes;   /* address of struct fldDes              */
         long    no_elements;        /* number of elements (arrays)           */
         short   field_type;         /* type of database field                */

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -851,7 +851,7 @@ unsigned int    caEventMask
          * Only send event msg if they are waiting on the field which
          * changed or pval==NULL, and are waiting on matching event
          */
-        if ( (dbChannelField(pevent->chan) == (void *)pField || pField==NULL) &&
+        if ( (pevent->chan->addr.compare == (void *)pField || pField==NULL) &&
             (caEventMask & pevent->select)) {
             db_field_log *pLog = db_create_event_log(pevent);
             pLog = dbChannelRunPreChain(pevent->chan, pLog);

--- a/modules/database/src/ioc/db/db_access.c
+++ b/modules/database/src/ioc/db/db_access.c
@@ -148,13 +148,18 @@ int dbChannel_get_count(
     long options;
     long i;
     long zero = 0;
+    /* we can avoid taking the record scan lock iif we have a db_field_log with all necessary info.
+     * Currently this means owned value, and only alarm+time meta.
+     */
+    int lockit = !pfl || !dbfl_has_copy((db_field_log*)pfl) || buffer_type>oldDBR_TIME_DOUBLE;
 
    /* The order of the DBR* elements in the "newSt" structures below is
     * very important and must correspond to the order of processing
     * in the dbAccess.c dbGet() and getOptions() routines.
     */
 
-    dbScanLock(dbChannelRecord(chan));
+    if(lockit)
+        dbScanLock(dbChannelRecord(chan));
 
     switch(buffer_type) {
     case(oldDBR_STRING):
@@ -798,7 +803,8 @@ int dbChannel_get_count(
         break;
     }
 
-    dbScanUnlock(dbChannelRecord(chan));
+    if(lockit)
+        dbScanUnlock(dbChannelRecord(chan));
 
     if (status) return -1;
     return 0;


### PR DESCRIPTION
A change I tried while playing around with https://github.com/epics-base/epics-base/pull/100#issuecomment-813701869 .  While it didn't have much effect in that highly artificial case with a single client, it might be interesting from the prospective of scalability.  Omitting `dbScanLock()` would allow many clients to run `dbChannel_get_count()` in parallel, potentially mitigating "thundering herd" scenarios following a subscription update.