### PR TITLE
fix missing declaration of 'close' function in vxWorks 6.3 and lower

### DIFF
--- a/modules/libcom/src/osi/os/vxWorks/osdFindSymbol.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdFindSymbol.c
@@ -21,6 +21,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <loadLib.h>
+#include <ioLib.h>
 
 #include "dbmf.h"
 #include "epicsString.h"

--- a/modules/libcom/src/osi/os/vxWorks/osiUnistd.h
+++ b/modules/libcom/src/osi/os/vxWorks/osiUnistd.h
@@ -1,0 +1,21 @@
+/*************************************************************************\
+* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
+*     National Laboratory.
+* Copyright (c) 2002 The Regents of the University of California, as
+*     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+/*
+ *  Author Jeffrey O. Hill
+ *  johill@lanl.gov
+ *  505 665 1831
+ */
+
+#include <unistd.h>
+
+/* VxWorks has some functions in ioLib.h instead of unistd.h,
+   for example close() and read()
+ */
+#include <ioLib.h>


### PR DESCRIPTION
VxWorks up to version 6.3 does not have the declaration for `close()` in `unistd.h` but in `ioLib.h`.
This is a problem since `-Werror-implicit-function-declaration` is enabled.
This fix does not harm any other vxWorks version and does not affect ant other OS.