### PR TITLE
Improved Validation and Error Messages for RELEASE files.

### DIFF
--- a/src/template/base/top/configure/CONFIG
+++ b/src/template/base/top/configure/CONFIG
@@ -13,6 +13,11 @@ ifdef T_A
 -include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
 endif
 
+# Check for proper EPICS_BASE
+ifneq (file,$(origin EPICS_BASE))
+ $(error EPICS_BASE must be defined in configure/RELEASE or a similar file or it will not be correctly read by convertRelease.pl!)
+endif
+
 CONFIG = $(RULES)/configure
 include $(CONFIG)/CONFIG
 

--- a/src/template/base/top/configure/CONFIG
+++ b/src/template/base/top/configure/CONFIG
@@ -8,9 +8,10 @@ RULES = $(EPICS_BASE)
 # RELEASE files point to other application tops
 include $(TOP)/configure/RELEASE
 -include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
+
 ifdef T_A
--include $(TOP)/configure/RELEASE.Common.$(T_A)
--include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
+  -include $(TOP)/configure/RELEASE.Common.$(T_A)
+  -include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
 endif
 
 # Check EPICS_BASE is set properly
@@ -28,11 +29,17 @@ include $(CONFIG)/CONFIG
 # Override the Base definition:
 INSTALL_LOCATION = $(TOP)
 
-# CONFIG_SITE files contain other build configuration settings
+# CONFIG_SITE files contain local build configuration settings
 include $(TOP)/configure/CONFIG_SITE
+
+# Host-arch specific settings
 -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+
 ifdef T_A
+  # Target-arch specific settings
  -include $(TOP)/configure/CONFIG_SITE.Common.$(T_A)
+
+  #  Host & target specific settings
  -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
 endif
 

--- a/src/template/base/top/configure/CONFIG
+++ b/src/template/base/top/configure/CONFIG
@@ -13,9 +13,13 @@ ifdef T_A
 -include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
 endif
 
-# Check for proper EPICS_BASE
+# Check EPICS_BASE is set properly
 ifneq (file,$(origin EPICS_BASE))
- $(error EPICS_BASE must be defined in configure/RELEASE or a similar file or it will not be correctly read by convertRelease.pl!)
+  $(error EPICS_BASE must be set in a configure/RELEASE file)
+else
+  ifeq ($(wildcard $(EPICS_BASE)/configure/CONFIG_BASE),)
+    $(error EPICS_BASE does not point to an EPICS installation)
+  endif
 endif
 
 CONFIG = $(RULES)/configure

--- a/src/template/ext/top/configure/CONFIG
+++ b/src/template/ext/top/configure/CONFIG
@@ -1,13 +1,11 @@
 # CONFIG - Load build configuration data
 #
-# Do not make changes in this file, any site-specific
-# overrides should be given in a CONFIG_SITE file.
+# Do not make changes to this file!
 
-# Where the build rules come from
+# Allow user to override where the build rules come from
 RULES = $(EPICS_BASE)
 
-INSTALL_IDLFILE = $(INSTALL)
-
+# RELEASE files point to other application tops
 include $(TOP)/configure/RELEASE
 -include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH)
 -include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).Common
@@ -29,24 +27,26 @@ endif
 CONFIG = $(RULES)/configure
 include $(CONFIG)/CONFIG
 
-# Override some Base definitions
+# Override the Base definition:
 INSTALL_LOCATION = $(TOP)
 
-# CONFIG_SITE files contain build configuration overrides
+# CONFIG_SITE files contain local build configuration settings
 include $(TOP)/configure/CONFIG_SITE
 
-# Host-arch specific settings
+# Host-arch specific settings for extensions are in configure/os
 -include $(TOP)/configure/os/CONFIG_SITE.$(EPICS_HOST_ARCH).Common
+
+ifdef T_A
+  # Target-arch specific settings for extensions are in configure/os
+  -include $(TOP)/configure/os/CONFIG_SITE.Common.$(T_A)
+
+  #  Host & target specific settings for extensions are in configure/os
+  -include $(TOP)/configure/os/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
+endif
+
+# Additional settings for extensions
+INSTALL_IDLFILE = $(INSTALL)
 
 ifdef INSTALL_LOCATION_EXTENSIONS
   INSTALL_LOCATION = $(INSTALL_LOCATION_EXTENSIONS)
 endif
