### PR TITLE
Refactor to use common epicsThreadGetParamWIN32() function

### DIFF
--- a/src/libCom/osi/os/WIN32/osdThread.c
+++ b/src/libCom/osi/os/WIN32/osdThread.c
@@ -780,10 +780,10 @@ epicsShareFunc int epicsShareAPI epicsThreadIsSuspended ( epicsThreadId id )
 HANDLE osdThreadGetTimer()
 {
     win32ThreadParam * pParm = epicsThreadGetParamWIN32();
-    if (pParam) {
+    if (pParm) {
         return pParm->timer;
     } else {
-	return NULL;
+        return NULL;
     }
 }
 

--- a/src/libCom/osi/os/WIN32/osdThread.c
+++ b/src/libCom/osi/os/WIN32/osdThread.c
@@ -780,7 +780,11 @@ epicsShareFunc int epicsShareAPI epicsThreadIsSuspended ( epicsThreadId id )
 HANDLE osdThreadGetTimer()
 {
     win32ThreadParam * pParm = epicsThreadGetParamWIN32();
-    return pParm->timer;
+    if (pParam) {
+        return pParm->timer;
+    } else {
+	return NULL;
+    }
 }
 
 /*


### PR DESCRIPTION
This is the refactor mentioned in #200 and also corrects the issue mentioned there 