### PR TITLE
Use <osiSock.h> rather than <osdSock.h>

### DIFF
--- a/modules/ca/src/client/caProto.h
+++ b/modules/ca/src/client/caProto.h
@@ -18,7 +18,7 @@
 #define INC_caProto_H
 
 // Pick up definition of IPPORT_USERRESERVED
-#include <osdSock.h>
+#include <osiSock.h>
 
 #define capStrOf(A) #A
 #define capStrOfX(A) capStrOf ( A )


### PR DESCRIPTION
Fix compile issue building PCAS module, which just includes <caProto.h> resulting in LIBCOM_API being undefined