### PR TITLE
Fix issue with very large timeout passed to epicsEventWaitWithTimeout()

### DIFF
--- a/src/libCom/osi/os/WIN32/osdEvent.c
+++ b/src/libCom/osi/os/WIN32/osdEvent.c
@@ -92,24 +92,27 @@ epicsShareFunc epicsEventStatus epicsEventWait ( epicsEventId pSem )
 epicsShareFunc epicsEventStatus epicsEventWaitWithTimeout (
     epicsEventId pSem, double timeOut )
 { 
-    static const unsigned nSec100PerSec = 10000000u; /* number of 100ns intervals per second */
-    static const unsigned mSecPerSec = 1000u;
+    /* waitable timers use 100 nanosecond intervals, like FILETIME */
+    static const unsigned ivalPerSec = 10000000u; /* number of 100ns intervals per second */
+    static const unsigned mSecPerSec = 1000u;     /* milliseconds per second */
     HANDLE handles[2];
     DWORD status;
     LARGE_INTEGER tmo;
     HANDLE timer;
-    LONGLONG nSec100;
+    LONGLONG nIvals;  /* number of intervals */
 
     if ( timeOut <= 0.0 ) {
         tmo.QuadPart = 0u;
     }
     else if ( timeOut >= INFINITE / mSecPerSec  ) {
-        nSec100 = (LONGLONG)(INFINITE - 1) * (nSec100PerSec / mSecPerSec); /* for compatibility with old approach */
-        tmo.QuadPart = -nSec100;  /* negative value means a relative time offset for timer */
+        /* we need to apply a maximum wait time to stop an overflow. We choose (INFINITE - 1) milliseconds,
+           to be compatible with previous WaitForSingleObject() implementation */    
+        nIvals = (LONGLONG)(INFINITE - 1) * (ivalPerSec / mSecPerSec);
+        tmo.QuadPart = -nIvals;  /* negative value means a relative time offset for timer */
     }
     else {
-        nSec100 = (LONGLONG)(timeOut * nSec100PerSec + 0.999999);
-        tmo.QuadPart = -nSec100;
+        nIvals = (LONGLONG)(timeOut * ivalPerSec + 0.999999);
+        tmo.QuadPart = -nIvals;
     }
 
     if (tmo.QuadPart < 0) {

--- a/src/libCom/osi/os/WIN32/osdEvent.c
+++ b/src/libCom/osi/os/WIN32/osdEvent.c
@@ -92,7 +92,7 @@ epicsShareFunc epicsEventStatus epicsEventWait ( epicsEventId pSem )
 epicsShareFunc epicsEventStatus epicsEventWaitWithTimeout (
     epicsEventId pSem, double timeOut )
 { 
-    static const unsigned nSec100PerSec = 10000000u;
+    static const unsigned nSec100PerSec = 10000000u; /* number of 100ns intervals per second */
     static const unsigned mSecPerSec = 1000u;
     HANDLE handles[2];
     DWORD status;
@@ -105,7 +105,7 @@ epicsShareFunc epicsEventStatus epicsEventWaitWithTimeout (
     }
     else if ( timeOut >= INFINITE / mSecPerSec  ) {
         nSec100 = (LONGLONG)(INFINITE - 1) * (nSec100PerSec / mSecPerSec); /* for compatibility with old approach */
-        tmo.QuadPart = -nSec100;
+        tmo.QuadPart = -nSec100;  /* negative value means a relative time offset for timer */
     }
     else {
         nSec100 = (LONGLONG)(timeOut * nSec100PerSec + 0.999999);

--- a/src/libCom/osi/os/WIN32/osdEvent.c
+++ b/src/libCom/osi/os/WIN32/osdEvent.c
@@ -93,16 +93,23 @@ epicsShareFunc epicsEventStatus epicsEventWaitWithTimeout (
     epicsEventId pSem, double timeOut )
 { 
     static const unsigned nSec100PerSec = 10000000u;
+    static const unsigned mSecPerSec = 1000u;
     HANDLE handles[2];
     DWORD status;
     LARGE_INTEGER tmo;
     HANDLE timer;
+    LONGLONG nSec100;
 
     if ( timeOut <= 0.0 ) {
         tmo.QuadPart = 0u;
     }
+    else if ( timeOut >= INFINITE / mSecPerSec  ) {
+        nSec100 = (LONGLONG)(INFINITE - 1) * (nSec100PerSec / mSecPerSec); /* for compatibility with old approach */
+        tmo.QuadPart = -nSec100;
+    }
     else {
-        tmo.QuadPart = -((LONGLONG)(timeOut * nSec100PerSec + 0.5));
+        nSec100 = (LONGLONG)(timeOut * nSec100PerSec + 0.999999);
+        tmo.QuadPart = -nSec100;
     }
 
     if (tmo.QuadPart < 0) {

--- a/src/libCom/osi/os/WIN32/osdThread.c
+++ b/src/libCom/osi/os/WIN32/osdThread.c
@@ -808,14 +808,21 @@ HANDLE osdThreadGetTimer()
 epicsShareFunc void epicsShareAPI epicsThreadSleep ( double seconds )
 {
     static const unsigned nSec100PerSec = 10000000u;
+    static const unsigned mSecPerSec = 1000u;
     LARGE_INTEGER tmo;
     HANDLE timer;
+    LONGLONG nSec100;
 
     if ( seconds <= 0.0 ) {
         tmo.QuadPart = 0u;
     }
+    else if ( seconds >= INFINITE / mSecPerSec  ) {
+        nSec100 = (LONGLONG)(INFINITE - 1) * (nSec100PerSec / mSecPerSec); /* for compatibility with old approach */
+        tmo.QuadPart = -nSec100;
+    }
     else {
-        tmo.QuadPart = -((LONGLONG)(seconds * nSec100PerSec + 0.5));
+        nSec100 = (LONGLONG)(seconds * nSec100PerSec + 0.999999);
+        tmo.QuadPart = -nSec100;
     }
 
     if (tmo.QuadPart == 0) {

--- a/src/libCom/osi/os/WIN32/osdThread.c
+++ b/src/libCom/osi/os/WIN32/osdThread.c
@@ -807,7 +807,7 @@ HANDLE osdThreadGetTimer()
  */
 epicsShareFunc void epicsShareAPI epicsThreadSleep ( double seconds )
 {
-    static const unsigned nSec100PerSec = 10000000u;
+    static const unsigned nSec100PerSec = 10000000u; /* number of 100ns intervals per second */
     static const unsigned mSecPerSec = 1000u;
     LARGE_INTEGER tmo;
     HANDLE timer;
@@ -818,7 +818,7 @@ epicsShareFunc void epicsShareAPI epicsThreadSleep ( double seconds )
     }
     else if ( seconds >= INFINITE / mSecPerSec  ) {
         nSec100 = (LONGLONG)(INFINITE - 1) * (nSec100PerSec / mSecPerSec); /* for compatibility with old approach */
-        tmo.QuadPart = -nSec100;
+        tmo.QuadPart = -nSec100; /* negative value means a relative time offset for timer */
     }
     else {
         nSec100 = (LONGLONG)(seconds * nSec100PerSec + 0.999999);


### PR DESCRIPTION
A very large timeout was getting converted to a 0 wait and causing some unit tests to fail in strange and random ways. Not trapping large timeouts was an oversight when converting to waitable timers on WIN32