### PR TITLE
Atomic compare and swap

### DIFF
--- a/modules/database/src/ioc/db/callback.c
+++ b/modules/database/src/ioc/db/callback.c
@@ -233,7 +233,7 @@ void callbackStop(void)
 {
     int i;
 
-    if (epicsAtomicCmpAndSwapIntT(&cbState, cbRun, cbStop)!=cbRun) return;
+    if (!epicsAtomicCompareAndSwapIntT(&cbState, cbRun, cbStop)) return;
 
     for (i = 0; i < NUM_CALLBACK_PRIORITIES; i++) {
         epicsAtomicSetIntT(&callbackQueue[i].shutdown, 1);
@@ -254,7 +254,7 @@ void callbackCleanup(void)
 {
     int i;
 
-    if(epicsAtomicCmpAndSwapIntT(&cbState, cbStop, cbInit)!=cbStop) {
+    if (!epicsAtomicCompareAndSwapIntT(&cbState, cbStop, cbInit)) {
         fprintf(stderr, "callbackCleanup() but not stopped\n");
     }
 
@@ -278,7 +278,7 @@ void callbackInit(void)
     int j;
     char threadName[32];
 
-    if (epicsAtomicCmpAndSwapIntT(&cbState, cbInit, cbRun)!=cbInit) {
+    if (!epicsAtomicCompareAndSwapIntT(&cbState, cbInit, cbRun)) {
         fprintf(stderr, "Warning: callbackInit called again before callbackCleanup\n");
         return;
     }

--- a/modules/libcom/src/osi/compiler/gcc/epicsAtomicCD.h
+++ b/modules/libcom/src/osi/compiler/gcc/epicsAtomicCD.h
@@ -130,10 +130,10 @@ EPICS_ATOMIC_INLINE int epicsAtomicAddIntT ( int * pTarget, int delta )
 }
 
 #define EPICS_ATOMIC_CAS_INTT
-EPICS_ATOMIC_INLINE int epicsAtomicCmpAndSwapIntT ( int * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapIntT ( int * pTarget,
                                         int oldVal, int newVal )
 {
-    return __sync_val_compare_and_swap ( pTarget, oldVal, newVal);
+    return __sync_bool_compare_and_swap ( pTarget, oldVal, newVal);
 }
 
 #endif /* if GCC_ATOMIC_INTRINSICS_AVAIL_INT_T */
@@ -166,18 +166,18 @@ EPICS_ATOMIC_INLINE size_t epicsAtomicSubSizeT ( size_t * pTarget, size_t delta 
 }
 
 #define EPICS_ATOMIC_CAS_SIZET
-EPICS_ATOMIC_INLINE size_t epicsAtomicCmpAndSwapSizeT ( size_t * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapSizeT ( size_t * pTarget,
                                         size_t oldVal, size_t newVal )
 {
-    return __sync_val_compare_and_swap ( pTarget, oldVal, newVal);
+    return __sync_bool_compare_and_swap ( pTarget, oldVal, newVal);
 }
 
 #define EPICS_ATOMIC_CAS_PTRT
-EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicCmpAndSwapPtrT (
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapPtrT (
                             EpicsAtomicPtrT * pTarget,
                             EpicsAtomicPtrT oldVal, EpicsAtomicPtrT newVal )
 {
-    return __sync_val_compare_and_swap ( pTarget, oldVal, newVal);
+    return __sync_bool_compare_and_swap ( pTarget, oldVal, newVal);
 }
 
 #endif /* if GCC_ATOMIC_INTRINSICS_AVAIL_SIZE_T */

--- a/modules/libcom/src/osi/epicsAtomic.h
+++ b/modules/libcom/src/osi/epicsAtomic.h
@@ -80,14 +80,14 @@ EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicGetPtrT ( const EpicsAtomicPtrT *
  * lock out other smp processors from accessing the target,
  * load target into cache, if target is equal to oldVal set target
  * to newVal, flush cache to target, allow other smp processors
- * to access the target, return the original value stored in the
- * target
+ * to access the target, and return 1 (true),
+ * otherwise do not modify target and return 0 (false)
  */
-EPICS_ATOMIC_INLINE size_t epicsAtomicCmpAndSwapSizeT ( size_t * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapSizeT ( size_t * pTarget,
                                             size_t oldVal, size_t newVal );
-EPICS_ATOMIC_INLINE int epicsAtomicCmpAndSwapIntT ( int * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapIntT ( int * pTarget,
                                             int oldVal, int newVal );
-EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicCmpAndSwapPtrT (
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapPtrT (
                                             EpicsAtomicPtrT * pTarget,
                                             EpicsAtomicPtrT oldVal,
                                             EpicsAtomicPtrT newVal );
@@ -192,22 +192,22 @@ EPICS_ATOMIC_INLINE EpicsAtomicPtrT get ( const EpicsAtomicPtrT & v )
 }
 
 /************* cas ***************/
-EPICS_ATOMIC_INLINE size_t compareAndSwap ( size_t & v,
+EPICS_ATOMIC_INLINE bool compareAndSwap ( size_t & v,
                                           size_t oldVal, size_t newVal )
 {
-    return epicsAtomicCmpAndSwapSizeT ( & v, oldVal, newVal );
+    return epicsAtomicCompareAndSwapSizeT ( & v, oldVal, newVal );
 }
 
-EPICS_ATOMIC_INLINE int compareAndSwap ( int & v, int oldVal, int newVal )
+EPICS_ATOMIC_INLINE bool compareAndSwap ( int & v, int oldVal, int newVal )
 {
-    return epicsAtomicCmpAndSwapIntT ( & v, oldVal, newVal );
+    return epicsAtomicCompareAndSwapIntT ( & v, oldVal, newVal );
 }
 
-EPICS_ATOMIC_INLINE EpicsAtomicPtrT compareAndSwap ( EpicsAtomicPtrT & v,
+EPICS_ATOMIC_INLINE bool compareAndSwap ( EpicsAtomicPtrT & v,
                                                    EpicsAtomicPtrT oldVal,
                                                    EpicsAtomicPtrT newVal )
 {
-    return epicsAtomicCmpAndSwapPtrT ( & v, oldVal, newVal );
+    return epicsAtomicCompareAndSwapPtrT ( & v, oldVal, newVal );
 }
 
 } /* end of name space atomic */

--- a/modules/libcom/src/osi/epicsAtomicDefault.h
+++ b/modules/libcom/src/osi/epicsAtomicDefault.h
@@ -189,7 +189,8 @@ EPICS_ATOMIC_INLINE EpicsAtomicPtrT
  * cmp and swap
  */
 #ifndef EPICS_ATOMIC_CAS_INTT
-EPICS_ATOMIC_INLINE int epicsAtomicCmpAndSwapIntT ( int * pTarget, int oldval, int newval )
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapIntT ( int * pTarget,
+                                int oldval, int newval )
 {
     EpicsAtomicLockKey key;
     int cur;
@@ -200,12 +201,12 @@ EPICS_ATOMIC_INLINE int epicsAtomicCmpAndSwapIntT ( int * pTarget, int oldval, i
         *pTarget = newval;
     }
     epicsAtomicUnlock ( & key );
-    return cur;
+    return cur == oldval;
 }
 #endif
 
 #ifndef EPICS_ATOMIC_CAS_SIZET
-EPICS_ATOMIC_INLINE size_t epicsAtomicCmpAndSwapSizeT ( size_t * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapSizeT ( size_t * pTarget,
                                 size_t oldval, size_t newval )
 {
     EpicsAtomicLockKey key;
@@ -217,12 +218,12 @@ EPICS_ATOMIC_INLINE size_t epicsAtomicCmpAndSwapSizeT ( size_t * pTarget,
         *pTarget = newval;
     }
     epicsAtomicUnlock ( & key );
-    return cur;
+    return cur == oldval;
 }
 #endif
 
 #ifndef EPICS_ATOMIC_CAS_PTRT
-EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicCmpAndSwapPtrT (
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapPtrT (
                             EpicsAtomicPtrT * pTarget,
                             EpicsAtomicPtrT oldval, EpicsAtomicPtrT newval )
 {
@@ -235,7 +236,7 @@ EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicCmpAndSwapPtrT (
         *pTarget = newval;
     }
     epicsAtomicUnlock ( & key );
-    return cur;
+    return cur == oldval;
 }
 #endif
 

--- a/modules/libcom/src/osi/os/WIN32/epicsAtomicMS.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsAtomicMS.h
@@ -57,13 +57,13 @@ EPICS_ATOMIC_INLINE int epicsAtomicAddIntT ( int * pTarget, int delta )
 
 #ifndef EPICS_ATOMIC_CAS_INTT
 #define EPICS_ATOMIC_CAS_INTT
-EPICS_ATOMIC_INLINE int epicsAtomicCmpAndSwapIntT ( int * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapIntT ( int * pTarget,
                                             int oldVal, int newVal )
 {
     STATIC_ASSERT ( sizeof ( MS_LONG ) == sizeof ( int ) );
     MS_LONG * const pTarg = ( MS_LONG * ) ( pTarget );
-    return (int) MS_InterlockedCompareExchange ( pTarg,
-                                    (MS_LONG) newVal, (MS_LONG) oldVal );
+    return MS_InterlockedCompareExchange ( pTarg,
+                    (MS_LONG) newVal, (MS_LONG) oldVal ) == (MS_LONG) oldVal;
 }
 #endif
 
@@ -120,25 +120,25 @@ EPICS_ATOMIC_INLINE size_t epicsAtomicSubSizeT ( size_t * pTarget, size_t delta 
 
 #ifndef EPICS_ATOMIC_CAS_SIZET
 #define EPICS_ATOMIC_CAS_SIZET
-EPICS_ATOMIC_INLINE size_t epicsAtomicCmpAndSwapSizeT (
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapSizeT (
                                     size_t * pTarget,
                                     size_t oldVal, size_t newVal )
 {
     MS_LONG * const pTarg = ( MS_LONG * ) ( pTarget );
-    return (size_t) MS_InterlockedCompareExchange ( pTarg,
-                                    (MS_LONG) newVal, (MS_LONG) oldVal );
+    return MS_InterlockedCompareExchange ( pTarg,
+                    (MS_LONG) newVal, (MS_LONG) oldVal ) == (MS_LONG) oldVal;
 }
 #endif
 
 #ifndef EPICS_ATOMIC_CAS_PTRT
 #define EPICS_ATOMIC_CAS_PTRT
-EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicCmpAndSwapPtrT (
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapPtrT (
                                     EpicsAtomicPtrT * pTarget,
                                     EpicsAtomicPtrT oldVal, EpicsAtomicPtrT newVal )
 {
     MS_LONG * const pTarg = ( MS_LONG * ) ( pTarget );
-    return (EpicsAtomicPtrT) MS_InterlockedCompareExchange ( pTarg,
-                                    (MS_LONG) newVal, (MS_LONG) oldVal );
+    return MS_InterlockedCompareExchange ( pTarg,
+                    (MS_LONG) newVal, (MS_LONG) oldVal ) == (MS_LONG) oldVal;
 }
 #endif
 
@@ -191,25 +191,26 @@ EPICS_ATOMIC_INLINE size_t epicsAtomicSubSizeT ( size_t * pTarget, size_t delta 
 
 #ifndef EPICS_ATOMIC_CAS_SIZET
 #define EPICS_ATOMIC_CAS_SIZET
-EPICS_ATOMIC_INLINE size_t epicsAtomicCmpAndSwapSizeT ( size_t * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapSizeT ( size_t * pTarget,
                                     size_t oldVal, size_t newVal )
 {
     MS_LONGLONG * const pTarg = ( MS_LONGLONG * ) ( pTarget );
-    return (size_t) MS_InterlockedCompareExchange64 ( pTarg,
-                                    (MS_LONGLONG) newVal,
-                                    (MS_LONGLONG) oldVal );
+    return MS_InterlockedCompareExchange64 ( pTarg,
+                            (MS_LONGLONG) newVal,
+                            (MS_LONGLONG) oldVal ) == (MS_LONGLONG) oldVal;
 }
 #endif
 
 #ifndef EPICS_ATOMIC_CAS_PTRT
 #define EPICS_ATOMIC_CAS_PTRT
-EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicCmpAndSwapPtrT (
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapPtrT (
                             EpicsAtomicPtrT * pTarget,
                             EpicsAtomicPtrT oldVal, EpicsAtomicPtrT newVal )
 {
     MS_LONGLONG * const pTarg = ( MS_LONGLONG * ) ( pTarget );
-    return (EpicsAtomicPtrT) MS_InterlockedCompareExchange64 ( pTarg,
-                                    (MS_LONGLONG) newVal, (MS_LONGLONG) oldVal );
+    return MS_InterlockedCompareExchange64 ( pTarg,
+                            (MS_LONGLONG) newVal,
+                            (MS_LONGLONG) oldVal ) == (MS_LONGLONG) oldVal;
 }
 #endif
 

--- a/modules/libcom/src/osi/os/WIN32/osdThread.c
+++ b/modules/libcom/src/osi/os/WIN32/osdThread.c
@@ -648,7 +648,7 @@ void epicsThreadMustJoin(epicsThreadId id)
 
     if(!id) {
         /* no-op */
-    } else if(epicsAtomicCmpAndSwapIntT(&id->joinable, 1, 0)!=1) {
+    } else if(!epicsAtomicCompareAndSwapIntT(&id->joinable, 1, 0)) {
         if(epicsThreadGetIdSelf()==id) {
             fprintf(stderr, "Warning: %s thread self-join of unjoinable\n", pParmWIN32->pName);
 

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -646,7 +646,7 @@ void epicsThreadMustJoin(epicsThreadId id)
 
     if(!id) {
         return;
-    } else if(epicsAtomicCmpAndSwapIntT(&id->joinable, 1, 0)!=1) {
+    } else if (!epicsAtomicCompareAndSwapIntT(&id->joinable, 1, 0)) {
         if(epicsThreadGetIdSelf()==id) {
             errlogPrintf("Warning: %s thread self-join of unjoinable\n", id->name);
 

--- a/modules/libcom/src/osi/os/solaris/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/solaris/epicsAtomicOSD.h
@@ -52,36 +52,36 @@ EPICS_ATOMIC_INLINE void epicsAtomicWriteMemoryBarrier (void)
 
 #ifndef EPICS_ATOMIC_CAS_INTT
 #define EPICS_ATOMIC_CAS_INTT
-EPICS_ATOMIC_INLINE int epicsAtomicCmpAndSwapIntT ( int * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapIntT ( int * pTarget,
                                                int oldVal, int newVal )
 {
     STATIC_ASSERT ( sizeof ( int ) == sizeof ( unsigned ) );
     unsigned * const pTarg = ( unsigned * ) pTarget;
-    return ( int ) atomic_cas_uint ( pTarg, ( unsigned ) oldVal,
-                                        ( unsigned ) newVal );
+    return atomic_cas_uint ( pTarg, ( unsigned ) oldVal,
+                                ( unsigned ) newVal ) == ( unsigned ) oldVal;
 }
 #endif
 
 #ifndef EPICS_ATOMIC_CAS_SIZET
 #define EPICS_ATOMIC_CAS_SIZET
-EPICS_ATOMIC_INLINE size_t epicsAtomicCmpAndSwapSizeT (
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapSizeT (
                                                   size_t * pTarget,
                                                   size_t oldVal, size_t newVal )
 {
     STATIC_ASSERT ( sizeof ( ulong_t ) == sizeof ( size_t ) );
     ulong_t * const pTarg = ( ulong_t * ) pTarget;
-    return ( size_t ) atomic_cas_ulong ( pTarg, oldVal, newVal );
+    return atomic_cas_ulong ( pTarg, oldVal, newVal ) == oldVal;
 }
 #endif
 
 #ifndef EPICS_ATOMIC_CAS_PTRT
 #define EPICS_ATOMIC_CAS_PTRT
-EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicCmpAndSwapPtrT (
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapPtrT (
                                        EpicsAtomicPtrT * pTarget,
                                        EpicsAtomicPtrT oldVal,
                                        EpicsAtomicPtrT newVal )
 {
-    return atomic_cas_ptr ( pTarget, oldVal, newVal );
+    return atomic_cas_ptr ( pTarget, oldVal, newVal ) == oldVal;
 }
 #endif
 

--- a/modules/libcom/src/osi/os/vxWorks/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/vxWorks/epicsAtomicOSD.h
@@ -125,21 +125,21 @@ EPICS_ATOMIC_INLINE size_t epicsAtomicSubSizeT ( size_t * pTarget, size_t delta 
 
 #ifndef EPICS_ATOMIC_CAS_SIZET
 #define EPICS_ATOMIC_CAS_SIZET
-EPICS_ATOMIC_INLINE size_t epicsAtomicCmpAndSwapSizeT ( size_t * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapSizeT ( size_t * pTarget,
                             size_t oldVal, size_t newVal )
 {
     atomic_t * const pTarg = ( atomic_t * ) ( pTarget );
-    return ( size_t ) vxCas ( pTarg, (atomic_t) oldVal, (atomic_t) newVal );
+    return vxCas ( pTarg, (atomic_t) oldVal, (atomic_t) newVal );
 }
 #endif
 
 #ifndef EPICS_ATOMIC_CAS_PTRT
 #define EPICS_ATOMIC_CAS_PTRT
-EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicCmpAndSwapPtrT ( EpicsAtomicPtrT * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapPtrT ( EpicsAtomicPtrT * pTarget,
                             EpicsAtomicPtrT oldVal, EpicsAtomicPtrT newVal )
 {
     atomic_t * const pTarg = ( atomic_t * ) ( pTarget );
-    return (EpicsAtomicPtrT) vxCas ( pTarg, (atomic_t) oldVal, (atomic_t) newVal );
+    return vxCas ( pTarg, (atomic_t) oldVal, (atomic_t) newVal );
 }
 #endif
 
@@ -192,11 +192,11 @@ EPICS_ATOMIC_INLINE int epicsAtomicAddIntT ( int * pTarget, int delta )
 
 #ifndef EPICS_ATOMIC_CAS_INTT
 #define EPICS_ATOMIC_CAS_INTT
-EPICS_ATOMIC_INLINE int epicsAtomicCmpAndSwapIntT ( int * pTarget,
+EPICS_ATOMIC_INLINE int epicsAtomicCompareAndSwapIntT ( int * pTarget,
                                             int oldVal, int newVal )
 {
     atomic_t * const pTarg = ( atomic_t * ) ( pTarget );
-    return ( int ) vxCas ( pTarg, (atomic_t) oldVal, (atomic_t) newVal );
+    return vxCas ( pTarg, (atomic_t) oldVal, (atomic_t) newVal );
 }
 #endif
 

--- a/modules/libcom/src/osi/os/vxWorks/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/vxWorks/epicsAtomicOSD.h
@@ -24,33 +24,6 @@
 #include "vxWorks.h" /* obtain the version of vxWorks */
 #include "epicsAssert.h"
 
-#include "vxLib.h"
-#include "intLib.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif /* __cplusplus */
-
-#ifndef EPICS_ATOMIC_LOCK
-#define EPICS_ATOMIC_LOCK
-
-typedef struct EpicsAtomicLockKey { int m_key; } EpicsAtomicLockKey;
-
-EPICS_ATOMIC_INLINE void epicsAtomicLock ( EpicsAtomicLockKey * pKey )
-{
-    pKey->m_key = intLock ();
-}
-
-EPICS_ATOMIC_INLINE void epicsAtomicUnlock ( EpicsAtomicLockKey * pKey )
-{
-    intUnlock ( pKey->m_key );
-}
-#endif
-
-#ifdef __cplusplus
-} /* end of extern "C" */
-#endif /* __cplusplus */
-
 /*
  * With vxWorks 6.6 and later we need to use vxAtomicLib
  * to implement this functionality correctly on SMP systems
@@ -150,6 +123,26 @@ EPICS_ATOMIC_INLINE size_t epicsAtomicSubSizeT ( size_t * pTarget, size_t delta 
 }
 #endif
 
+#ifndef EPICS_ATOMIC_CAS_SIZET
+#define EPICS_ATOMIC_CAS_SIZET
+EPICS_ATOMIC_INLINE size_t epicsAtomicCmpAndSwapSizeT ( size_t * pTarget,
+                            size_t oldVal, size_t newVal )
+{
+    atomic_t * const pTarg = ( atomic_t * ) ( pTarget );
+    return ( size_t ) vxCas ( pTarg, (atomic_t) oldVal, (atomic_t) newVal );
+}
+#endif
+
+#ifndef EPICS_ATOMIC_CAS_PTRT
+#define EPICS_ATOMIC_CAS_PTRT
+EPICS_ATOMIC_INLINE EpicsAtomicPtrT epicsAtomicCmpAndSwapPtrT ( EpicsAtomicPtrT * pTarget,
+                            EpicsAtomicPtrT oldVal, EpicsAtomicPtrT newVal )
+{
+    atomic_t * const pTarg = ( atomic_t * ) ( pTarget );
+    return (EpicsAtomicPtrT) vxCas ( pTarg, (atomic_t) oldVal, (atomic_t) newVal );
+}
+#endif
+
 #else /* ULONG_MAX == UINT_MAX */
 
 /*
@@ -197,6 +190,15 @@ EPICS_ATOMIC_INLINE int epicsAtomicAddIntT ( int * pTarget, int delta )
 }
 #endif
 
+#ifndef EPICS_ATOMIC_CAS_INTT
+#define EPICS_ATOMIC_CAS_INTT
+EPICS_ATOMIC_INLINE int epicsAtomicCmpAndSwapIntT ( int * pTarget,
+                                            int oldVal, int newVal )
+{
+    atomic_t * const pTarg = ( atomic_t * ) ( pTarget );
+    return ( int ) vxCas ( pTarg, (atomic_t) oldVal, (atomic_t) newVal );
+}
+#endif
 
 #ifdef __cplusplus
 } /* end of extern "C" */
@@ -212,6 +214,22 @@ EPICS_ATOMIC_INLINE int epicsAtomicAddIntT ( int * pTarget, int delta )
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
+
+#ifndef EPICS_ATOMIC_LOCK
+#define EPICS_ATOMIC_LOCK
+
+typedef struct EpicsAtomicLockKey { int m_key; } EpicsAtomicLockKey;
+
+EPICS_ATOMIC_INLINE void epicsAtomicLock ( EpicsAtomicLockKey * pKey )
+{
+    pKey->m_key = intLock ();
+}
+
+EPICS_ATOMIC_INLINE void epicsAtomicUnlock ( EpicsAtomicLockKey * pKey )
+{
+    intUnlock ( pKey->m_key );
+}
+#endif
 
 #ifndef EPICS_ATOMIC_READ_MEMORY_BARRIER
 #define EPICS_ATOMIC_READ_MEMORY_BARRIER

--- a/modules/libcom/test/epicsAtomicPerform.cpp
+++ b/modules/libcom/test/epicsAtomicPerform.cpp
@@ -355,7 +355,7 @@ void AtomicCmpAndSwap < T > :: diagnostic ( double delay )
     delay /= 10.0;
     delay *= 1e6;
     const char * const pName = typeid ( T ) . name ();
-    testDiag ( "epicsAtomicCmpAndSwap of \"%s\" takes %f microseconds",
+    testDiag ( "epicsAtomicCompareAndSwap of \"%s\" takes %f microseconds",
                          pName, delay );
 }
 

--- a/modules/libcom/test/epicsAtomicTest.cpp
+++ b/modules/libcom/test/epicsAtomicTest.cpp
@@ -337,13 +337,13 @@ static void testClassify()
     testDiag("Use default epicsAtomicGetPtrT()");
 #endif
 #ifndef EPICS_ATOMIC_CAS_INTT
-    testDiag("Use default epicsAtomicCmpAndSwapIntT()");
+    testDiag("Use default epicsAtomicCompareAndSwapIntT()");
 #endif
 #ifndef EPICS_ATOMIC_CAS_SIZET
-    testDiag("Use default epicsAtomicCmpAndSwapSizeT()");
+    testDiag("Use default epicsAtomicCompareAndSwapSizeT()");
 #endif
 #ifndef EPICS_ATOMIC_CAS_PTRT
-    testDiag("Use default epicsAtomicCmpAndSwapPtrT()");
+    testDiag("Use default epicsAtomicCompareAndSwapPtrT()");
 #endif
 #endif /* __GNUC__ */
 }
@@ -388,17 +388,17 @@ void testBasic()
     testOk1(get(Int)==-44);
     testOk1(get(Sizet)==40);
 
-    testOk1(compareAndSwap(Int, -34, -10)==-44);
-    testOk1(compareAndSwap(Sizet, 34, 10)==40);
-    testOk1(compareAndSwap(voidp, NULL, (void*)&Sizet)==(void*)&voidp);
+    testOk1(!compareAndSwap(Int, -34, -10));
+    testOk1(!compareAndSwap(Sizet, 34, 10));
+    testOk1(!compareAndSwap(voidp, NULL, (void*)&Sizet));
 
     testOk1(get(Int)==-44);
     testOk1(get(Sizet)==40);
     testOk1(get(voidp)==(void*)&voidp);
 
-    testOk1(compareAndSwap(Int, -44, -10)==-44);
-    testOk1(compareAndSwap(Sizet, 40, 10)==40);
-    testOk1(compareAndSwap(voidp, (void*)&voidp, (void*)&Sizet)==(void*)&voidp);
+    testOk1(compareAndSwap(Int, -44, -10));
+    testOk1(compareAndSwap(Sizet, 40, 10));
+    testOk1(compareAndSwap(voidp, (void*)&voidp, (void*)&Sizet));
 
     testOk1(get(Int)==-10);
     testOk1(get(Sizet)==10);

--- a/modules/libcom/test/epicsSpinTest.c
+++ b/modules/libcom/test/epicsSpinTest.c
@@ -138,7 +138,7 @@ static void verifyTryLockThread(void *pArg)
     while(epicsAtomicGetIntT(&pVerify->main->flag)==0) {
         int ret = epicsSpinTryLock(pVerify->main->spin);
         if(ret!=0) {
-            epicsAtomicCmpAndSwapIntT(&pVerify->main->flag, 0, ret);
+            epicsAtomicCompareAndSwapIntT(&pVerify->main->flag, 0, ret);
             break;
         } else
             epicsSpinUnlock(pVerify->main->spin);


### PR DESCRIPTION
New atomic compare and swap semantics returning bool (`int` actually becaue `bool` is not C) instead of the old value (because this is the only flavor supported by VxWorks 6). This is related to bug https://bugs.launchpad.net/epics-base/+bug/1932118.

I have renamed the functions `epicsAtomicCmpAndSwap*()` to   #`epicsAtomicCmpAndSwap*()` so that potential externall usage will not show unexpected behavior because of the changed return value (but instead will fail to link).
I have changed the C++ wrapper `compareAndSwap` to return `bool` but I have not changed the name. (Should I ?)

Tested on RHEL7 and vxWorks 6.7.