-
-ifdef T_A
-  # Target-arch specific settings
-  -include $(TOP)/configure/os/CONFIG_SITE.Common.$(T_A)
-
-  #  Host & target specific combination settings
-  -include $(TOP)/configure/os/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
-endif
-

--- a/src/template/ext/top/configure/CONFIG
+++ b/src/template/ext/top/configure/CONFIG
@@ -17,6 +17,11 @@ ifdef T_A
   -include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
 endif
 
+# Check for proper EPICS_BASE
+ifneq (file,$(origin EPICS_BASE))
+ $(error EPICS_BASE must be defined in configure/RELEASE or a similar file or it will not be correctly read by convertRelease.pl!)
+endif
+
 CONFIG = $(RULES)/configure
 include $(CONFIG)/CONFIG
 

--- a/src/template/ext/top/configure/CONFIG
+++ b/src/template/ext/top/configure/CONFIG
@@ -17,9 +17,13 @@ ifdef T_A
   -include $(TOP)/configure/RELEASE.$(EPICS_HOST_ARCH).$(T_A)
 endif
 
-# Check for proper EPICS_BASE
+# Check EPICS_BASE is set properly
 ifneq (file,$(origin EPICS_BASE))
- $(error EPICS_BASE must be defined in configure/RELEASE or a similar file or it will not be correctly read by convertRelease.pl!)
+  $(error EPICS_BASE must be set in a configure/RELEASE file)
+else
+  ifeq ($(wildcard $(EPICS_BASE)/configure/CONFIG_BASE),)
+    $(error EPICS_BASE does not point to an EPICS installation)
+  endif
 endif
 
 CONFIG = $(RULES)/configure

--- a/src/tools/convertRelease.pl
+++ b/src/tools/convertRelease.pl
@@ -113,9 +113,6 @@ EOF
 #
 sub releaseTops {
     my @includes = grep !m/^ (TOP | TEMPLATE_TOP) $/x, @apps;
-    if (!@includes) {
-        die "No variables defined in RELEASE*s";
-    }
     print join(' ', @includes), "\n";
 }
 

--- a/src/tools/convertRelease.pl
+++ b/src/tools/convertRelease.pl
@@ -113,6 +113,9 @@ EOF
 #
 sub releaseTops {
     my @includes = grep !m/^ (TOP | TEMPLATE_TOP) $/x, @apps;
+    if (!@includes) {
+        die "No variables defined in RELEASE*s";
+    }
     print join(' ', @includes), "\n";
 }
 
@@ -256,6 +259,9 @@ sub checkRelease {
     }
 
     my @modules = grep(!m/^(RULES|TOP|TEMPLATE_TOP)$/, @apps);
+    if (!@modules) {
+        die "No variables defined in RELEASE*s";
+    }
     my $app = shift @modules;
     my $latest = AbsPath($macros{$app});
     my %paths = ($latest => $app);

--- a/src/tools/convertRelease.pl
+++ b/src/tools/convertRelease.pl
@@ -227,6 +227,12 @@ sub envPaths {
 # Check RELEASE file consistency with support modules
 #
 sub checkRelease {
+    die "\nEPICS_BASE must be set in a configure/RELEASE file.\n\n"
+        unless grep(m/^(EPICS_BASE)$/, @apps) &&
+            exists $macros{EPICS_BASE} &&
+            $macros{EPICS_BASE} ne '' &&
+            -f "$macros{EPICS_BASE}/configure/CONFIG_BASE";
+
     my $status = 0;
     delete $macros{RULES};
     delete $macros{TOP};
@@ -256,9 +262,6 @@ sub checkRelease {
     }
 
     my @modules = grep(!m/^(RULES|TOP|TEMPLATE_TOP)$/, @apps);
-    if (!@modules) {
-        die "No variables defined in RELEASE*s";
-    }
     my $app = shift @modules;
     my $latest = AbsPath($macros{$app});
     my %paths = ($latest => $app);


### PR DESCRIPTION
- Added error message for when EPICS_BASE is not set on templates.
- Added error message and validation at convertRelease.pl for empty RELEASE files.

I came across this issue when I tried to build a module which depends only on EPICS_BASE and I didn't have it defined on my RELEASE.local file but it was defined on my environment variables.