### PR TITLE
RTEMS5: Make QEMU tests work

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -85,7 +85,6 @@ jobs:
             configuration: default
             rtems: "5"
             rtems_target: RTEMS-pc686-qemu
-            test: NO
             name: "Ub-20 gcc-9 + RT-5.1 pc686"
 
           - os: ubuntu-20.04
@@ -145,7 +144,6 @@ jobs:
             rtems: "4.9"
             name: "Ub-20 gcc-9 + RT-4.9"
             rtems_target: RTEMS-pc386-qemu
-            test: NO
 
           - os: macos-latest
             cmp: clang
@@ -188,7 +186,7 @@ jobs:
     - name: Build main module
       run: python .ci/cue.py build
     - name: Run main module tests
-      run: python .ci/cue.py -T 20M test
+      run: python .ci/cue.py -T 60M test
     - name: Upload tapfiles Artifact
       if: ${{ always() }}
       uses: actions/upload-artifact@v2

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -1003,12 +1003,19 @@ POSIX_Init ( void *argument __attribute__((unused)))
         rtems_get_version_string());
 
 #ifndef RTEMS_LEGACY_STACK
+#if defined(QEMU_FIXUPS) && defined(__i386__)
+    // glorious hack to stub out useless EEPROM check
+    // which takes sooooo longggg w/ QEMU
+    // Writes a 'ret' instruction to immediatly return to the caller
+    extern void _bsd_e1000_validate_nvm_checksum(void);
+    *(char*)&_bsd_e1000_validate_nvm_checksum = 0xc3;
+#endif
     /*
      * Start network (libbsd)
      *
      * start qemu like this
      * qemu-system-i386 -m 64 -no-reboot -serial stdio -display none \
-     * -net nic,model=rtl8139,macaddr=0e:b0:ba:5e:ba:11 -net user,restrict=yes \
+     * -net nic,model=e1000 -net user,restrict=yes \
      * -append "--video=off --console=/dev/com1" -kernel libComTestHarness
      */
     printf("\n***** Initializing network (libbsd, dhcpcd) *****\n");

--- a/modules/libcom/RTEMS/rtems_netconfig.c
+++ b/modules/libcom/RTEMS/rtems_netconfig.c
@@ -32,7 +32,7 @@
  * Ticket URL: <http://devel.rtems.org/ticket/2375#comment:23>
  */
 
-#if RTEMS_VERSION_INT<=VERSION_INT(4,10,0,0)
+#if RTEMS_VERSION_INT<VERSION_INT(4,11,0,0)
 extern void rtems_bsdnet_loopattach();
 static struct rtems_bsdnet_ifconfig loopback_config = {
     "lo0",                          /* name */
@@ -58,7 +58,7 @@ rtems_ne2kpci_driver_attach (struct rtems_bsdnet_ifconfig *config, int attach);
 static struct rtems_bsdnet_ifconfig ne2k_driver_config = {
     "ne2",                             /* name */
     rtems_ne2kpci_driver_attach,       /* attach function */
-#if RTEMS_VERSION_INT<=VERSION_INT(4,10,0,0)
+#if RTEMS_VERSION_INT<VERSION_INT(4,11,0,0)
     &loopback_config,                   /* link to next interface */
 #else
     NULL,
@@ -96,7 +96,7 @@ static struct rtems_bsdnet_ifconfig e3c509_driver_config = {
 static struct rtems_bsdnet_ifconfig netdriver_config = {
     RTEMS_BSP_NETWORK_DRIVER_NAME,      /* name */
     RTEMS_BSP_NETWORK_DRIVER_ATTACH,    /* attach function */
-#if RTEMS_VERSION_INT<=VERSION_INT(4,10,0,0)
+#if RTEMS_VERSION_INT<VERSION_INT(4,11,0,0)
     &loopback_config,                   /* link to next interface */
 #endif
 };

--- a/modules/libcom/src/misc/epicsUnitTest.c
+++ b/modules/libcom/src/misc/epicsUnitTest.c
@@ -28,6 +28,13 @@
 #  endif
 #endif
 
+#ifdef __rtems__
+#  include <syslog.h>
+#  ifndef RTEMS_LEGACY_STACK
+#    include <rtems/bsd/bsd.h>
+#  endif
+#endif
+
 #include "epicsThread.h"
 #include "epicsMutex.h"
 #include "epicsUnitTest.h"
@@ -95,6 +102,18 @@ static int testReportHook(int reportType, char *message, int *returnValue)
 static void testOnce(void *dummy) {
     testLock = epicsMutexMustCreate();
     perlHarness = (getenv("HARNESS_ACTIVE") != NULL);
+#ifdef __rtems__
+    // syslog() on RTEMS prints to stdout, which will interfere with test output.
+    // setlogmask() ignores empty mask, so must allow at least one level.
+    (void)setlogmask(LOG_MASK(LOG_CRIT));
+    printf("# mask syslog() output\n");
+#ifndef RTEMS_LEGACY_STACK
+    // with libbsd  setlogmask() is a no-op :(
+    // name strings in sys/syslog.h
+    rtems_bsd_setlogpriority("crit");
+#endif
+#endif
+
 #ifdef _WIN32
 #ifdef HAVE_SETERROMODE
     /* SEM_FAILCRITICALERRORS - Don't display modal dialog


### PR DESCRIPTION
Partially address #175.

Rewrite the DHCP handler to avoid repeated explicit `char*` handling.

Make `rtemsInit_NTP_server_ip` optional, and remove the default.

Change the dhcpcd.conf option name separator from `_` to `-`.  May be necessary.