### PR TITLE
caRepeater fallback to internal for all targets

### DIFF
--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -629,8 +629,8 @@ void epicsStdCall caStartRepeaterIfNotInstalled ( unsigned repeaterPort )
          * repeater's port)
          */
         osiSpawnDetachedProcessReturn osptr =
-            osiSpawnDetachedProcess ( "CA Repeater", "caRepeater" );
-        if ( osptr == osiSpawnDetachedProcessNoSupport ) {
+            osiSpawnDetachedProcess ( "!CA Repeater", "caRepeater" );
+        if ( osptr != osiSpawnDetachedProcessSuccess ) {
             epicsThreadId tid;
 
             tid = epicsThreadCreate ( "CAC-repeater", epicsThreadPriorityLow,
@@ -638,9 +638,6 @@ void epicsStdCall caStartRepeaterIfNotInstalled ( unsigned repeaterPort )
             if ( tid == 0 ) {
                 fprintf ( stderr, "caStartRepeaterIfNotInstalled : unable to create CA repeater daemon thread\n" );
             }
-        }
-        else if ( osptr == osiSpawnDetachedProcessFail ) {
-            fprintf ( stderr, "caStartRepeaterIfNotInstalled (): unable to start CA repeater daemon detached process\n" );
         }
     }
 }

--- a/modules/libcom/src/osi/os/WIN32/osdProcess.c
+++ b/modules/libcom/src/osi/os/WIN32/osdProcess.c
@@ -50,9 +50,13 @@ LIBCOM_API osiGetUserNameReturn epicsStdCall osiGetUserName (char *pBuf, unsigne
 LIBCOM_API osiSpawnDetachedProcessReturn epicsStdCall osiSpawnDetachedProcess 
     ( const char *pProcessName, const char *pBaseExecutableName )
 {
+    BOOL silent = pProcessName && pProcessName[0]=='!';
     BOOL status;
     STARTUPINFO startupInfo;
     PROCESS_INFORMATION processInfo;
+
+    if(silent)
+        pProcessName++; /* skip '!' */
 
     GetStartupInfo ( &startupInfo );
     startupInfo.lpReserved = NULL;
@@ -115,7 +119,7 @@ LIBCOM_API osiSpawnDetachedProcessReturn epicsStdCall osiSpawnDetachedProcess
             /* Free the buffer. */
             LocalFree (errStrMsgBuf);
         }
-        else {
+        else if(!silent) {
             fprintf (stderr, "!!WARNING!!\n");
             fprintf (stderr, "Unable to locate executable \"%s\".\n", pBaseExecutableName);
             fprintf (stderr, "You may need to modify your \"path\" environment variable.\n");

--- a/modules/libcom/src/osi/os/posix/osdProcess.c
+++ b/modules/libcom/src/osi/os/posix/osdProcess.c
@@ -63,7 +63,11 @@ LIBCOM_API osiSpawnDetachedProcessReturn epicsStdCall osiSpawnDetachedProcess
     (const char *pProcessName, const char *pBaseExecutableName)
 {
     int status;
+    int silent = pProcessName && pProcessName[0]=='!';
     int fds[2]; /* [reader, writer] */
+
+    if(silent)
+        pProcessName++; /* skip '!' */
 
     if(pipe(fds))
         return osiSpawnDetachedProcessFail;
@@ -137,7 +141,7 @@ LIBCOM_API osiSpawnDetachedProcessReturn epicsStdCall osiSpawnDetachedProcess
      * Run the specified executable
      */
     status = execlp (pBaseExecutableName, pBaseExecutableName, (char *)NULL);
-    if ( status < 0 ) {
+    if ( status < 0 && !silent ) {
         fprintf ( stderr, "**** The executable \"%s\" couldn't be located\n", pBaseExecutableName );
         fprintf ( stderr, "**** because of errno = \"%s\".\n", strerror (errno) );
         fprintf ( stderr, "**** You may need to modify your PATH environment variable.\n" );

--- a/modules/libcom/src/osi/os/posix/osdProcess.c
+++ b/modules/libcom/src/osi/os/posix/osdProcess.c
@@ -24,7 +24,9 @@
 #include <unistd.h>
 #include <sched.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <pwd.h>
+#include <fcntl.h>
 
 #include "osiProcess.h"
 #include "errlog.h"
@@ -61,12 +63,18 @@ LIBCOM_API osiSpawnDetachedProcessReturn epicsStdCall osiSpawnDetachedProcess
     (const char *pProcessName, const char *pBaseExecutableName)
 {
     int status;
+    int fds[2]; /* [reader, writer] */
+
+    if(pipe(fds))
+        return osiSpawnDetachedProcessFail;
 
     /*
      * create a duplicate process
      */
     status = fork ();
     if (status < 0) {
+        close(fds[0]);
+        close(fds[1]);
         return osiSpawnDetachedProcessFail;
     }
 
@@ -75,11 +83,29 @@ LIBCOM_API osiSpawnDetachedProcessReturn epicsStdCall osiSpawnDetachedProcess
      * in the initiating (parent) process
      */
     if (status) {
-        return osiSpawnDetachedProcessSuccess;
-    }
+        osiSpawnDetachedProcessReturn ret = osiSpawnDetachedProcessSuccess;
+        char buf;
+        ssize_t n;
+        close(fds[1]);
 
-    /*
-     * This is executed only by the new child process.
+        n = read(fds[0], &buf, 1);
+        /* Success if child exec'd without sending a '!'.
+         * Of course child may crash soon after, but can't
+         * wait around for this to happen.
+         */
+        if(n!=0) {
+            ret = osiSpawnDetachedProcessFail;
+        }
+
+        close(fds[0]);
+        return ret;
+    }
+    close(fds[0]);
+    (void)fcntl ( fds[1], F_SETFD, FD_CLOEXEC );
+
+    /* This is executed only by the new child process.
+     * Since we may be called from a library, we don't assume that
+     * all other code has set properly set FD_CLOEXEC.
      * Close all open files except for STDIO, so they will not
      * be inherited by the new program.
      */
@@ -89,6 +115,8 @@ LIBCOM_API osiSpawnDetachedProcessReturn epicsStdCall osiSpawnDetachedProcess
             if (fd==STDIN_FILENO) continue;
             if (fd==STDOUT_FILENO) continue;
             if (fd==STDERR_FILENO) continue;
+            /* pipe to our parent will be closed automatically via FD_CLOEXEC */
+            if (fd==fds[1]) continue;
             close (fd);
         }
     }
@@ -115,6 +143,10 @@ LIBCOM_API osiSpawnDetachedProcessReturn epicsStdCall osiSpawnDetachedProcess
         fprintf ( stderr, "**** You may need to modify your PATH environment variable.\n" );
         fprintf ( stderr, "**** Unable to start \"%s\" process.\n", pProcessName);
     }
+    /* signal error to parent */
+    ssize_t ret = write(fds[1], "!", 1);
+    (void)ret; /* not much we could do about this */
+    close(fds[1]);
     /* Don't run our parent's atexit() handlers */
     _exit ( -1 );
 }


### PR DESCRIPTION
Instead of complaining if the `caRepeater` executable can't be found, silently fall back to an in-process repeater thread as is done for embedded targets.

Two preparatory changes are also made.

1. Fix the posix/ `osiSpawnDetachedProcess()` so the `execvp()` failure is actually reported.  Currently `osiSpawnDetachedProcessFail` is only returned if `fork()` fails.
2. Allow optional bypass of the warning printed by `osiSpawnDetachedProcess()` by prefixing the process name with a special character.  (I picked `'!'` to start)

The possibility came up in conversation with @thomascobb.