### PR TITLE
Fix a couple memory leaks and a segfault

### DIFF
--- a/modules/database/src/ioc/db/dbBkpt.c
+++ b/modules/database/src/ioc/db/dbBkpt.c
@@ -331,6 +331,7 @@ long dbb(const char *record_name)
      if (pnode->ex_sem == NULL) {
         printf("   BKPT> Out of memory\n");
         dbScanUnlock(precord);
+        free(pnode);
         epicsMutexUnlock(bkpt_stack_sem);
         return(1);
      }

--- a/modules/database/src/ioc/db/dbNotify.c
+++ b/modules/database/src/ioc/db/dbNotify.c
@@ -613,8 +613,10 @@ long dbtpn(char *pname, char *pvalue)
     ptpnInfo = dbCalloc(1, sizeof(tpnInfo));
     ptpnInfo->ppn = ppn;
     ptpnInfo->callbackDone = epicsEventCreate(epicsEventEmpty);
-    strncpy(ptpnInfo->buffer, pvalue, 80);
-    ptpnInfo->buffer[79] = 0;
+    if (pvalue) {
+        strncpy(ptpnInfo->buffer, pvalue, sizeof(ptpnInfo->buffer));
+        ptpnInfo->buffer[sizeof(ptpnInfo->buffer)-1] = 0;
+    }
 
     ppn->usrPvt = ptpnInfo;
     epicsThreadCreate("dbtpn", epicsThreadPriorityHigh,

--- a/modules/database/src/std/dev/devSiSoftCallback.c
+++ b/modules/database/src/std/dev/devSiSoftCallback.c
@@ -108,6 +108,7 @@ static long add_record(dbCommon *pcommon)
 
         recGblRecordError(status, (void *)prec,
             "devSiSoftCallback (add_record) linked record not found");
+        free(pdevPvt);
         return status;
     }
 

--- a/modules/libcom/src/log/iocLogServer.c
+++ b/modules/libcom/src/log/iocLogServer.c
@@ -113,6 +113,7 @@ int main(void)
 
     pserver->pfdctx = (void *) fdmgr_init();
     if (!pserver->pfdctx) {
+        free(pserver);
         fprintf(stderr, "iocLogServer: %s\n", strerror(errno));
         return IOCLS_ERROR;
     }

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -956,8 +956,10 @@ LIBCOM_API epicsThreadPrivateId epicsStdCall epicsThreadPrivateCreate(void)
         return NULL;
     status = pthread_key_create(key,0);
     checkStatus(status,"pthread_key_create epicsThreadPrivateCreate");
-    if(status)
+    if(status) {
+        free(key);
         return NULL;
+    }
     return((epicsThreadPrivateId)key);
 }
 


### PR DESCRIPTION
This fixes some possible memory leaks pointed out by static code analysis, and a segfault I encountered while running `dptpn` without a value parameter.
None of the memory leaks fixed are critical bugs, just small things that occur on certain failures.

I'm not sure what to do here in dptpn, so I just have it pass an empty string in the case where `pvalue` is NULL (Line 616 in dbNotifty.c):
```c
    strncpy(ptpnInfo->buffer, pvalue ? pvalue : "", sizeof(ptpnInfo->buffer));
```