### PR TITLE
Com: clear IP_MULTICAST_ALL on Linux

### DIFF
--- a/modules/libcom/src/osi/os/posix/osdSock.c
+++ b/modules/libcom/src/osi/os/posix/osdSock.c
@@ -99,6 +99,22 @@ LIBCOM_API SOCKET epicsStdCall epicsSocketCreate (
             close ( sock );
             sock = INVALID_SOCKET;
         }
+
+#ifdef __linux__
+#  ifndef IP_MULTICAST_ALL
+#    define IP_MULTICAST_ALL		49
+#  endif
+        /* Enable compliant filtering of multicasts on Linux.  cf. 'man 7 ip' */
+        if(domain==AF_INET && type==SOCK_DGRAM){
+            static int logged;
+            int val = 0;
+            if(setsockopt(sock, IPPROTO_IP, IP_MULTICAST_ALL, (char*)&val, sizeof(val)) && !logged) {
+                logged = 1;
+                errlogPrintf("Warning: Unable to clear IP_MULTICAST_ALL (err=%d).  This may cause problems on multi-homed hosts.\n",
+                             SOCKERRNO);
+            }
+        }
+#endif
     }
     return sock;
 }


### PR DESCRIPTION
Quoting [`man 7 ip`](https://man7.org/linux/man-pages/man7/ip.7.html).

```
IP_MULTICAST_ALL (since Linux 2.6.31)
              This option can be used to modify the delivery policy of
              multicast messages to sockets bound to the wildcard
              INADDR_ANY address.  The argument is a boolean integer
              (defaults to 1).  If set to 1, the socket will receive
              messages from all the groups that have been joined
              globally on the whole system.  Otherwise, it will deliver
              messages only from the groups that have been explicitly
              joined (for example via the IP_ADD_MEMBERSHIP option) on
              this particular socket.
```

Not of the other targets I've tested (OSX and RTEMS+libbsd) behave in this non-compliant way by default.  It seems reasonable to me that, where possible, sockets created by `epicsSocketCreate()` should behave in a uniform way across all supported targets.  So I would like to set `IP_MULTICAST_ALL=0` by default.

If it isn't done for all sockets, it will at least have to by done for the CA UDP sockets.
