### PR TITLE
Fix issue when osdThreadGetTimer() called from non EPICS threads

### DIFF
--- a/modules/libcom/src/osi/os/WIN32/osdThread.c
+++ b/modules/libcom/src/osi/os/WIN32/osdThread.c
@@ -810,8 +810,14 @@ HANDLE osdThreadGetTimer()
 
     pParm = ( win32ThreadParam * )
         TlsGetValue ( pGbl->tlsIndexThreadLibraryEPICS );
-
-    return pParm->timer;
+    if ( !pParm ) {
+        pParm = epicsThreadImplicitCreate();
+    }
+    if ( pParm ) {
+        return pParm->timer;
+    } else {
+        return NULL;
+    }
 }
 
 /*


### PR DESCRIPTION
This fixes the issue reported in https://epics.anl.gov/tech-talk/2021/msg01691.php

The function need to use epicsThreadImplicitCreate() to handle the case of if it is called from a non EPICS thread - this approach is already used in epicsThreadSuspendSelf, epicsThreadGetPrioritySelf, epicsThreadGetIdSelf and epicsThreadGetNameSelf.
This repeated logic should probably be moved into a separate function, but maybe that is for a separate PR?
