### PR TITLE
Fix several compilation errors for -DDEBUG

### DIFF
--- a/modules/ca/src/client/searchTimer.cpp
+++ b/modules/ca/src/client/searchTimer.cpp
@@ -279,8 +279,8 @@ epicsTimerNotify::expireStatus searchTimer::expire (
         if ( this->searchAttempts ) {
             char buf[64];
             currentTime.strftime ( buf, sizeof(buf), "%M:%S.%09f");
-            debugPrintf ( ("sent %u delay sec=%f Rts=%s\n",
-                nFrameSent, this->period(), buf ) );
+            debugPrintf ( ("sent %u delay Rts=%s\n",
+                nFrameSent, buf ) );
         }
 #   endif
 

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -1174,7 +1174,7 @@ void db_event_flow_ctrl_mode_on (dbEventCtx ctx)
      * notify the event handler task
      */
     epicsEventSignal(evUser->ppendsem);
-#ifdef DEBUG
+#if defined(DEBUG) && defined(vxWorks)
     printf("fc on %lu\n", tickGet());
 #endif
 }
@@ -1193,7 +1193,7 @@ void db_event_flow_ctrl_mode_off (dbEventCtx ctx)
      * notify the event handler task
      */
     epicsEventSignal (evUser->ppendsem);
-#ifdef DEBUG
+#if defined(DEBUG) && defined(vxWorks)
     printf("fc off %lu\n", tickGet());
 #endif
 }

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -1245,8 +1245,8 @@ static int claim_ciu_action ( caHdrLargeArray *mp,
         return RSRV_OK;
     }
 
-    DLOG ( 2, ("CAS: claim_ciu_action found '%s', type %d, count %d\n",
-        pName, dbChannelCAType(dbch), dbChannelElements(dbch)) );
+    DLOG ( 2, ("CAS: claim_ciu_action found '%s', count %ld\n",
+        pName, dbChannelElements(dbch)) );
 
     pciu = casCreateChannel (
             client,
@@ -1874,7 +1874,7 @@ static int event_add_action (caHdrLargeArray *mp, void *pPayload, struct client 
      * messages sent by the server).
      */
 
-    DLOG ( 3, ("event_add_action: db_post_single_event (0x%X)\n",
+    DLOG ( 3, ("event_add_action: db_post_single_event (%p)\n",
         pevext->pdbev) );
     db_post_single_event(pevext->pdbev);
 
@@ -2191,7 +2191,7 @@ static int search_reply_udp ( caHdrLargeArray *mp, void *pPayload, struct client
 
     /* Exit quickly if channel not on this node */
     if (dbChannelTest(pName)) {
-        DLOG ( 2, ( "CAS: Lookup for channel \"%s\" failed\n", pPayLoad ) );
+        DLOG ( 2, ( "CAS: Lookup for channel \"%s\" failed\n", pName ) );
         return RSRV_OK;
     }
 
@@ -2278,7 +2278,7 @@ static int search_reply_tcp (
 
     /* Exit quickly if channel not on this node */
     if (dbChannelTest(pName)) {
-        DLOG ( 2, ( "CAS: Lookup for channel \"%s\" failed\n", pPayLoad ) );
+        DLOG ( 2, ( "CAS: Lookup for channel \"%s\" failed\n", pName ) );
         if (mp->m_dataType == DOREPLY)
             search_fail_reply ( mp, pPayload, client );
         return RSRV_OK;
@@ -2410,7 +2410,7 @@ int camessage ( struct client *client )
         }
     }
 
-    DLOG ( 2, ( "CAS: Parsing %d(decimal) bytes\n", recv->cnt ) );
+    DLOG ( 2, ( "CAS: Parsing %d(decimal) bytes\n", client->recv.cnt ) );
 
     while ( 1 )
     {

--- a/modules/libcom/src/log/iocLogServer.c
+++ b/modules/libcom/src/log/iocLogServer.c
@@ -681,12 +681,6 @@ static void freeLogClient(struct iocLogClient     *pclient)
 {
     int     status;
 
-#   ifdef   DEBUG
-    if(length == 0){
-        fprintf(stderr, "iocLogServer: nil message disconnect\n");
-    }
-#   endif
-
     /*
      * flush any left overs
      */

--- a/modules/libcom/src/timer/timer.cpp
+++ b/modules/libcom/src/timer/timer.cpp
@@ -127,7 +127,7 @@ void timer::privateStart ( epicsTimerNotify & notify, const epicsTime & expire )
 #   endif
 
     debugPrintf ( ("Start of \"%s\" with delay %f at %p preempting %u\n",
-        typeid ( this->notify ).name (),
+        typeid ( this->pNotify ).name (),
         expire - epicsTime::getCurrent (), 
         this, preemptCount ) );
 }

--- a/modules/libcom/src/timer/timerQueue.cpp
+++ b/modules/libcom/src/timer/timerQueue.cpp
@@ -134,7 +134,7 @@ double timerQueue::process ( const epicsTime & currentTime )
             epicsGuardRelease < epicsMutex > unguard ( guard );
 
             debugPrintf ( ( "%5u expired \"%s\" with error %f sec\n",
-                N++, typeid ( this->pExpireTmr->notify ).name (),
+                N++, typeid ( this->pExpireTmr->pNotify ).name (),
                 currentTime - this->pExpireTmr->exp ) );
             try {
                 expStat = pTmpNotify->expire ( currentTime );


### PR DESCRIPTION
After Adding "-DDEBUG" to the compiler options some files don't
compile any more.
Fix the compilation errors.