### PR TITLE
IPv6: part 1, Linux and MacOs

### DIFF
--- a/documentation/ipv6-howto.txt
+++ b/documentation/ipv6-howto.txt
@@ -1,0 +1,35 @@
+Start using IPv6:
+  Using global IPv6 addresses:
+    caget, camonitor can work via IPV6 like this:
+    $ export EPICS_CA_AUTO_ADDR_LIST=NO
+    $ export EPICS_CA_ADDR_LIST='[2001:db8:1:0:0:1:2:3]'
+    cainfo IOC:m1
+
+  Using IPv6 with link local addresses:
+    # On the IOC
+      # Disable IPv4:
+      $ export EPICS_CA_AUTO_ADDR_LIST=NO
+      # enable IPv6:
+      $ export EPICS_CAS_AUTO_BEACON_ADDR_LIST=6
+      # start the IOC:
+      $ st.cmd
+
+    # On the client, use something like this:
+      $ export EPICS_CA_AUTO_ADDR_LIST=NO
+      $ export EPICS_CA_AUTO_ADDR_LIST=6
+      $ cainfo IOC:m1
+      
+
+Running an IOC with IPv6:
+    $  export EPICS_CAS_AUTO_BEACON_ADDR_LIST=46
+    This sends out beacons on all IPv4 and IPv6 interfaces
+
+
+Windows (Mingw)
+  More investigations are needed.
+  Which version of Windows do we want to support ?
+  XP ? Vista ? Windows 10 ?
+
+
+Further reading:
+  https://datatracker.ietf.org/doc/html/rfc3493

--- a/modules/ca/src/client/CAref.html
+++ b/modules/ca/src/client/CAref.html
@@ -269,13 +269,13 @@ is used.</p>
       <th>Default</th>
     </tr>
     <tr>
-      <td>EPICS_CA_ADDR_LIST</td>
-      <td>{N.N.N.N N.N.N.N:P ...}</td>
+      <td>EPICS_CA_ADDR_LIST  (IPv6 must use[])</td>
+      <td>{N.N.N.N N.N.N.N:P [ipv6] [ipv6local%en0]...}</td>
       <td>&lt;none&gt;</td>
     </tr>
     <tr>
       <td>EPICS_CA_AUTO_ADDR_LIST</td>
-      <td>{YES, NO}</td>
+      <td>{YES, NO, 4, 6, 46}</td>
       <td>YES</td>
     </tr>
     <tr>
@@ -498,6 +498,11 @@ This automatic server address list initialization can be disabled if the EPICS
 environment variable EPICS_CA_AUTO_ADDR_LIST exists and its value is either
 "no" or "NO". The typical default is to enable network interface introspection
 driven initialization with EPICS_CA_AUTO_ADDR_LIST set to "YES" or "yes".</p>
+
+<p>Using IPv6:
+Set EPICS_CA_AUTO_ADDR_LIST to "46" to use both IPv4 and IPv6 in parallel.
+Set EPICS_CA_AUTO_ADDR_LIST to "6" to use only IPv6.
+Set EPICS_CA_AUTO_ADDR_LIST to "4" to use only IPv4, this is the same as "YES".</p>
 
 <p>Following network interface introspection, any IP addresses specified in the
 EPICS environment variable EPICS_CA_ADDR_LIST are added to the list of

--- a/modules/ca/src/client/SearchDest.h
+++ b/modules/ca/src/client/SearchDest.h
@@ -27,7 +27,7 @@ struct SearchDest :
         virtual ~Callback () {};
         virtual void notify (
             const caHdr & msg, const void * pPayload,
-            const osiSockAddr & addr, const epicsTime & ) = 0;
+            const osiSockAddr46 & addr46, const epicsTime & ) = 0;
         virtual void show (
             epicsGuard < epicsMutex > &, unsigned level ) const = 0;
     };

--- a/modules/ca/src/client/access.cpp
+++ b/modules/ca/src/client/access.cpp
@@ -309,7 +309,7 @@ int epicsStdCall ca_create_channel (
             }
         }
         if ( pFunc ) {
-            ( *pFunc ) ( pArg, pcac->sock, true );
+            ( *pFunc ) ( pArg, pcac->sock46, true );
         }
     }
 

--- a/modules/ca/src/client/ca_client_context.cpp
+++ b/modules/ca/src/client/ca_client_context.cpp
@@ -87,8 +87,8 @@ ca_client_context::ca_client_context ( bool enablePreemptiveCallback ) :
         }
     }
 
-    this->sock = epicsSocketCreate ( AF_INET, SOCK_DGRAM, IPPROTO_UDP );
-    if ( this->sock == INVALID_SOCKET ) {
+    this->sock46 = epicsSocket46Create ( epicsSocket46GetDefaultAddressFamily(), SOCK_DGRAM, IPPROTO_UDP );
+    if ( this->sock46 == INVALID_SOCKET ) {
         char sockErrBuf[64];
         epicsSocketConvertErrnoToString ( sockErrBuf, sizeof ( sockErrBuf ) );
         this->printFormated (
@@ -100,12 +100,12 @@ ca_client_context::ca_client_context ( bool enablePreemptiveCallback ) :
 
     {
         osiSockIoctl_t yes = true;
-        int status = socket_ioctl ( this->sock,
+        int status = socket_ioctl ( this->sock46,
                                     FIONBIO, & yes);
         if ( status < 0 ) {
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString ( sockErrBuf, sizeof ( sockErrBuf ) );
-            epicsSocketDestroy ( this->sock );
+            epicsSocketDestroy ( this->sock46 );
             this->printFormated (
                 "%s: non blocking IO set fail because \"%s\"\n",
                             __FILE__, sockErrBuf );
@@ -116,16 +116,11 @@ ca_client_context::ca_client_context ( bool enablePreemptiveCallback ) :
     // force a bind to an unconstrained address so we can obtain
     // the local port number below
     {
-        osiSockAddr addr;
-        memset ( (char *)&addr, 0 , sizeof ( addr ) );
-        addr.ia.sin_family = AF_INET;
-        addr.ia.sin_addr.s_addr = htonl ( INADDR_ANY );
-        addr.ia.sin_port = htons ( PORT_ANY );
-        int status = bind (this->sock, &addr.sa, sizeof (addr) );
+      int status = epicsSocket46BindLocalPort(this->sock46, PORT_ANY);
         if ( status < 0 ) {
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString ( sockErrBuf, sizeof ( sockErrBuf ) );
-            epicsSocketDestroy (this->sock);
+            epicsSocketDestroy (this->sock46);
             this->printFormated (
                 "CAC: unable to bind to an unconstrained "
                 "address because = \"%s\"\n",
@@ -135,22 +130,23 @@ ca_client_context::ca_client_context ( bool enablePreemptiveCallback ) :
     }
 
     {
-        osiSockAddr tmpAddr;
-        osiSocklen_t saddr_length = sizeof ( tmpAddr );
-        int status = getsockname ( this->sock, & tmpAddr.sa, & saddr_length );
+        osiSockAddr46 tmpAddr46;
+        osiSocklen_t saddr_length = sizeof ( tmpAddr46 );
+        int status = getsockname ( this->sock46, & tmpAddr46.sa, & saddr_length );
         if ( status < 0 ) {
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString ( sockErrBuf, sizeof ( sockErrBuf ) );
-            epicsSocketDestroy ( this->sock );
+            epicsSocketDestroy ( this->sock46 );
             this->printFormated ( "CAC: getsockname () error was \"%s\"\n", sockErrBuf );
             throwWithLocation ( noSocket () );
         }
-        if ( tmpAddr.sa.sa_family != AF_INET) {
-            epicsSocketDestroy ( this->sock );
-            this->printFormated ( "CAC: UDP socket was not inet addr family\n" );
+        if ( ! epicsSocket46IsAF_INETorAF_INET6 ( tmpAddr46.sa.sa_family ) ) {
+            epicsSocketDestroy ( this->sock46 );
+            this->printFormated ( "CAC: UDP socket was not inet addr family=%d\n",
+                                  tmpAddr46.sa.sa_family);
             throwWithLocation ( noSocket () );
         }
-        this->localPort = htons ( tmpAddr.ia.sin_port );
+        this->localPort = epicsSocket46portFromAddress ( &tmpAddr46 ) ;
     }
 
     ca::auto_ptr < CallbackGuard > pCBGuard;
@@ -166,9 +162,9 @@ ca_client_context::~ca_client_context ()
 {
     if ( this->fdRegFunc ) {
         ( *this->fdRegFunc )
-            ( this->fdRegArg, this->sock, false );
+            ( this->fdRegArg, this->sock46, false );
     }
-    epicsSocketDestroy ( this->sock );
+    epicsSocketDestroy ( this->sock46 );
 
     osiSockRelease ();
 
@@ -547,13 +543,12 @@ int ca_client_context::pendEvent ( const double & timeout )
 
             // remove short udp message sent to wake
             // up a file descriptor manager
-            osiSockAddr tmpAddr;
-            osiSocklen_t addrSize = sizeof ( tmpAddr.sa );
+            osiSockAddr46 tmpAddr46;
             char buf = 0;
             int status = 0;
             do {
-                status = recvfrom ( this->sock, & buf, sizeof ( buf ),
-                        0, & tmpAddr.sa, & addrSize );
+                status = epicsSocket46Recvfrom ( this->sock46, & buf, sizeof ( buf ),
+                                                 0, & tmpAddr46 );
             } while ( status > 0 );
         }
         while ( this->callbackThreadsPending > 0 ) {
@@ -621,13 +616,21 @@ void ca_client_context :: _sendWakeupMsg ()
 {
     // send short udp message to wake up a file descriptor manager
     // when a message arrives
-    osiSockAddr tmpAddr;
-    tmpAddr.ia.sin_family = AF_INET;
-    tmpAddr.ia.sin_addr.s_addr = htonl ( INADDR_LOOPBACK );
-    tmpAddr.ia.sin_port = htons ( this->localPort );
+    osiSockAddr46 addr46;
     char buf = 0;
-    sendto ( this->sock, & buf, sizeof ( buf ),
-            0, & tmpAddr.sa, sizeof ( tmpAddr.sa ) );
+
+    memset ( &addr46, 0, sizeof(addr46) );
+#if EPICS_HAS_IPV6
+    addr46.in6.sin6_family = AF_INET6;
+    addr46.in6.sin6_addr = in6addr_loopback;
+    addr46.in6.sin6_port = htons ( this->localPort );
+#else
+    addr46.ia.sin_family = AF_INET;
+    addr46.ia.sin_addr.s_addr = htonl ( INADDR_LOOPBACK );
+    addr46.ia.sin_port = htons ( this->localPort );
+#endif
+    epicsSocket46Sendto ( this->sock46, & buf, sizeof ( buf ),
+                            0, & addr46 );
 }
 
 void ca_client_context::callbackProcessingCompleteNotify ()

--- a/modules/ca/src/client/cac.h
+++ b/modules/ca/src/client/cac.h
@@ -122,7 +122,7 @@ public:
     void transferChanToVirtCircuit (
         unsigned cid, unsigned sid,
         ca_uint16_t typeCode, arrayElementCount count,
-        unsigned minorVersionNumber, const osiSockAddr &,
+        unsigned minorVersionNumber, const osiSockAddr46 &,
         const epicsTime & currentTime );
     cacChannel & createChannel (
         epicsGuard < epicsMutex > & guard, const char * pChannelName,
@@ -172,7 +172,7 @@ public:
     void registerSearchDest (
         epicsGuard < epicsMutex > &, SearchDest & req );
     bool findOrCreateVirtCircuit (
-        epicsGuard < epicsMutex > &, const osiSockAddr &,
+        epicsGuard < epicsMutex > &, const osiSockAddr46 &,
         unsigned, tcpiiu *&, unsigned, SearchDestTCP * pSearchDest = NULL );
 
     // diagnostics

--- a/modules/ca/src/client/casw.cpp
+++ b/modules/ca/src/client/casw.cpp
@@ -62,8 +62,8 @@ int main ( int argc, char ** argv )
     epicsTime programBeginTime = epicsTime::getCurrent();
     bool validCommandLine = false;
     unsigned interest = 0u;
-    SOCKET sock;
-    osiSockAddr addr;
+    SOCKET sock4;
+    osiSockAddr46 addr46;
     osiSocklen_t addrSize;
     char buf [0x4000];
     const char *pCurBuf;
@@ -105,8 +105,8 @@ int main ( int argc, char ** argv )
 
     caStartRepeaterIfNotInstalled ( repeaterPort );
 
-    sock = epicsSocketCreate ( AF_INET, SOCK_DGRAM, IPPROTO_UDP );
-    if ( sock == INVALID_SOCKET ) {
+    sock4 = epicsSocket46Create ( AF_INET, SOCK_DGRAM, IPPROTO_UDP );
+    if ( sock4 == INVALID_SOCKET ) {
         char sockErrBuf[64];
         epicsSocketConvertErrnoToString (
             sockErrBuf, sizeof ( sockErrBuf ) );
@@ -115,28 +115,28 @@ int main ( int argc, char ** argv )
         return -1;
     }
 
-    memset ( (char *) &addr, 0 , sizeof (addr) );
-    addr.ia.sin_family = AF_INET;
-    addr.ia.sin_addr.s_addr = htonl ( INADDR_ANY );
-    addr.ia.sin_port = htons ( 0 );  // any port
-    status = bind ( sock, &addr.sa, sizeof (addr) );
+    memset ( (char *) &addr46, 0 , sizeof (addr46) );
+    addr46.ia.sin_family = AF_INET;
+    addr46.ia.sin_addr.s_addr = htonl ( INADDR_ANY );
+    addr46.ia.sin_port = htons ( 0 ); // any port
+    status = epicsSocket46Bind ( sock4, &addr46 );
     if ( status < 0 ) {
         char sockErrBuf[64];
         epicsSocketConvertErrnoToString (
             sockErrBuf, sizeof ( sockErrBuf ) );
-        epicsSocketDestroy ( sock );
+        epicsSocketDestroy ( sock4 );
         errlogPrintf ( "casw: unable to bind to an unconstrained address because = \"%s\"\n",
             sockErrBuf );
         return -1;
     }
 
     osiSockIoctl_t yes = true;
-    status = socket_ioctl ( sock, FIONBIO, &yes );
+    status = socket_ioctl ( sock4, FIONBIO, &yes );
     if ( status < 0 ) {
         char sockErrBuf[64];
         epicsSocketConvertErrnoToString (
             sockErrBuf, sizeof ( sockErrBuf ) );
-        epicsSocketDestroy ( sock );
+        epicsSocketDestroy ( sock4 );
         errlogPrintf ( "casw: unable to set socket to nonblocking state because \"%s\"\n",
             sockErrBuf );
         return -1;
@@ -144,11 +144,11 @@ int main ( int argc, char ** argv )
 
     unsigned attemptNumber = 0u;
     while ( true ) {
-        caRepeaterRegistrationMessage ( sock, repeaterPort, attemptNumber );
+        caRepeaterRegistrationMessage ( sock4, repeaterPort, attemptNumber );
         epicsThreadSleep ( 0.1 );
-        addrSize = ( osiSocklen_t ) sizeof ( addr );
-        status = recvfrom ( sock, buf, sizeof ( buf ), 0,
-                            &addr.sa, &addrSize );
+        addrSize = ( osiSocklen_t ) sizeof ( addr46.ia );
+        status = recvfrom ( sock4, buf, sizeof ( buf ), 0,
+                            &addr46.sa, &addrSize);
         if ( status >= static_cast <int> ( sizeof ( *pCurMsg ) ) ) {
             pCurMsg = reinterpret_cast < caHdr * > ( buf );
             epicsUInt16 cmmd = AlignedWireRef < const epicsUInt16 > ( pCurMsg->m_cmmd );
@@ -159,19 +159,19 @@ int main ( int argc, char ** argv )
 
         attemptNumber++;
         if ( attemptNumber > 100 ) {
-            epicsSocketDestroy ( sock );
+            epicsSocketDestroy ( sock4 );
             errlogPrintf ( "casw: unable to register with the CA repeater\n" );
             return -1;
         }
     }
 
     osiSockIoctl_t no = false;
-    status = socket_ioctl ( sock, FIONBIO, &no );
+    status = socket_ioctl ( sock4, FIONBIO, &no );
     if ( status < 0 ) {
         char sockErrBuf[64];
         epicsSocketConvertErrnoToString (
             sockErrBuf, sizeof ( sockErrBuf ) );
-        epicsSocketDestroy ( sock );
+        epicsSocketDestroy ( sock4 );
         errlogPrintf ( "casw: unable to set socket to blocking state because \"%s\"\n",
             sockErrBuf );
         return -1;
@@ -180,20 +180,20 @@ int main ( int argc, char ** argv )
     resTable < bhe, inetAddrID > beaconTable;
     while ( true ) {
 
-        addrSize = ( osiSocklen_t ) sizeof ( addr );
-        status = recvfrom ( sock, buf, sizeof ( buf ), 0,
-                            &addr.sa, &addrSize );
+        addrSize = ( osiSocklen_t ) sizeof ( addr46.ia );
+        status = recvfrom ( sock4, buf, sizeof ( buf ), 0,
+                            &addr46.sa, &addrSize );
         if ( status <= 0 ) {
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
-            epicsSocketDestroy ( sock );
+            epicsSocketDestroy ( sock4 );
             errlogPrintf ("casw: " ERL_ERROR " from recv was = \"%s\"\n",
                 sockErrBuf );
             return -1;
         }
 
-        if ( addr.sa.sa_family != AF_INET ) {
+        if ( ! ( epicsSocket46IsAF_INETorAF_INET6 ( addr46.sa.sa_family ) ) ) {
             continue;
         }
 
@@ -211,7 +211,7 @@ int main ( int argc, char ** argv )
             if ( cmmd == CA_PROTO_RSRV_IS_UP ) {
                 bool anomaly = false;
                 epicsTime previousTime;
-                struct sockaddr_in ina;
+                osiSockAddr46 addr46;
 
                 /*
                  * this allows a fan-out server to potentially
@@ -227,18 +227,19 @@ int main ( int argc, char ** argv )
                  * field is set to something that isn't INADDR_ANY
                  * then it is the overriding IP address of the server.
                  */
-                ina.sin_family = AF_INET;
-                ina.sin_addr.s_addr = pCurMsg->m_available;
+                memset ( &addr46, 0, sizeof(addr46) );
+                addr46.ia.sin_family = AF_INET;
+                addr46.ia.sin_addr.s_addr = pCurMsg->m_available;
 
                 if ( pCurMsg->m_count != 0 ) {
-                    ina.sin_port = pCurMsg->m_count;
+                    addr46.ia.sin_port = pCurMsg->m_count;
                 }
                 else {
                     /*
                      * old servers don't supply this and the
                      * default port must be assumed
                      */
-                    ina.sin_port = htons ( serverPort );
+                    addr46.ia.sin_port = htons ( serverPort );
                 }
 
                 ca_uint32_t beaconNumber = ntohl ( pCurMsg->m_cid );
@@ -249,7 +250,7 @@ int main ( int argc, char ** argv )
                 /*
                  * look for it in the hash table
                  */
-                bhe *pBHE = beaconTable.lookup ( ina );
+                bhe *pBHE = beaconTable.lookup ( addr46 );
                 if ( pBHE ) {
                     previousTime = pBHE->updateTime ( guard );
                     anomaly = pBHE->updatePeriod (
@@ -265,7 +266,7 @@ int main ( int argc, char ** argv )
                      * shortly after the program started up)
                      */
                     pBHE = new ( bheFreeList )
-                        bhe ( mutex, currentTime, beaconNumber, ina );
+                        bhe ( mutex, currentTime, beaconNumber, addr46 );
                     if ( pBHE ) {
                         if ( beaconTable.add ( *pBHE ) < 0 ) {
                             pBHE->~bhe ();
@@ -278,7 +279,7 @@ int main ( int argc, char ** argv )
                     currentTime.strftime ( date, sizeof ( date ),
                         "%Y-%m-%d %H:%M:%S.%09f");
                     char host[64];
-                    ipAddrToA ( &ina, host, sizeof ( host ) );
+                    ipAddrToA ( &addr46.ia, host, sizeof ( host ) );
                     const char * pPrefix = "";
                     if ( interest > 1 ) {
                         if ( anomaly ) {

--- a/modules/ca/src/client/hostNameCache.cpp
+++ b/modules/ca/src/client/hostNameCache.cpp
@@ -30,7 +30,7 @@
 #include "epicsGuard.h"
 
 hostNameCache::hostNameCache (
-    const osiSockAddr & addr, ipAddrToAsciiEngine & engine ) :
+    const osiSockAddr46 & addr, ipAddrToAsciiEngine & engine ) :
     dnsTransaction ( engine.createTransaction() ), nameLength ( 0 )
 {
     sockAddrToDottedIP ( &addr.sa, hostNameBuf, sizeof ( hostNameBuf ) );
@@ -85,7 +85,7 @@ unsigned hostNameCache::getName (
         }
     }
     else {
-        osiSockAddr tmpAddr = this->dnsTransaction.address ();
+        osiSockAddr46 tmpAddr = this->dnsTransaction.address ();
         return sockAddrToDottedIP ( &tmpAddr.sa, pBuf, bufSize );
     }
 }

--- a/modules/ca/src/client/hostNameCache.h
+++ b/modules/ca/src/client/hostNameCache.h
@@ -31,7 +31,7 @@
 
 class hostNameCache : public ipAddrToAsciiCallBack {
 public:
-    hostNameCache ( const osiSockAddr & addr, ipAddrToAsciiEngine & engine );
+    hostNameCache ( const osiSockAddr46 & addr, ipAddrToAsciiEngine & engine );
     ~hostNameCache ();
     void destroy ();
     void transactionComplete ( const char * pHostName );

--- a/modules/ca/src/client/iocinf.cpp
+++ b/modules/ca/src/client/iocinf.cpp
@@ -35,6 +35,7 @@
 #include "addrList.h"
 #include "iocinf.h"
 
+#include "osiSock.h" /* EPICS_HAS_IPV6, NETDEBUG */
 /*
  * getToken()
  */
@@ -78,8 +79,8 @@ extern "C" int epicsStdCall addAddrToChannelAccessAddressList
     osiSockAddrNode *pNewNode;
     const char *pStr;
     const char *pToken;
-    struct sockaddr_in addr;
-    char buf[32u]; /* large enough to hold an IP address */
+    osiSockAddr46 addr46;
+    char buf[64u]; /* large enough to hold an IP address */
     int status, ret = -1;
 
     pStr = envGetConfigParamPtr (pEnv);
@@ -88,24 +89,38 @@ extern "C" int epicsStdCall addAddrToChannelAccessAddressList
     }
 
     while ( ( pToken = getToken (&pStr, buf, sizeof (buf) ) ) ) {
-        status = aToIPAddr ( pToken, port, &addr );
+      int flags = 0;
+      status = aToIPAddr46 ( pToken, port, &addr46, flags );
         if (status<0) {
             fprintf ( stderr, "%s: Parsing '%s'\n", __FILE__, pEnv->name);
             fprintf ( stderr, "\tBad internet address or host name: '%s'\n", pToken);
             continue;
         }
 
-        if ( ignoreNonDefaultPort && ntohs ( addr.sin_port ) != port ) {
+        if ( ignoreNonDefaultPort && epicsSocket46portFromAddress(&addr46) != port ) {
+#ifdef NETDEBUG
+            char buf[64];
+            sockAddrToDottedIP(&addr46.sa, buf, sizeof(buf));
+            errlogPrintf ("addAddrToChannelAccessAddressList: ignore addr='%s' port=%u\n",
+                          buf, port);
+#endif
             continue;
         }
-
+#ifdef NETDEBUG
+        {
+          char buf[64];
+          sockAddrToDottedIP(&addr46.sa, buf, sizeof(buf));
+          errlogPrintf ("addAddrToChannelAccessAddressList: add addr='%s'\n",
+                        buf );
+        }
+#endif
         pNewNode = (osiSockAddrNode *) calloc (1, sizeof(*pNewNode));
         if (pNewNode==NULL) {
             fprintf ( stderr, "addAddrToChannelAccessAddressList(): no memory available for configuration\n");
             break;
         }
 
-        pNewNode->addr.ia = addr;
+        pNewNode->addr46 = addr46;
 
         /*
          * LOCK applied externally
@@ -130,23 +145,20 @@ extern "C" void epicsStdCall removeDuplicateAddresses
         osiSockAddrNode *pNode = reinterpret_cast <osiSockAddrNode *> ( pRawNode );
         osiSockAddrNode *pTmpNode;
 
-        if ( pNode->addr.sa.sa_family == AF_INET ) {
+        if ( epicsSocket46IsAF_INETorAF_INET6 (pNode->addr46.sa.sa_family ) ) {
 
             pTmpNode = (osiSockAddrNode *) ellFirst (pDestList);
             while ( pTmpNode ) {
-                if (pTmpNode->addr.sa.sa_family == AF_INET) {
-                    if ( pNode->addr.ia.sin_addr.s_addr == pTmpNode->addr.ia.sin_addr.s_addr &&
-                            pNode->addr.ia.sin_port == pTmpNode->addr.ia.sin_port ) {
-                        if ( ! silent ) {
-                            char buf[64];
-                            ipAddrToDottedIP ( &pNode->addr.ia, buf, sizeof (buf) );
-                            fprintf ( stderr,
-                                "Warning: Duplicate EPICS CA Address list entry \"%s\" discarded\n", buf );
-                        }
-                        free (pNode);
-                        pNode = NULL;
-                        break;
+                if ( sockAddrAreIdentical46(&pTmpNode->addr46, &pNode->addr46 ) ) {
+                    if ( ! silent ) {
+                        char buf[64];
+                        sockAddrToDottedIP (&pNode->addr46.sa, buf, sizeof (buf) );
+                        fprintf ( stderr,
+                                  "Warning: Duplicate EPICS CA Address list entry \"%s\" discarded\n", buf );
                     }
+                    free (pNode);
+                    pNode = NULL;
+                    break;
                 }
                 pTmpNode = (osiSockAddrNode *) ellNext (&pTmpNode->node);
             }
@@ -169,8 +181,12 @@ static void  forcePort ( ELLLIST *pList, unsigned short port )
 
     pNode  = ( osiSockAddrNode * ) ellFirst ( pList );
     while ( pNode ) {
-        if ( pNode->addr.sa.sa_family == AF_INET ) {
-            pNode->addr.ia.sin_port = htons ( port );
+        if ( pNode->addr46.sa.sa_family == AF_INET ) {
+            pNode->addr46.ia.sin_port = htons ( port );
+#if EPICS_HAS_IPV6
+        } else if ( pNode->addr46.sa.sa_family == AF_INET6 ) {
+            pNode->addr46.in6.sin6_port = htons ( port );
+#endif
         }
         pNode = ( osiSockAddrNode * ) ellNext ( &pNode->node );
     }
@@ -185,8 +201,8 @@ extern "C" void epicsStdCall configureChannelAccessAddressList
 {
     ELLLIST         tmpList;
     char            *pstr;
-    char            yesno[32u];
-    int             yes;
+    char            addrautolistascii[32u];
+    int             addrautolistIPversion;
 
     /*
      * don't load the list twice
@@ -200,25 +216,59 @@ extern "C" void epicsStdCall configureChannelAccessAddressList
      * initializing the search b-cast list
      * from the interfaces found.
      */
-    yes = true;
+    addrautolistIPversion = 4; /* IPv4 is used when EPICS_CA_AUTO_ADDR_LIST is not defined */
     pstr = envGetConfigParam ( &EPICS_CA_AUTO_ADDR_LIST,
-            sizeof (yesno), yesno );
+                               sizeof (addrautolistascii), addrautolistascii );
     if ( pstr ) {
-        if ( strstr ( pstr, "no" ) || strstr ( pstr, "NO" ) ) {
-            yes = false;
-        }
+      if ( strstr ( pstr, "no" ) || strstr ( pstr, "NO" ) ) {
+        addrautolistIPversion = 0;
+      } else if ( strstr ( pstr, "yes" ) || strstr ( pstr, "YES" ) ) {
+        addrautolistIPversion = 4;
+      } else if ( !strcmp( pstr, "4" ) ) {
+        addrautolistIPversion = 4;
+      } else if ( !strcmp( pstr, "6" ) ) {
+        addrautolistIPversion = 6;
+      } else if ( !strcmp( pstr, "46" ) ) {
+        addrautolistIPversion = 46;
+      } else {
+        errlogPrintf ( "EPICS_CA_AUTO_ADDR_LIST is invalid('%s'); IPv4 is used\n",
+                       pstr);
+      }
     }
+#ifdef NETDEBUG
+    ::printf ("%s/%d: EPICS_CA_AUTO_ADDR_LIST='%s' addrautolistIPversion=%d\n",
+	      __FILE__, __LINE__,
+	      pstr ? pstr : "",
+	      addrautolistIPversion);
+
+#endif
 
     /*
      * LOCK is for piiu->destAddr list
      * (lock outside because this is used by the server also)
      */
-    if (yes) {
+    if (addrautolistIPversion) {
         ELLLIST bcastList;
-        osiSockAddr addr;
+        osiSockAddr46 match46;
         ellInit ( &bcastList );
-        addr.ia.sin_family = AF_UNSPEC;
-        osiSockDiscoverBroadcastAddresses ( &bcastList, sock, &addr );
+        memset(&match46, 0, sizeof(match46));
+        match46.ia.sin_family = AF_INET; /* This is the default */
+#if EPICS_HAS_IPV6
+        if (addrautolistIPversion == 46) {
+          match46.ia.sin_family = AF_UNSPEC; /* Both v6 and v4 */
+        } else if (addrautolistIPversion == 6) {
+          match46.ia.sin_family = AF_INET6; /* v6 only */
+        }
+#endif
+#ifdef NETDEBUG
+        {
+            char buf[64];
+            sockAddrToDottedIP(&match46.sa, buf, sizeof(buf));
+            ::printf ("%s/%d: calling osiSockDiscoverBroadcastAddresses: sock=%d match46='%s'\n",
+                      __FILE__, __LINE__, (int)sock, buf);
+        }
+#endif
+        osiSockDiscoverBroadcastAddresses ( &bcastList, sock, &match46 );
         forcePort ( &bcastList, port );
         removeDuplicateAddresses ( &tmpList, &bcastList, 1 );
         if ( ellCount ( &tmpList ) == 0 ) {
@@ -229,9 +279,9 @@ extern "C" void epicsStdCall configureChannelAccessAddressList
                  * if no interfaces found then look for local channels
                  * with the loop back interface
                  */
-                pNewNode->addr.ia.sin_family = AF_INET;
-                pNewNode->addr.ia.sin_addr.s_addr = htonl ( INADDR_LOOPBACK );
-                pNewNode->addr.ia.sin_port = htons ( port );
+                pNewNode->addr46.ia.sin_family = AF_INET;
+                pNewNode->addr46.ia.sin_addr.s_addr = htonl ( INADDR_LOOPBACK );
+                pNewNode->addr46.ia.sin_port = htons ( port );
                 ellAdd ( &tmpList, &pNewNode->node );
             }
             else {
@@ -256,7 +306,7 @@ extern "C" void epicsStdCall printChannelAccessAddressList ( const ELLLIST *pLis
     pNode = (osiSockAddrNode *) ellFirst ( pList );
     while (pNode) {
         char buf[64];
-        ipAddrToA ( &pNode->addr.ia, buf, sizeof ( buf ) );
+        ipAddrToA ( &pNode->addr46.ia, buf, sizeof ( buf ) );
         ::printf ( "%s\n", buf );
         pNode = (osiSockAddrNode *) ellNext ( &pNode->node );
     }

--- a/modules/ca/src/client/msgForMultiplyDefinedPV.h
+++ b/modules/ca/src/client/msgForMultiplyDefinedPV.h
@@ -47,7 +47,7 @@ public:
         callbackForMultiplyDefinedPV &, const char * pChannelName,
         const char * pAcc );
     virtual ~msgForMultiplyDefinedPV ();
-    void ioInitiate ( const osiSockAddr & rej );
+    void ioInitiate ( const osiSockAddr46 & rej );
     void * operator new ( size_t size, tsFreeList < class msgForMultiplyDefinedPV, 16 > & );
     epicsPlacementDeleteOperator (( void *, tsFreeList < class msgForMultiplyDefinedPV, 16 > & ))
 private:
@@ -61,7 +61,7 @@ private:
     void operator delete ( void * );
 };
 
-inline void msgForMultiplyDefinedPV::ioInitiate ( const osiSockAddr & rej )
+inline void msgForMultiplyDefinedPV::ioInitiate ( const osiSockAddr46 & rej )
 {
     this->dnsTransaction.ipAddrToAscii ( rej, *this );
 }

--- a/modules/ca/src/client/netiiu.cpp
+++ b/modules/ca/src/client/netiiu.cpp
@@ -116,10 +116,10 @@ const char * netiiu::pHostName (
     return pHostNameNetIIU;
 }
 
-osiSockAddr netiiu::getNetworkAddress (
+osiSockAddr46 netiiu::getNetworkAddress (
     epicsGuard < epicsMutex > & ) const
 {
-    osiSockAddr addr;
+    osiSockAddr46 addr;
     addr.sa.sa_family = AF_UNSPEC;
     return addr;
 }

--- a/modules/ca/src/client/netiiu.h
+++ b/modules/ca/src/client/netiiu.h
@@ -31,7 +31,7 @@
 class netWriteNotifyIO;
 class netReadNotifyIO;
 class netSubscription;
-union osiSockAddr;
+union osiSockAddr46;
 class cac;
 class nciu;
 
@@ -80,7 +80,7 @@ public:
         epicsGuard < epicsMutex > & ) = 0;
     virtual void requestRecvProcessPostponedFlush (
         epicsGuard < epicsMutex > & ) = 0;
-    virtual osiSockAddr getNetworkAddress (
+    virtual osiSockAddr46 getNetworkAddress (
         epicsGuard < epicsMutex > & ) const = 0;
     virtual void uninstallChan (
         epicsGuard < epicsMutex > &, nciu & ) = 0;

--- a/modules/ca/src/client/noopiiu.cpp
+++ b/modules/ca/src/client/noopiiu.cpp
@@ -133,7 +133,7 @@ void noopiiu::requestRecvProcessPostponedFlush (
     netiiu::requestRecvProcessPostponedFlush ( guard );
 }
 
-osiSockAddr noopiiu::getNetworkAddress (
+osiSockAddr46 noopiiu::getNetworkAddress (
     epicsGuard < epicsMutex > & guard ) const
 {
     return netiiu::getNetworkAddress ( guard );

--- a/modules/ca/src/client/noopiiu.h
+++ b/modules/ca/src/client/noopiiu.h
@@ -72,7 +72,7 @@ public:
         epicsGuard < epicsMutex > & );
     void requestRecvProcessPostponedFlush (
         epicsGuard < epicsMutex > & );
-    osiSockAddr getNetworkAddress (
+    osiSockAddr46 getNetworkAddress (
         epicsGuard < epicsMutex > & ) const;
     void uninstallChan (
         epicsGuard < epicsMutex > & mutex,

--- a/modules/ca/src/client/oldAccess.h
+++ b/modules/ca/src/client/oldAccess.h
@@ -411,7 +411,7 @@ private:
     caPrintfFunc * pVPrintfFunc;
     CAFDHANDLER * fdRegFunc;
     void * fdRegArg;
-    SOCKET sock;
+    SOCKET sock46;
     unsigned pndRecvCnt;
     unsigned ioSeqNo;
     unsigned callbackThreadsPending;

--- a/modules/ca/src/client/repeater.cpp
+++ b/modules/ca/src/client/repeater.cpp
@@ -543,15 +543,15 @@ void ca_repeater ()
             pNode = (osiSockAddrNode*)ellNext(&pNode->node))
         {
 
-            if(pNode->addr.ia.sin_family==AF_INET) {
-                epicsUInt32 top = ntohl(pNode->addr.ia.sin_addr.s_addr)>>24;
+            if(pNode->addr46.ia.sin_family==AF_INET) {
+                epicsUInt32 top = ntohl(pNode->addr46.ia.sin_addr.s_addr)>>24;
                 if(top>=224 && top<=239) {
 
                     /* This is a multi-cast address */
                     struct ip_mreq mreq;
 
                     memset(&mreq, 0, sizeof(mreq));
-                    mreq.imr_multiaddr = pNode->addr.ia.sin_addr;
+                    mreq.imr_multiaddr = pNode->addr46.ia.sin_addr;
                     mreq.imr_interface.s_addr = INADDR_ANY;
 
                     if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP,
@@ -559,7 +559,7 @@ void ca_repeater ()
                         char name[40];
                         char sockErrBuf[64];
                         epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
-                        ipAddrToDottedIP (&pNode->addr.ia, name, sizeof(name));
+                        ipAddrToDottedIP (&pNode->addr46.ia, name, sizeof(name));
                         errlogPrintf("caR: Socket mcast join to %s failed: %s\n", name, sockErrBuf );
                     }
                 }

--- a/modules/ca/src/client/tcpiiu.cpp
+++ b/modules/ca/src/client/tcpiiu.cpp
@@ -613,9 +613,9 @@ void tcpRecvThread::connect (
         int status;
         {
             epicsGuardRelease < epicsMutex > unguard ( guard );
-            osiSockAddr tmp = this->iiu.address ();
-            status = ::connect ( this->iiu.sock,
-                            & tmp.sa, sizeof ( tmp.sa ) );
+            osiSockAddr46 tmp = this->iiu.address ();
+            status = epicsSocket46Connect ( this->iiu.sock,
+                                        & tmp );
         }
 
         if ( this->iiu.state != tcpiiu::iiucs_connecting ) {
@@ -666,12 +666,12 @@ void tcpRecvThread::connect (
 tcpiiu::tcpiiu (
         cac & cac, epicsMutex & mutexIn, epicsMutex & cbMutexIn,
         cacContextNotify & ctxNotifyIn, double connectionTimeout,
-        epicsTimerQueue & timerQueue, const osiSockAddr & addrIn,
+        epicsTimerQueue & timerQueue, const osiSockAddr46 & addrIn,
         comBufMemoryManager & comBufMemMgrIn,
         unsigned minorVersion, ipAddrToAsciiEngine & engineIn,
         const cacChannel::priLev & priorityIn,
         SearchDestTCP * pSearchDestIn ) :
-    caServerID ( addrIn.ia, priorityIn ),
+    caServerID ( addrIn, priorityIn ),
     hostNameCacheInstance ( addrIn, engineIn ),
     recvThread ( *this, cbMutexIn, ctxNotifyIn, "CAC-TCP-recv",
         epicsThreadGetStackSize ( epicsThreadStackBig ),
@@ -717,7 +717,8 @@ tcpiiu::tcpiiu (
     if(!pCurData)
         throw std::bad_alloc();
 
-    this->sock = epicsSocketCreate ( AF_INET, SOCK_STREAM, IPPROTO_TCP );
+    this->sock = epicsSocket46Create ( epicsSocket46GetDefaultAddressFamily(),
+                                     SOCK_STREAM, IPPROTO_TCP );
     if ( this->sock == INVALID_SOCKET ) {
         freeListFree(this->cacRef.tcpSmallRecvBufFreeList, this->pCurData);
         char sockErrBuf[64];
@@ -1058,7 +1059,7 @@ void tcpiiu::show ( unsigned level ) const
             this->_receiveThreadIsBusy );
     }
     if ( level > 2u ) {
-        ::printf ( "\tvirtual circuit socket identifier %d\n", this->sock );
+        ::printf ( "\tvirtual circuit socket identifier %d\n", (int)this->sock );
         ::printf ( "\tsend thread flush signal:\n" );
         this->sendThreadFlushEvent.show ( level-2u );
         ::printf ( "\tsend thread:\n" );
@@ -1767,7 +1768,7 @@ void tcpiiu::decrementBlockingForFlushCount (
     }
 }
 
-osiSockAddr tcpiiu::getNetworkAddress (
+osiSockAddr46 tcpiiu::getNetworkAddress (
     epicsGuard < epicsMutex > & guard ) const
 {
     guard.assertIdenticalMutex ( this->mutex );
@@ -2134,7 +2135,7 @@ bool tcpiiu::searchMsg (
 }
 
 SearchDestTCP :: SearchDestTCP (
-    cac & cacIn, const osiSockAddr & addrIn ) :
+    cac & cacIn, const osiSockAddr46 & addrIn ) :
     _ptcpiiu ( NULL ),
     _cac ( cacIn ),
     _addr ( addrIn ),
@@ -2198,7 +2199,7 @@ void tcpiiu :: searchRespNotify (
      * the type field is abused to carry the port number
      * so that we can have multiple servers on one host
      */
-    osiSockAddr serverAddr;
+    osiSockAddr46 serverAddr;
     if ( msg.m_cid != INADDR_BROADCAST ) {
         serverAddr.ia.sin_family = AF_INET;
         serverAddr.ia.sin_addr.s_addr = htonl ( msg.m_cid );

--- a/modules/ca/src/client/udpiiu.h
+++ b/modules/ca/src/client/udpiiu.h
@@ -120,15 +120,16 @@ private:
     class SearchDestUDP :
         public SearchDest {
     public:
-        SearchDestUDP ( const osiSockAddr &, udpiiu & );
+        SearchDestUDP ( const osiSockAddr46 &, udpiiu & , SOCKET);
         void searchRequest (
             epicsGuard < epicsMutex > &, const char * pBuf, size_t bufLen );
         void show (
             epicsGuard < epicsMutex > &, unsigned level ) const;
     private:
         int _lastError;
-        osiSockAddr _destAddr;
+        osiSockAddr46 _destAddr;
         udpiiu & _udpiiu;
+        SOCKET _sock46;
     };
     class SearchRespCallback :
         public SearchDest :: Callback {
@@ -136,7 +137,7 @@ private:
         SearchRespCallback ( udpiiu & );
         void notify (
             const caHdr &, const void * pPayload,
-            const osiSockAddr &, const epicsTime & );
+            const osiSockAddr46 &, const epicsTime & );
         void show (
             epicsGuard < epicsMutex > &, unsigned level ) const;
     private:
@@ -185,7 +186,9 @@ private:
     unsigned beaconAnomalyTimerIndex;
     ca_uint32_t sequenceNumber;
     ca_uint32_t lastReceivedSeqNo;
-    SOCKET sock;
+    SOCKET sock4;
+    struct pollfd *pPollFds;
+    unsigned numPollFds;
     ca_uint16_t repeaterPort;
     ca_uint16_t serverPort;
     ca_uint16_t localPort;
@@ -195,7 +198,7 @@ private:
     bool wakeupMsg ();
 
     void postMsg (
-            const osiSockAddr & net_addr,
+            const osiSockAddr46 & net_addr,
             char *pInBuf, arrayElementCount blockSize,
             const epicsTime &currenTime );
 
@@ -205,7 +208,7 @@ private:
 
     typedef bool ( udpiiu::*pProtoStubUDP ) (
         const caHdr &,
-        const osiSockAddr &, const epicsTime & );
+        const osiSockAddr46 &, const epicsTime & );
 
     // UDP protocol dispatch table
     static const pProtoStubUDP udpJumpTableCAC[];
@@ -213,25 +216,25 @@ private:
     // UDP protocol stubs
     bool versionAction (
         const caHdr &,
-        const osiSockAddr &, const epicsTime & );
+        const osiSockAddr46 &, const epicsTime & );
     bool badUDPRespAction (
         const caHdr &msg,
-        const osiSockAddr &netAddr, const epicsTime & );
+        const osiSockAddr46 &netAddr, const epicsTime & );
     bool searchRespAction (
         const caHdr &msg,
-        const osiSockAddr &net_addr, const epicsTime & );
+        const osiSockAddr46 &net_addr, const epicsTime & );
     bool exceptionRespAction (
         const caHdr &msg,
-        const osiSockAddr &net_addr, const epicsTime & );
+        const osiSockAddr46 &net_addr, const epicsTime & );
     bool beaconAction (
         const caHdr &msg,
-        const osiSockAddr &net_addr, const epicsTime & );
+        const osiSockAddr46 &net_addr, const epicsTime & );
     bool notHereRespAction (
         const caHdr &msg,
-        const osiSockAddr &net_addr, const epicsTime & );
+        const osiSockAddr46 &net_addr, const epicsTime & );
     bool repeaterAckAction (
         const caHdr &msg,
-        const osiSockAddr &net_addr, const epicsTime & );
+        const osiSockAddr46 &net_addr, const epicsTime & );
 
     // netiiu stubs
     unsigned getHostName (
@@ -276,7 +279,7 @@ private:
         epicsGuard < epicsMutex > & );
     void requestRecvProcessPostponedFlush (
         epicsGuard < epicsMutex > & );
-        osiSockAddr getNetworkAddress (
+        osiSockAddr46 getNetworkAddress (
         epicsGuard < epicsMutex > & ) const;
     void uninstallChan (
         epicsGuard < epicsMutex > &, nciu & );

--- a/modules/ca/src/client/virtualCircuit.h
+++ b/modules/ca/src/client/virtualCircuit.h
@@ -95,7 +95,7 @@ private:
 
 class SearchDestTCP : public SearchDest {
 public:
-    SearchDestTCP ( cac &, const osiSockAddr & );
+    SearchDestTCP ( cac &, const osiSockAddr46 & );
     void searchRequest ( epicsGuard < epicsMutex > & guard,
          const char * pbuf, size_t len );
     void show ( epicsGuard < epicsMutex > & guard, unsigned level ) const;
@@ -105,7 +105,7 @@ public:
 private:
     tcpiiu * _ptcpiiu;
     cac & _cac;
-    const osiSockAddr _addr;
+    const osiSockAddr46 _addr;
     bool _active;
 };
 
@@ -118,7 +118,7 @@ class tcpiiu :
 public:
     tcpiiu ( cac & cac, epicsMutex & mutualExclusion, epicsMutex & callbackControl,
         cacContextNotify &, double connectionTimeout, epicsTimerQueue & timerQueue,
-        const osiSockAddr & addrIn, comBufMemoryManager &, unsigned minorVersion,
+        const osiSockAddr46 & addrIn, comBufMemoryManager &, unsigned minorVersion,
         ipAddrToAsciiEngine & engineIn, const cacChannel::priLev & priorityIn,
         SearchDestTCP * pSearchDestIn = NULL);
     ~tcpiiu ();
@@ -174,7 +174,7 @@ public:
         epicsGuard < epicsMutex > & ) const;
     bool receiveThreadIsBusy (
         epicsGuard < epicsMutex > & );
-    osiSockAddr getNetworkAddress (
+    osiSockAddr46 getNetworkAddress (
         epicsGuard < epicsMutex > & ) const;
     int printFormated (
         epicsGuard < epicsMutex > & cbGuard,

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -280,7 +280,7 @@ static void log_header (
     struct channel_in_use *pciu;
     char hostName[256];
 
-    ipAddrToDottedIP (&client->addr, hostName, sizeof(hostName));
+    sockAddrToDottedIP (&client->addr46.sa, hostName, sizeof(hostName));
 
     pciu = MPTOPCIU(mp);
 

--- a/modules/database/src/ioc/rsrv/camsgtask.c
+++ b/modules/database/src/ioc/rsrv/camsgtask.c
@@ -147,7 +147,7 @@ void camsgtask ( void *pParm )
             /*
              * disconnect when there are severe message errors
              */
-            ipAddrToDottedIP (&client->addr, buf, sizeof(buf));
+            sockAddrToDottedIP (&client->addr46.sa, buf, sizeof(buf));
             epicsPrintf ("CAS: forcing disconnect from %s\n", buf);
                 break;
         }

--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -48,6 +48,8 @@
 #include "server.h"
 
 epicsThreadPrivateId rsrvCurrentClient;
+static SOCKET        beaconSocket4;
+static rsrv_online_notify_config conf;
 
 /*
  *
@@ -72,22 +74,20 @@ static void req_server (void *pParm)
 
     while (TRUE) {
         SOCKET clientSock;
-        osiSockAddr         sockAddr;
-        osiSocklen_t        addLen = sizeof(sockAddr);
+        osiSockAddr46       sockAddr46;
 
         while (castcp_ctl == ctlPause) {
             epicsThreadSleep(0.1);
         }
 
-        clientSock = epicsSocketAccept ( IOC_sock, &sockAddr.sa, &addLen );
+        clientSock = epicsSocket46Accept ( IOC_sock, &sockAddr46 );
         if ( clientSock == INVALID_SOCKET ||
-             sockAddr.sa.sa_family != AF_INET ||
-             addLen < sizeof(sockAddr.ia) ) {
+             ( !epicsSocket46IsAF_INETorAF_INET6 ( sockAddr46.sa.sa_family ) ) ) {
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
-            errlogPrintf("CAS: Client accept " ERL_ERROR ": %s (%d)\n",
-                sockErrBuf, (int)addLen );
+            errlogPrintf("CAS: Client accept " ERL_ERROR ": %s\n",
+                sockErrBuf );
             epicsThreadSleep(15.0);
             continue;
         }
@@ -96,7 +96,7 @@ static void req_server (void *pParm)
             struct client *pClient;
 
             /* socket passed in is closed if unsuccessful here */
-            pClient = create_tcp_client ( clientSock, &sockAddr );
+            pClient = create_tcp_client ( clientSock, &sockAddr46 );
             if ( ! pClient ) {
                 epicsThreadSleep ( 15.0 );
                 continue;
@@ -123,9 +123,9 @@ static void req_server (void *pParm)
 }
 
 static
-int tryBind(SOCKET sock, const osiSockAddr* addr, const char *name)
+int tryBind(SOCKET sock, const osiSockAddr46* pAddr46, const char *name)
 {
-    if(bind(sock, (struct sockaddr *) &addr->sa, sizeof(*addr))<0) {
+    if(epicsSocket46Bind(sock, pAddr46)<0) {
         char sockErrBuf[64];
         if(SOCKERRNO!=SOCK_EADDRINUSE)
         {
@@ -150,7 +150,7 @@ static
 SOCKET* rsrv_grab_tcp(unsigned short *port)
 {
     SOCKET *socks;
-    osiSockAddr scratch;
+    osiSockAddr46 scratch46;
     unsigned i;
 
     socks = mallocMustSucceed(ellCount(&casIntfAddrList)*sizeof(*socks), "rsrv_grab_tcp");
@@ -158,9 +158,16 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
         socks[i] = INVALID_SOCKET;
 
     /* start with preferred port */
-    memset(&scratch, 0, sizeof(scratch));
-    scratch.ia.sin_family = AF_INET;
-    scratch.ia.sin_port = htons(*port);
+    memset(&scratch46, 0, sizeof(scratch46));
+    scratch46.ia.sin_family = epicsSocket46GetDefaultAddressFamily();
+    scratch46.ia.sin_port = htons(*port);
+#if EPICS_HAS_IPV6
+    /*
+     * the port handling below assumes that the port is on the same
+     * location for both IPv4 and IPv6
+    */
+    assert(&scratch46.in6.sin6_port == &scratch46.ia.sin_port);
+#endif
 
     while(ellCount(&casIntfAddrList)>0) {
         ELLNODE *cur, *next;
@@ -177,18 +184,25 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
              i++, cur=next, next=next ? ellNext(next) : NULL)
         {
             SOCKET tcpsock;
-            osiSockAddr ifaceAddr = ((osiSockAddrNode *)cur)->addr;
+            osiSockAddr46 ifaceAddr = ((osiSockAddrNode *)cur)->addr46;
 
-            scratch.ia.sin_addr = ifaceAddr.ia.sin_addr;
-
-            tcpsock = socks[i] = epicsSocketCreate (AF_INET, SOCK_STREAM, 0);
+#ifdef NETDEBUG
+            {
+                char buf[64];
+                sockAddrToDottedIP(&ifaceAddr.sa, buf, sizeof(buf));
+                epicsPrintf("%s:%d:rsrv_grab_tcp  ifaceAddr='%s'\n",
+                            __FILE__, __LINE__,  buf);
+            }
+#endif
+            tcpsock = socks[i] = epicsSocket46Create (scratch46.ia.sin_family,
+                                                      SOCK_STREAM, 0);
             if(tcpsock==INVALID_SOCKET)
                 cantProceed("rsrv ran out of sockets during initialization");
 
             epicsSocketEnableAddressReuseDuringTimeWaitState ( tcpsock );
 
-            if(bind(tcpsock, &scratch.sa, sizeof(scratch))==0 && listen(tcpsock, 20)==0) {
-                if(scratch.ia.sin_port==0) {
+            if(epicsSocket46Bind(tcpsock, &scratch46)==0 && listen(tcpsock, 20)==0) {
+                if(scratch46.ia.sin_port==0) {
                     /* use first socket to pick a random port */
                     osiSocklen_t alen = sizeof(ifaceAddr);
                     assert(i==0);
@@ -202,8 +216,8 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
                         ok = 0;
                         break;
                     }
-                    scratch.ia.sin_port = ifaceAddr.ia.sin_port;
-                    assert(scratch.ia.sin_port!=0);
+                    scratch46.ia.sin_port = ifaceAddr.ia.sin_port;
+                    assert(scratch46.ia.sin_port!=0);
                 }
             } else {
                 int errcode = SOCKERRNO;
@@ -211,8 +225,8 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
                 if(errcode==SOCK_EADDRNOTAVAIL) {
                     /* this is not a bind()able address. */
                     int j;
-                    char name[40];
-                    ipAddrToDottedIP(&scratch.ia, name, sizeof(name));
+                    char name[64];
+                    sockAddrToDottedIP(&scratch46.sa, name, sizeof(name));
                     printf("Skipping %s which is not an interface address\n", name);
 
                     for(j=0; j<=i; j++) {
@@ -234,7 +248,7 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
                     char sockErrBuf[64];
                     epicsSocketConvertErrnoToString (
                         sockErrBuf, sizeof ( sockErrBuf ) );
-                    ipAddrToDottedIP(&scratch.ia, name, sizeof(name));
+                    sockAddrToDottedIP(&scratch46.sa, name, sizeof(name));
                     cantProceed( "CAS: Socket bind %s error: %s\n",
                         name, sockErrBuf );
                 }
@@ -244,8 +258,8 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
         }
 
         if (ok) {
-            assert(scratch.ia.sin_port!=0);
-            *port = ntohs(scratch.ia.sin_port);
+            assert(scratch46.ia.sin_port!=0);
+            *port = ntohs(scratch46.ia.sin_port);
 
             break;
         } else {
@@ -258,7 +272,7 @@ SOCKET* rsrv_grab_tcp(unsigned short *port)
                 }
             }
 
-            scratch.ia.sin_port=0; /* next iteration starts with a random port */
+            scratch46.ia.sin_port=0; /* next iteration starts with a random port */
         }
     }
 
@@ -279,7 +293,27 @@ void rsrv_build_addr_lists(void)
     assert(ca_beacon_port!=0);
     assert(ca_udp_port!=0);
 
-    envGetBoolConfigParam(&EPICS_CAS_AUTO_BEACON_ADDR_LIST, &autobeaconlist);
+    {
+        char            beaconlistascii[32];
+        char            *pstr;
+        pstr = envGetConfigParam ( &EPICS_CAS_AUTO_BEACON_ADDR_LIST,
+                                   sizeof (beaconlistascii), beaconlistascii );
+        if ( pstr ) {
+            if ( !strcmp( pstr, "4" ) ) {
+                autobeaconlist = 1;
+            } else if ( !strcmp( pstr, "6" ) ) {
+                autobeaconlist = 6;
+            } else if ( !strcmp( pstr, "46" ) ) {
+                autobeaconlist = 46;
+            } else {
+                envGetBoolConfigParam(&EPICS_CAS_AUTO_BEACON_ADDR_LIST, &autobeaconlist);
+            }
+        }
+        epicsPrintf("%s:%d:rsrv_build_addr_lists EPICS_CAS_AUTO_BEACON_ADDR_LIST='%s' autobeaconlist=%d\n",
+                    __FILE__, __LINE__,
+                    pstr ? pstr : "" , autobeaconlist);
+
+    }
 
     ellInit ( &casIntfAddrList );
     ellInit ( &beaconAddrList );
@@ -289,20 +323,21 @@ void rsrv_build_addr_lists(void)
      * Also used for NIC introspection
      */
 
-    beaconSocket = epicsSocketCreate(AF_INET, SOCK_DGRAM, 0);
-    if (beaconSocket==INVALID_SOCKET)
+    // The family must match the address used in rsrv/online_notify.c:88
+    beaconSocket4 = epicsSocket46Create(AF_INET, SOCK_DGRAM, 0);
+    if (beaconSocket4==INVALID_SOCKET)
         cantProceed("socket allocation failed during address list expansion");
 
     {
         int intTrue = 1;
-        if (setsockopt (beaconSocket, SOL_SOCKET, SO_BROADCAST,
+        if (setsockopt (beaconSocket4, SOL_SOCKET, SO_BROADCAST,
                         (char *)&intTrue, sizeof(intTrue))<0) {
             cantProceed("CAS: online socket set up error\n");
         }
 #ifdef IP_ADD_MEMBERSHIP
         {
             osiSockOptMcastLoop_t flag = 1;
-            if (setsockopt(beaconSocket, IPPROTO_IP, IP_MULTICAST_LOOP,
+            if (setsockopt(beaconSocket4, IPPROTO_IP, IP_MULTICAST_LOOP,
                            (char *)&flag, sizeof(flag))<0) {
                 char sockErrBuf[64];
                 epicsSocketConvertErrnoToString (
@@ -320,7 +355,7 @@ void rsrv_build_addr_lists(void)
         if(envGetLongConfigParam(&EPICS_CA_MCAST_TTL, &val))
             val =1;
         ttl = val;
-        if ( setsockopt(beaconSocket, IPPROTO_IP, IP_MULTICAST_TTL, (char*)&ttl, sizeof(ttl))) {
+        if ( setsockopt(beaconSocket4, IPPROTO_IP, IP_MULTICAST_TTL, (char*)&ttl, sizeof(ttl))) {
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
@@ -345,7 +380,7 @@ void rsrv_build_addr_lists(void)
      */
     {
         int foundWildcard = 0, doautobeacon = autobeaconlist;
-
+        /* TODO for IPv6 */
         osiSockAddrNode *pNode, *pNext;
         for(pNode = (osiSockAddrNode*)ellFirst(&casIntfAddrList),
             pNext = pNode ? (osiSockAddrNode*)ellNext(&pNode->node) : NULL;
@@ -353,19 +388,21 @@ void rsrv_build_addr_lists(void)
             pNode = pNext,
             pNext = pNext ? (osiSockAddrNode*)ellNext(&pNext->node) : NULL)
         {
-            osiSockAddr match;
-            epicsUInt32 top = ntohl(pNode->addr.ia.sin_addr.s_addr)>>24;
+            osiSockAddr46 match46;
+            epicsUInt32 top = ntohl(pNode->addr46.ia.sin_addr.s_addr)>>24;
 
-            if(pNode->addr.ia.sin_family==AF_INET && pNode->addr.ia.sin_addr.s_addr==htonl(INADDR_ANY))
+            if(pNode->addr46.ia.sin_family==AF_INET && pNode->addr46.ia.sin_addr.s_addr==htonl(INADDR_ANY))
             {
                 foundWildcard = 1;
 
-            } else if(pNode->addr.ia.sin_family==AF_INET && top>=224 && top<=239) {
+            } else if(pNode->addr46.ia.sin_family==AF_INET && top>=224 && top<=239) {
                 /* This is a multi-cast address */
                 ellDelete(&casIntfAddrList, &pNode->node);
                 ellAdd(&casMCastAddrList, &pNode->node);
                 continue;
             }
+            epicsPrintf("%s:%d:rsrv_build_addr_lists doautobeacon=%d\n",
+                        __FILE__, __LINE__,  doautobeacon);
 
             if(!doautobeacon)
                 continue;
@@ -375,12 +412,28 @@ void rsrv_build_addr_lists(void)
 
             autobeaconlist = 0; /* prevent later population from wildcard */
 
-            memset(&match, 0, sizeof(match));
-            match.ia.sin_family = AF_INET;
-            match.ia.sin_addr.s_addr = pNode->addr.ia.sin_addr.s_addr;
-            match.ia.sin_port = htons(ca_beacon_port);
+            memset(&match46, 0, sizeof(match46));
 
-            osiSockDiscoverBroadcastAddresses(&beaconAddrList, beaconSocket, &match);
+            if(pNode->addr46.ia.sin_family==AF_INET) {
+                match46.ia.sin_family = AF_INET;
+                match46.ia.sin_addr.s_addr = pNode->addr46.ia.sin_addr.s_addr;
+                match46.ia.sin_port = htons(ca_beacon_port);
+            }
+#if EPICS_HAS_IPV6
+            else if(pNode->addr46.ia.sin_family==AF_INET6) {
+                memcpy(&match46, &pNode->addr46, sizeof(match46));
+                match46.in6.sin6_port = htons(ca_beacon_port);
+            }
+#endif
+#ifdef NETDEBUG
+            {
+                char buf[64];
+                sockAddrToDottedIP(&match46.sa, buf, sizeof(buf));
+                epicsPrintf("%s/%d: calling osiSockDiscoverBroadcastAddresses: match46='%s'\n",
+                            __FILE__, __LINE__, buf);
+            }
+#endif
+            osiSockDiscoverBroadcastAddresses(&beaconAddrList, beaconSocket4, &match46);
         }
 
         if (foundWildcard && ellCount(&casIntfAddrList) != 1) {
@@ -391,9 +444,7 @@ void rsrv_build_addr_lists(void)
     if (ellCount(&casIntfAddrList) == 0) {
         /* default to wildcard 0.0.0.0 when interface address list is empty */
         osiSockAddrNode *pNode = (osiSockAddrNode *) callocMustSucceed( 1, sizeof(*pNode), "rsrv_init" );
-        pNode->addr.ia.sin_family = AF_INET;
-        pNode->addr.ia.sin_addr.s_addr = htonl ( INADDR_ANY );
-        pNode->addr.ia.sin_port = 0;
+        pNode->addr46.sa.sa_family = epicsSocket46GetDefaultAddressFamily();
         ellAdd ( &casIntfAddrList, &pNode->node );
     }
 
@@ -408,18 +459,34 @@ void rsrv_build_addr_lists(void)
          */
         addAddrToChannelAccessAddressList ( &temp, &EPICS_CAS_BEACON_ADDR_LIST, ca_beacon_port, 0 );
 
+        epicsPrintf("%s:%d:rsrv_build_addr_lists autobeaconlist=%d\n",
+                    __FILE__, __LINE__,  autobeaconlist);
         if (autobeaconlist) {
             /* auto populate with all broadcast addresses.
              * Note that autobeaconlist is zeroed above if an interface
              * address list is provided.
              */
-            osiSockAddr match;
-            memset(&match, 0, sizeof(match));
-            match.ia.sin_family = AF_INET;
-            match.ia.sin_addr.s_addr = htonl(INADDR_ANY);
-            match.ia.sin_port = htons(ca_beacon_port);
+            osiSockAddr46 match46;
+            memset(&match46, 0, sizeof(match46));
+            match46.ia.sin_family = AF_INET; /* This is the default */
+#if EPICS_HAS_IPV6
+            if (autobeaconlist == 46) {
+                match46.ia.sin_family = AF_UNSPEC; /* Both v6 and v4 */
+            } else if (autobeaconlist == 6) {
+                match46.ia.sin_family = AF_INET6; /* v6 only */
+            }
+#endif
+            match46.ia.sin_port = htons(ca_beacon_port);
 
-            osiSockDiscoverBroadcastAddresses(&temp, beaconSocket, &match);
+#ifdef NETDEBUG
+            {
+                char buf[64];
+                sockAddrToDottedIP(&match46.sa, buf, sizeof(buf));
+                epicsPrintf("%s/%d: calling osiSockDiscoverBroadcastAddresses: match46='%s'\n",
+                            __FILE__, __LINE__, buf);
+            }
+#endif
+            osiSockDiscoverBroadcastAddresses(&temp, beaconSocket4, &match46);
         }
 
         /* set the port for any automatically discovered destinations. */
@@ -427,8 +494,17 @@ void rsrv_build_addr_lists(void)
             pNode;
             pNode = (osiSockAddrNode*)ellNext(&pNode->node))
         {
-            if(pNode->addr.ia.sin_port==0)
-                pNode->addr.ia.sin_port = htons(ca_beacon_port);
+#ifdef NETDEBUG
+            {
+                char buf[64];
+                sockAddrToDottedIP(&pNode->addr46.sa, buf, sizeof(buf));
+                epicsPrintf("%s:%d:rsrv_XXXX addr='%s'\n",
+                            __FILE__, __LINE__,  buf);
+            }
+#endif
+            if(pNode->addr46.ia.sin_port==0) {
+                pNode->addr46.ia.sin_port = htons(ca_beacon_port);
+            }
         }
 
         removeDuplicateAddresses(&beaconAddrList, &temp, 0);
@@ -436,6 +512,29 @@ void rsrv_build_addr_lists(void)
 
     if (ellCount(&beaconAddrList)==0)
         fprintf(stderr, "Warning: RSRV has empty beacon address list\n");
+
+    conf.pSockets = callocMustSucceed( ellCount(&beaconAddrList), sizeof(SOCKET), "rsrv_init" );
+    {
+        ELLNODE *cur;
+        unsigned i;
+
+        /* send beacon to each interface */
+        for(i=0, cur=ellFirst(&beaconAddrList); cur; i++, cur=ellNext(cur))
+        {
+            osiSockAddrNode *pNode = CONTAINER(cur, osiSockAddrNode, node);
+            conf.pSockets[i] = beaconSocket4; /* the default */
+#if EPICS_HAS_IPV6
+            if (pNode->addr46.sa.sa_family == AF_INET6) {
+                SOCKET sock = epicsSocket46Create (AF_INET6, SOCK_DGRAM, 0);
+                if (sock != INVALID_SOCKET) {
+                    unsigned int interfaceIndex = (unsigned int)pNode->addr46.in6.sin6_scope_id;
+                    epicsSocket46optIPv6MultiCast(sock, interfaceIndex);
+                    conf.pSockets[i] = sock;
+                }
+            }
+#endif
+        }
+    }
 
     {
         osiSockAddrNode *node;
@@ -450,14 +549,14 @@ void rsrv_build_addr_lists(void)
          * it is short enough that using a hash table would be slower.
          * 0.0.0.0 indicates end of list
          */
-        casIgnoreAddrs = callocMustSucceed(1+ellCount(&temp2), sizeof(casIgnoreAddrs[0]), "casIgnoreAddrs");
+        casIgnoreAddrs46 = callocMustSucceed(1+ellCount(&temp2), sizeof(casIgnoreAddrs46[0]), "casIgnoreAddrs");
 
         while((node=(osiSockAddrNode*)ellGet(&temp2))!=NULL)
         {
-            casIgnoreAddrs[idx++] = node->addr.ia.sin_addr.s_addr;
+            memcpy(&casIgnoreAddrs46[idx++], &node->addr46, sizeof(casIgnoreAddrs46[idx]));
             free(node);
         }
-        casIgnoreAddrs[idx] = 0;
+        //casIgnoreAddrs46[idx] = 0; This is done by calloc above
     }
 }
 
@@ -599,27 +698,34 @@ void rsrv_init (void)
 
             conf = callocMustSucceed(1, sizeof(*conf), "rsrv_init");
 
-            conf->tcpAddr = ((osiSockAddrNode *)cur)->addr;
-            conf->tcpAddr.ia.sin_port = htons(ca_server_port);
+            conf->tcpAddr46 = ((osiSockAddrNode *)cur)->addr46;
+#if EPICS_HAS_IPV6
+            if ( conf->tcpAddr46.sa.sa_family == AF_INET6 ) {
+                conf->tcpAddr46.in6.sin6_port = htons ( ca_server_port );
+            }
+            else
+#endif
+            {
+                conf->tcpAddr46.ia.sin_port = htons( ca_server_port );
+            }
             conf->tcp = socks[i];
             socks[i] = INVALID_SOCKET;
 
-            ipAddrToDottedIP (&conf->tcpAddr.ia, ifaceName, sizeof(ifaceName));
+            sockAddrToDottedIP (&conf->tcpAddr46.sa, ifaceName, sizeof(ifaceName));
 
             conf->udp = conf->udpbcast = INVALID_SOCKET;
 
             /* create and bind UDP name receiver socket(s) */
 
-            conf->udp = epicsSocketCreate(AF_INET, SOCK_DGRAM, 0);
+            conf->udpAddr46 = conf->tcpAddr46;
+            conf->udp = epicsSocket46Create(epicsSocket46GetDefaultAddressFamily(),
+                                        SOCK_DGRAM, 0);
             if(conf->udp==INVALID_SOCKET)
                 cantProceed("rsrv_init ran out of udp sockets");
 
-            conf->udpAddr = conf->tcpAddr;
-            conf->udpAddr.ia.sin_port = htons(ca_udp_port);
-
             epicsSocketEnableAddressUseForDatagramFanout ( conf->udp );
 
-            if(tryBind(conf->udp, &conf->udpAddr, "UDP unicast socket"))
+            if (epicsSocket46BindLocalPort(conf->udp, ca_server_port))
                 goto cleanup;
 
 #ifdef IP_ADD_MEMBERSHIP
@@ -631,25 +737,27 @@ void rsrv_init (void)
                     pNode;
                     pNode = (osiSockAddrNode*)ellNext(&pNode->node))
                 {
-                    struct ip_mreq mreq;
+                    if (pNode->addr46.sa.sa_family == AF_INET) {
+                        struct ip_mreq mreq;
+                        memset(&mreq, 0, sizeof(mreq));
+                        mreq.imr_multiaddr = pNode->addr46.ia.sin_addr;
+                        mreq.imr_interface.s_addr = conf->udpAddr46.ia.sin_addr.s_addr;
 
-                    memset(&mreq, 0, sizeof(mreq));
-                    mreq.imr_multiaddr = pNode->addr.ia.sin_addr;
-                    mreq.imr_interface.s_addr = conf->udpAddr.ia.sin_addr.s_addr;
-
-                    if (setsockopt(conf->udp, IPPROTO_IP, IP_ADD_MEMBERSHIP,
-                        (char *) &mreq, sizeof(mreq))!=0) {
-                        struct sockaddr_in temp;
-                        char name[40];
-                        char sockErrBuf[64];
-                        temp.sin_family = AF_INET;
-                        temp.sin_addr = mreq.imr_multiaddr;
-                        temp.sin_port = conf->udpAddr.ia.sin_port;
-                        epicsSocketConvertErrnoToString (
-                            sockErrBuf, sizeof ( sockErrBuf ) );
-                        ipAddrToDottedIP (&temp, name, sizeof(name));
-                        errlogPrintf("CAS: Socket mcast join %s to %s failed: %s\n",
-                            ifaceName, name, sockErrBuf );
+                        if (setsockopt(conf->udp, IPPROTO_IP, IP_ADD_MEMBERSHIP,
+                            (char *) &mreq, sizeof(mreq))!=0) {
+                            osiSockAddr46 temp46;
+                            char name[40];
+                            char sockErrBuf[64];
+                            memset(&temp46, 0, sizeof(temp46));
+                            temp46.ia.sin_family = AF_INET;
+                            temp46.ia.sin_addr = mreq.imr_multiaddr;
+                            temp46.ia.sin_port = conf->udpAddr46.ia.sin_port;
+                            epicsSocketConvertErrnoToString (
+                                sockErrBuf, sizeof ( sockErrBuf ) );
+                            sockAddrToDottedIP (&temp46.sa, name, sizeof(name));
+                            errlogPrintf("CAS: Socket mcast join %s to %s failed: %s\n",
+                                ifaceName, name, sockErrBuf );
+                        }
                     }
                 }
             }
@@ -666,33 +774,41 @@ void rsrv_init (void)
              * is to bind a second socket to the interface broadcast address,
              * which will then receive only broadcasts.
              */
-            if(conf->udpAddr.ia.sin_addr.s_addr!=htonl(INADDR_ANY)) {
+            if(conf->udpAddr46.ia.sin_addr.s_addr!=htonl(INADDR_ANY)) {
                 /* find interface broadcast address */
                 ELLLIST bcastList = ELLLIST_INIT;
                 osiSockAddrNode *pNode;
 
+#ifdef NETDEBUG
+                {
+                    char buf[64];
+                    sockAddrToDottedIP(&conf->udpAddr46.sa, buf, sizeof(buf));
+                    epicsPrintf("%s/%d: calling osiSockDiscoverBroadcastAddresses: match46='%s'\n",
+                                __FILE__, __LINE__, buf);
+            }
+#endif
                 osiSockDiscoverBroadcastAddresses (&bcastList,
-                                                   conf->udp, &conf->udpAddr); // match addr
+                                                   conf->udp, &conf->udpAddr46); // match addr
 
                 if(ellCount(&bcastList)==0) {
                     fprintf(stderr, "Warning: Can't find broadcast address of interface %s\n"
                                     "         Name lookup may not work on this interface\n", ifaceName);
                 } else {
-                    if(ellCount(&bcastList)>1 && conf->udpAddr.ia.sin_addr.s_addr!=htonl(INADDR_ANY))
+                    if(ellCount(&bcastList)>1 && conf->udpAddr46.ia.sin_addr.s_addr!=htonl(INADDR_ANY))
                         printf("Interface %s has more than one broadcast address?\n", ifaceName);
 
                     pNode = (osiSockAddrNode*)ellFirst(&bcastList);
 
-                    conf->udpbcast = epicsSocketCreate(AF_INET, SOCK_DGRAM, 0);
+                    conf->udpbcast = epicsSocket46Create(AF_INET, SOCK_DGRAM, 0);
                     if(conf->udpbcast==INVALID_SOCKET)
                         cantProceed("rsrv_init ran out of udp sockets for bcast");
 
                     epicsSocketEnableAddressUseForDatagramFanout ( conf->udpbcast );
 
-                    conf->udpbcastAddr = conf->udpAddr;
-                    conf->udpbcastAddr.ia.sin_addr.s_addr = pNode->addr.ia.sin_addr.s_addr;
+                    conf->udpbcastAddr46 = conf->udpAddr46;
+                    conf->udpbcastAddr46.ia.sin_addr.s_addr = pNode->addr46.ia.sin_addr.s_addr;
 
-                    if(tryBind(conf->udpbcast, &conf->udpbcastAddr, "UDP Socket bcast"))
+                    if(tryBind(conf->udpbcast, &conf->udpbcastAddr46, "UDP Socket bcast"))
                         goto cleanup;
                 }
 
@@ -745,11 +861,11 @@ void rsrv_init (void)
     }
 
     /* servers list is considered read-only from this point */
-
-    epicsThreadMustCreate("CAS-beacon", threadPrios[3],
-            epicsThreadGetStackSize(epicsThreadStackSmall),
-            &rsrv_online_notify_task, NULL);
-
+    {
+        epicsThreadMustCreate("CAS-beacon", threadPrios[3],
+                              epicsThreadGetStackSize(epicsThreadStackSmall),
+                              &rsrv_online_notify_task, &conf);
+    }
     epicsEventMustWait(beacon_startStopEvent);
 }
 
@@ -811,10 +927,10 @@ static void showChanList (
  */
 static void log_one_client (struct client *client, unsigned level)
 {
-    char clientIP[40];
+    char clientIP[64];
     int n;
 
-    ipAddrToDottedIP (&client->addr, clientIP, sizeof(clientIP));
+    sockAddrToDottedIP (&client->addr46.sa, clientIP, sizeof(clientIP));
 
     if ( client->proto == IPPROTO_UDP ) {
         printf ( "\tLast name requested by %s:\n",
@@ -930,12 +1046,12 @@ void casr (unsigned level)
     if (level>=1) {
         rsrv_iface_config *iface = (rsrv_iface_config *) ellFirst ( &servers );
         while (iface) {
-            char    buf[40];
+            char    buf[64];
 
-            ipAddrToDottedIP (&iface->tcpAddr.ia, buf, sizeof(buf));
+            sockAddrToDottedIP (&iface->tcpAddr46.sa, buf, sizeof(buf));
             printf("CAS-TCP server on %s with\n", buf);
 
-            ipAddrToDottedIP (&iface->udpAddr.ia, buf, sizeof(buf));
+            sockAddrToDottedIP (&iface->udpAddr46.sa, buf, sizeof(buf));
 #if defined(_WIN32)
             printf("    CAS-UDP name server on %s\n", buf);
             if (level >= 2)
@@ -950,7 +1066,7 @@ void casr (unsigned level)
                 printf("    CAS-UDP unicast name server on %s\n", buf);
                 if (level >= 2)
                     log_one_client(iface->client, level - 2);
-                ipAddrToDottedIP (&iface->udpbcastAddr.ia, buf, sizeof(buf));
+                sockAddrToDottedIP (&iface->udpbcastAddr46.sa, buf, sizeof(buf));
                 printf("    CAS-UDP broadcast name server on %s\n", buf);
                 if (level >= 2)
                     log_one_client(iface->bclient, level - 2);
@@ -963,7 +1079,7 @@ void casr (unsigned level)
 
     if (level>=1) {
         osiSockAddrNode * pAddr;
-        char buf[40];
+        char buf[64];
         int n = ellCount(&casMCastAddrList);
 
         if (n) {
@@ -973,7 +1089,7 @@ void casr (unsigned level)
                 pAddr;
                 pAddr = (osiSockAddrNode*)ellNext(&pAddr->node))
             {
-                ipAddrToDottedIP (&pAddr->addr.ia, buf, sizeof(buf));
+                sockAddrToDottedIP (&pAddr->addr46.sa, buf, sizeof(buf));
                 printf("    %s\n", buf);
             }
         }
@@ -985,23 +1101,17 @@ void casr (unsigned level)
             pAddr;
             pAddr = (osiSockAddrNode*)ellNext(&pAddr->node))
         {
-            ipAddrToDottedIP (&pAddr->addr.ia, buf, sizeof(buf));
+            sockAddrToDottedIP (&pAddr->addr46.sa, buf, sizeof(buf));
             printf("    %s\n", buf);
         }
 
-        if (casIgnoreAddrs[0]) { /* 0 indicates end of array */
+        if (casIgnoreAddrs46[0].ia.sin_port) { /* port=0 indicates end of array */
             size_t i;
             printf("Ignoring UDP messages from address%s\n",
                    n == 1 ? "" : "es");
-            for(i=0; casIgnoreAddrs[i]; i++)
+            for(i=0; casIgnoreAddrs46[i].ia.sin_port; i++)
             {
-                struct sockaddr_in addr;
-                memset(&addr, 0, sizeof(addr));
-                addr.sin_family = AF_INET;
-                addr.sin_addr.s_addr = casIgnoreAddrs[i];
-                addr.sin_port = 0;
-                ipAddrToDottedIP(&addr, buf, sizeof(buf));
-                printf("    %s\n", buf);
+                epicsSocket46IpOnlyToDotted(&casIgnoreAddrs46[i].sa, buf, sizeof(buf));
             }
         }
     }
@@ -1266,7 +1376,7 @@ struct client * create_client ( SOCKET sock, int proto )
     ellInit ( & client->chanList );
     ellInit ( & client->chanPendingUpdateARList );
     ellInit ( & client->putNotifyQue );
-    memset ( (char *)&client->addr, 0, sizeof (client->addr) );
+    memset ( (char *)&client->addr46, 0, sizeof (client->addr46) );
     client->tid = 0;
 
     if ( proto == IPPROTO_TCP ) {
@@ -1399,7 +1509,7 @@ void casExpandRecvBuffer ( struct client *pClient, ca_uint32_t size )
 /*
  *  create_tcp_client ()
  */
-struct client *create_tcp_client (SOCKET sock , const osiSockAddr *peerAddr)
+struct client *create_tcp_client (SOCKET sock , const osiSockAddr46 *peerAddr46)
 {
     int                     status;
     struct client           *client;
@@ -1412,20 +1522,15 @@ struct client *create_tcp_client (SOCKET sock , const osiSockAddr *peerAddr)
         return NULL;
     }
 
-    client->addr = peerAddr->ia;
+    client->addr46 = *peerAddr46;
     if(asCheckClientIP) {
-        epicsUInt32 ip = ntohl(client->addr.sin_addr.s_addr);
-        client->pHostName = malloc(24);
+        unsigned bufLength = 64;
+        client->pHostName = malloc(bufLength);
         if(!client->pHostName) {
             destroy_client ( client );
             return NULL;
         }
-        epicsSnprintf(client->pHostName, 24,
-                      "%u.%u.%u.%u",
-                      (ip>>24)&0xff,
-                      (ip>>16)&0xff,
-                      (ip>>8)&0xff,
-                      (ip>>0)&0xff);
+        sockAddrToDottedIP(&peerAddr46->sa, client->pHostName, bufLength);
     }
 
     /*
@@ -1517,7 +1622,7 @@ struct client *create_tcp_client (SOCKET sock , const osiSockAddr *peerAddr)
 
     if ( CASDEBUG > 0 ) {
         char buf[64];
-        ipAddrToDottedIP ( &client->addr, buf, sizeof(buf) );
+        sockAddrToDottedIP ( &client->addr46.sa, buf, sizeof(buf) );
         errlogPrintf ( "CAS: conn req from %s\n", buf );
     }
 

--- a/modules/database/src/ioc/rsrv/online_notify.c
+++ b/modules/database/src/ioc/rsrv/online_notify.c
@@ -38,10 +38,12 @@
  */
 void rsrv_online_notify_task(void *pParm)
 {
+    rsrv_online_notify_config   *pConf = pParm;
     double                      delay;
     double                      maxdelay;
     long                        longStatus;
     double                      maxPeriod;
+    SOCKET                      *pSockets = pConf->pSockets;
     caHdr                       msg;
     int                         status;
     ca_uint32_t                 beaconCounter = 0;
@@ -84,16 +86,16 @@ void rsrv_online_notify_task(void *pParm)
         for(i=0, cur=ellFirst(&beaconAddrList); cur; i++, cur=ellNext(cur))
         {
             osiSockAddrNode *pAddr = CONTAINER(cur, osiSockAddrNode, node);
-            status = sendto (beaconSocket, (char *)&msg, sizeof(msg), 0,
-                             &pAddr->addr.sa, sizeof(pAddr->addr));
+            status = epicsSocket46Sendto (pSockets[i], (char *)&msg, sizeof(msg), 0,
+                                          &pAddr->addr46 );
             if (status < 0) {
                 int err = SOCKERRNO;
                 if(err != lastError[i]) {
                     char sockErrBuf[64];
-                    char sockDipBuf[22];
+                    char sockDipBuf[64];
 
                     epicsSocketConvertErrorToString(sockErrBuf, sizeof(sockErrBuf), err);
-                    ipAddrToDottedIP(&pAddr->addr.ia, sockDipBuf, sizeof(sockDipBuf));
+                    sockAddrToDottedIP(&pAddr->addr46.sa, sockDipBuf, sizeof(sockDipBuf));
                     errlogPrintf ( "CAS: CA beacon send to %s " ERL_ERROR ": %s\n",
                         sockDipBuf, sockErrBuf);
 
@@ -103,9 +105,9 @@ void rsrv_online_notify_task(void *pParm)
             else {
                 assert (status == sizeof(msg));
                 if(lastError[i]) {
-                    char sockDipBuf[22];
+                    char sockDipBuf[64];
 
-                    ipAddrToDottedIP(&pAddr->addr.ia, sockDipBuf, sizeof(sockDipBuf));
+                    sockAddrToDottedIP(&pAddr->addr46.sa, sockDipBuf, sizeof(sockDipBuf));
                     errlogPrintf ( "CAS: CA beacon send to %s ok\n",
                         sockDipBuf);
                 }

--- a/modules/database/src/ioc/rsrv/server.h
+++ b/modules/database/src/ioc/rsrv/server.h
@@ -78,7 +78,7 @@ typedef struct client {
   ELLLIST               chanList;
   ELLLIST               chanPendingUpdateARList;
   ELLLIST               putNotifyQue;
-  struct sockaddr_in    addr; /* peer address, TCP only */
+  osiSockAddr46         addr46; /* peer address, TCP only */
   epicsTimeStamp        time_at_last_send;
   epicsTimeStamp        time_at_last_recv;
   void                  *evuser;
@@ -149,14 +149,18 @@ struct event_ext {
 
 typedef struct {
     ELLNODE node;
-    osiSockAddr tcpAddr, /* TCP listener endpoint */
-                udpAddr, /* UDP name unicast receiver endpoint */
-                udpbcastAddr; /* UDP name broadcast receiver endpoint */
+    osiSockAddr46 tcpAddr46, /* TCP listener endpoint */
+                  udpAddr46, /* UDP name unicast receiver endpoint */
+                  udpbcastAddr46; /* UDP name broadcast receiver endpoint */
     SOCKET tcp, udp, udpbcast;
     struct client *client, *bclient;
 
     unsigned int startbcast:1;
 } rsrv_iface_config;
+
+typedef struct {
+    SOCKET *pSockets;
+} rsrv_online_notify_config;
 
 enum ctl {ctlInit, ctlRun, ctlPause, ctlExit};
 
@@ -184,9 +188,8 @@ GLBLTYPE unsigned short     ca_server_port, ca_udp_port, ca_beacon_port;
 GLBLTYPE ELLLIST            clientQ             GLBLTYPE_INIT(ELLLIST_INIT);
 GLBLTYPE ELLLIST            servers; /* rsrv_iface_config::node, read-only after rsrv_init() */
 GLBLTYPE ELLLIST            beaconAddrList;
-GLBLTYPE SOCKET             beaconSocket;
 GLBLTYPE ELLLIST            casIntfAddrList, casMCastAddrList;
-GLBLTYPE epicsUInt32        *casIgnoreAddrs;
+GLBLTYPE osiSockAddr46      *casIgnoreAddrs46;
 GLBLTYPE epicsMutexId       clientQlock;
 GLBLTYPE BUCKET             *pCaBucket; /* locked by clientQlock */
 GLBLTYPE void               *rsrvClientFreeList;
@@ -226,7 +229,7 @@ void rsrv_online_notify_task (void *);
 void cast_server (void *);
 struct client *create_client ( SOCKET sock, int proto );
 void destroy_client ( struct client * );
-struct client *create_tcp_client ( SOCKET sock, const osiSockAddr* peerAddr );
+struct client *create_tcp_client ( SOCKET sock, const osiSockAddr46* peerAddr );
 void destroy_tcp_client ( struct client * );
 void casAttachThreadToClient ( struct client * );
 int camessage ( struct client *client );

--- a/modules/libcom/src/env/envDefs.h
+++ b/modules/libcom/src/env/envDefs.h
@@ -35,6 +35,7 @@ extern "C" {
 #endif
 
 #include "libComAPI.h"
+#include "osiSock.h"
 
 /**
  * \brief A structure to hold a single environment parameter
@@ -135,7 +136,7 @@ LIBCOM_API long epicsStdCall
  * \return 0, or -1 if an error is encountered
  */
 LIBCOM_API long epicsStdCall
-    envGetInetAddrConfigParam(const ENV_PARAM *pParam, struct in_addr *pAddr);
+    envGetInetAddrConfigParam46(const ENV_PARAM *pParam, osiSockAddr46 *pAddr46);
 
 /**
  * \brief Get value of a double configuration parameter.

--- a/modules/libcom/src/env/envSubr.c
+++ b/modules/libcom/src/env/envSubr.c
@@ -243,23 +243,24 @@ double  *pDouble        /* O pointer to place to store value */
 *       }
 *
 *-*/
-long epicsStdCall envGetInetAddrConfigParam(
+long epicsStdCall envGetInetAddrConfigParam46(
 const ENV_PARAM *pParam,/* I pointer to config param structure */
-struct in_addr *pAddr   /* O pointer to struct to receive inet addr */
+osiSockAddr46   *pAddr46/* O pointer to struct to receive inet addr */
 )
 {
     char        text[128];
     char        *ptext;
     long        status;
-    struct sockaddr_in sin;
+    osiSockAddr46 addr46;
 
     ptext = envGetConfigParam(pParam, sizeof text, text);
     if (ptext) {
-                status = aToIPAddr (text, 0u, &sin);
-                if (status == 0) {
-                        *pAddr = sin.sin_addr;
-                        return 0;
-                }
+        int flags = 0;
+        status = aToIPAddr46 (text, 0u, &addr46, flags);
+        if (status == 0) {
+            *pAddr46 = addr46;
+            return 0;
+        }
         (void)fprintf(stderr,"Unable to find an IP address or valid host name in %s=%s\n",
                                                 pParam->name, text);
     }

--- a/modules/libcom/src/log/iocLog.c
+++ b/modules/libcom/src/log/iocLog.c
@@ -33,7 +33,7 @@ static logClientId iocLogClient;
  *  getConfig()
  *  Get Server Configuration
  */
-static int getConfig (struct in_addr *pserver_addr, unsigned short *pserver_port)
+static int getConfig (osiSockAddr46 *pserver_addr46, unsigned short *pserver_port)
 {
     long status;
     long epics_port;
@@ -54,7 +54,7 @@ static int getConfig (struct in_addr *pserver_addr, unsigned short *pserver_port
     }
     *pserver_port = (unsigned short) epics_port;
 
-    status = envGetInetAddrConfigParam (&EPICS_IOC_LOG_INET, pserver_addr);
+    status = envGetInetAddrConfigParam46 (&EPICS_IOC_LOG_INET, pserver_addr46);
     if (status<0) {
         fprintf (stderr,
             "iocLog: EPICS environment variable \"%s\" undefined\n",
@@ -100,14 +100,14 @@ static logClientId iocLogClientInit (void)
 {
     int status;
     logClientId id;
-    struct in_addr addr;
+    osiSockAddr46 addr46;
     unsigned short port;
 
-    status = getConfig (&addr, &port);
+    status = getConfig (&addr46, &port);
     if (status) {
         return NULL;
     }
-    id = logClientCreate (addr, port);
+    id = logClientCreate46 (&addr46, port);
     if (id != NULL) {
         errlogAddListener (logClientSendMessage, id);
         epicsAtExit (iocLogClientDestroy, id);

--- a/modules/libcom/src/log/logClient.h
+++ b/modules/libcom/src/log/logClient.h
@@ -28,8 +28,8 @@ extern "C" {
 #endif
 
 typedef void *logClientId;
-LIBCOM_API logClientId epicsStdCall logClientCreate (
-    struct in_addr server_addr, unsigned short server_port);
+LIBCOM_API logClientId epicsStdCall logClientCreate46 (
+    osiSockAddr46 *pAddr46, unsigned short server_port);
 LIBCOM_API void epicsStdCall logClientSend (logClientId id, const char *message);
 LIBCOM_API void epicsStdCall logClientShow (logClientId id, unsigned level);
 LIBCOM_API void epicsStdCall logClientFlush (logClientId id);

--- a/modules/libcom/src/misc/aToIPAddr.c
+++ b/modules/libcom/src/misc/aToIPAddr.c
@@ -17,6 +17,8 @@
 
 #include "epicsTypes.h"
 #include "osiSock.h"
+#include "epicsStdio.h"
+#include "errlog.h"
 
 #ifndef NELEMENTS
 #define NELEMENTS(A) (sizeof(A)/sizeof(A[0]))
@@ -193,5 +195,138 @@ aToIPAddr( const char *pAddrString, unsigned short defaultPort,
         }
     }
 
+    return -1;
+}
+
+
+/*
+ * rational replacement for inet_addr()
+ * which allows the limited broadcast address
+ * 255.255.255.255, allows the user
+ * to specify a port number, and allows also a
+ * named host to be specified.
+ *
+ * Sets the port number to "defaultPort" only if
+ * "pAddrString" does not contain an address of the form
+ * "n.n.n.n:p or host:p or [IPv6]:p"
+ */
+LIBCOM_API int epicsStdCall aToIPAddr46(const char *pAddrString,
+                                        unsigned short defaultPort,
+                                        osiSockAddr46 *pAddr46,
+                                        int flags)
+{
+    if (pAddrString == NULL) {
+        return -1;
+    }
+#ifdef NETDEBUG
+    epicsPrintf("%s:%d: aToIPAddr46 pAddrString='%s' defaultPort=%u flags=0x%x\n",
+                __FILE__, __LINE__,
+                pAddrString, defaultPort, flags);
+#endif
+    if (*pAddrString != '[') {
+        /* IPv4 */
+        int status;
+        memset ( pAddr46, 0, sizeof(*pAddr46) ) ;
+        pAddr46->sa.sa_family = AF_INET;
+        status = aToIPAddr( pAddrString, defaultPort, &pAddr46->ia);
+#ifdef NETDEBUG
+        {
+            char buf[64];
+            sockAddrToDottedIP(&pAddr46->sa, buf, sizeof(buf));
+            epicsPrintf("%s:%d: aToIPAddr46 pAddrString='%s' status=%d addr46='%s'\n",
+                        __FILE__, __LINE__,
+                        pAddrString, status, buf);
+                }
+#endif
+        return status;
+    }
+#if EPICS_HAS_IPV6
+    else
+    {
+        char hostName[512];
+        char portAscii[8];
+        char *pPort = NULL;
+        struct addrinfo hints;
+        struct addrinfo *ai, *ai_to_free;
+        osiSocklen_t socklen = 0;
+        int gai;
+        epicsSnprintf(portAscii, sizeof(portAscii), "%u", defaultPort);
+        memset(pAddr46, 0, sizeof(*pAddr46));
+        strncpy(hostName, pAddrString, sizeof(hostName) - 1);
+        hostName[sizeof(hostName) - 1] = '\0';
+        char *pClosingBracket = strchr(hostName, ']');
+        if (pClosingBracket) {
+            *pClosingBracket = '\0';
+            memmove(hostName, &hostName[1], sizeof(hostName) - 1);
+            /* now pClosingBracket may pint to a ':', if any */
+            if (*pClosingBracket == ':') {
+                pPort = pClosingBracket + 1;
+                *pClosingBracket = '\0';
+            }
+        }
+        if (!strlen(hostName) && pPort) {
+            errlogPrintf("%s:%d: aToIPAddr46 invalid, probably missing []. pAddrString='%s' hostname='' pPort='%s'\n",
+                     __FILE__, __LINE__, pAddrString, pPort ? pPort : "");
+            return -1;
+        }
+#ifdef NETDEBUG
+        epicsPrintf("%s:%d: aToIPAddr46 hostName='%s' pPort='%s' portAscii='%s'\n",
+                    __FILE__, __LINE__,
+                    hostName, pPort ? pPort : "NULL", portAscii);
+#endif
+        /* After the printout, set pPort to a valid value */
+        if (!pPort) pPort = portAscii;
+#ifdef NETDEBUG
+        epicsPrintf("%s:%d: aToIPAddr46 hostName='%s' pPort='%s'\n",
+                __FILE__, __LINE__,
+                hostName, pPort ? pPort : "NULL");
+#endif
+        /* we could find both IPv4 and Ipv6 addresses, but see below */
+        memset(&hints, 0, sizeof(hints));
+
+        if (sizeof(*pAddr46) < sizeof(struct sockaddr_in6)) {
+            hints.ai_socktype = AF_INET;
+            hints.ai_family = AF_INET;
+        } else if (flags & EPICSSOCKET_CONNECT_IPV4) {
+            hints.ai_family = AF_INET;
+        } else if (flags & EPICSSOCKET_CONNECT_IPV6) {
+            hints.ai_family = AF_INET6;
+        }
+        gai = getaddrinfo(hostName, pPort, &hints, &ai);
+        if (gai) {
+#ifdef NETDEBUG
+          errlogPrintf("%s:%d: unable to look up pAddrString '%s' '%s:%s' (%s)\n",
+                         __FILE__, __LINE__,
+                       pAddrString, hostName, pPort,
+                         gai_strerror(gai));
+#endif
+          return -1;
+        }
+        for (ai_to_free = ai; ai; ai = ai->ai_next) {
+            socklen = ai->ai_addrlen;
+            if (socklen <= sizeof(*pAddr46)) {
+                memcpy(pAddr46, ai->ai_addr, socklen);
+#ifdef NETDEBUG
+                {
+                    char buf[128];
+                    sockAddrToDottedIP(&pAddr46->sa, buf, sizeof(buf));
+                    epicsPrintf("%s:%d: aToIPAddr46 pAddrString='%s' res=%s socklen=%u\n",
+                                __FILE__, __LINE__,
+                                pAddrString, buf, (unsigned)socklen);
+                }
+#endif
+                freeaddrinfo(ai_to_free);
+                return socklen;
+            } else {
+                char buf[64];
+                sockAddrToDottedIP(&pAddr46->sa, buf, sizeof(buf));
+                epicsPrintf("%s:%d: aToIPAddr46 pAddrString='%s' osiSockAddr46 too short %u/%u ignore add='%s'\n",
+                             __FILE__, __LINE__,
+                             pAddrString, (unsigned)sizeof(*pAddr46), socklen, buf);
+            }
+        }
+        freeaddrinfo(ai_to_free);
+    }
+#endif
     return -1;
 }

--- a/modules/libcom/src/misc/ipAddrToAsciiAsynchronous.cpp
+++ b/modules/libcom/src/misc/ipAddrToAsciiAsynchronous.cpp
@@ -41,17 +41,17 @@ class ipAddrToAsciiTransactionPrivate :
 public:
     ipAddrToAsciiTransactionPrivate ( class ipAddrToAsciiEnginePrivate & engineIn );
     virtual ~ipAddrToAsciiTransactionPrivate ();
-    osiSockAddr address () const;
+    osiSockAddr46 address () const;
     void show ( unsigned level ) const;
     void * operator new ( size_t size, tsFreeList
         < ipAddrToAsciiTransactionPrivate, 0x80 > & );
     epicsPlacementDeleteOperator (( void *, tsFreeList
         < ipAddrToAsciiTransactionPrivate, 0x80 > & ))
-    osiSockAddr addr;
+    osiSockAddr46 addr;
     ipAddrToAsciiEnginePrivate & engine;
     ipAddrToAsciiCallBack * pCB;
     bool pending;
-    void ipAddrToAscii ( const osiSockAddr &, ipAddrToAsciiCallBack & );
+    void ipAddrToAscii ( const osiSockAddr46 &, ipAddrToAsciiCallBack & );
     void release ();
     void operator delete ( void * );
 private:
@@ -308,7 +308,7 @@ void ipAddrToAsciiGlobal::run ()
             if ( ! pItem ) {
                 break;
             }
-            osiSockAddr addr = pItem->addr;
+            osiSockAddr46 addr = pItem->addr;
             this->pCurrent = pItem;
 
             if ( this->exitFlag )
@@ -418,7 +418,7 @@ ipAddrToAsciiTransactionPrivate::~ipAddrToAsciiTransactionPrivate ()
 }
 
 void ipAddrToAsciiTransactionPrivate::ipAddrToAscii (
-    const osiSockAddr & addrIn, ipAddrToAsciiCallBack & cbIn )
+    const osiSockAddr46 & addrIn, ipAddrToAsciiCallBack & cbIn )
 {
     bool success;
     ipAddrToAsciiGlobal *pGlobal = this->engine.pEngine;
@@ -454,7 +454,7 @@ void ipAddrToAsciiTransactionPrivate::ipAddrToAscii (
     }
 }
 
-osiSockAddr ipAddrToAsciiTransactionPrivate::address () const
+osiSockAddr46 ipAddrToAsciiTransactionPrivate::address () const
 {
     return this->addr;
 }

--- a/modules/libcom/src/misc/ipAddrToAsciiAsynchronous.h
+++ b/modules/libcom/src/misc/ipAddrToAsciiAsynchronous.h
@@ -29,8 +29,8 @@ public:
 class LIBCOM_API ipAddrToAsciiTransaction {
 public:
     virtual void release () = 0;
-    virtual void ipAddrToAscii ( const osiSockAddr &, ipAddrToAsciiCallBack & ) = 0;
-    virtual osiSockAddr address () const  = 0;
+    virtual void ipAddrToAscii ( const osiSockAddr46 &, ipAddrToAsciiCallBack & ) = 0;
+    virtual osiSockAddr46 address () const  = 0;
     virtual void show ( unsigned level ) const = 0;
 protected:
     virtual ~ipAddrToAsciiTransaction () = 0;

--- a/modules/libcom/src/osi/os/WIN32/osdNetIntf.c
+++ b/modules/libcom/src/osi/os/WIN32/osdNetIntf.c
@@ -40,16 +40,160 @@
 #include "epicsThread.h"
 #include "epicsVersion.h"
 
-static osiSockAddr      osiLocalAddrResult;
+#ifdef NETDEBUG
+#   define ifDepenDebugPrintf(argsInParen) printf argsInParen
+#else
+#   define ifDepenDebugPrintf(argsInParen)
+#endif
+
+static osiSockAddr46     osiLocalAddrResult;
 static epicsThreadOnceId osiLocalAddrId = EPICS_THREAD_ONCE_INIT;
 
 /*
- * osiLocalAddr ()
+ * osiSockDiscoverBroadcastAddresses ()
  */
-static void osiLocalAddrOnce ( void *raw )
+LIBCOM_API void epicsStdCall osiSockDiscoverBroadcastAddresses
+     (ELLLIST *pList, SOCKET socket, const osiSockAddr46 *pMatchAddr46)
+{
+    int                 status;
+    INTERFACE_INFO      *pIfinfo;
+    INTERFACE_INFO      *pIfinfoList;
+    unsigned            nelem;
+    int                 numifs;
+    DWORD               cbBytesReturned;
+    osiSockAddrNode     *pNewNode;
+
+#ifdef NETDEBUG
+    const static char* fname = "osiSockDiscoverBroadcastAddresses()";
+#endif
+    if ( pMatchAddr46->sa.sa_family == AF_INET  ) {
+        if ( pMatchAddr46->ia.sin_addr.s_addr == htonl (INADDR_LOOPBACK) ) {
+            pNewNode = (osiSockAddrNode *) calloc (1, sizeof (*pNewNode) );
+            if ( pNewNode == NULL ) {
+                return;
+            }
+            pNewNode->addr46.ia.sin_family = AF_INET;
+            pNewNode->addr46.ia.sin_port = htons ( 0 );
+            pNewNode->addr46.ia.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+            ellAdd ( pList, &pNewNode->node );
+            return;
+        }
+    }
+
+    /* only valid for winsock 2 and above */
+    if (wsaMajorVersion() < 2 ) {
+        fprintf(stderr, "Need to set EPICS_CA_AUTO_ADDR_LIST=NO for winsock 1\n");
+        return;
+    }
+
+    nelem = 100;
+    pIfinfoList = (INTERFACE_INFO *) calloc(nelem, sizeof(INTERFACE_INFO));
+    if(!pIfinfoList){
+        return;
+    }
+
+    status = WSAIoctl (socket, SIO_GET_INTERFACE_LIST,
+                       NULL, 0,
+                       (LPVOID)pIfinfoList, nelem*sizeof(INTERFACE_INFO),
+                       &cbBytesReturned, NULL, NULL);
+
+    if (status != 0 || cbBytesReturned == 0) {
+        fprintf(stderr, "WSAIoctl SIO_GET_INTERFACE_LIST failed %d\n",WSAGetLastError());
+        free(pIfinfoList);
+        return;
+    }
+
+    numifs = cbBytesReturned/sizeof(INTERFACE_INFO);
+    for (pIfinfo = pIfinfoList; pIfinfo < (pIfinfoList+numifs); pIfinfo++){
+
+#ifdef NETDEBUG
+        const struct sockaddr *pSockAddr = (struct sockaddr *) &pIfinfo->iiAddress.Address;
+	const char *if_name = "";
+        {
+            char buf[64];
+            epicsSocket46IpOnlyToDotted(pSockAddr, buf, sizeof(buf));
+            ifDepenDebugPrintf (("%s %s:%d: interface %s has addr '%s'\n",
+                                 fname, __FILE__, __LINE__,
+                                 if_name, buf));
+        }
+#endif
+        /*
+         * don't bother with interfaces that have been disabled
+         */
+        if (!(pIfinfo->iiFlags & IFF_UP)) {
+            continue;
+        }
+
+        if (pIfinfo->iiFlags & IFF_LOOPBACK) {
+            continue;
+        }
+
+        /*
+         * work around WS2 bug
+         */
+        if (pIfinfo->iiAddress.Address.sa_family != AF_INET) {
+            if (pIfinfo->iiAddress.Address.sa_family == 0) {
+                pIfinfo->iiAddress.Address.sa_family = AF_INET;
+            }
+        }
+
+        /*
+         * if it isn't a wildcarded interface then look for
+         * an exact match
+         */
+        if (pMatchAddr46->sa.sa_family != AF_UNSPEC) {
+            if (pIfinfo->iiAddress.Address.sa_family != pMatchAddr46->sa.sa_family) {
+                continue;
+            }
+            if (pIfinfo->iiAddress.Address.sa_family != AF_INET) {
+                continue;
+            }
+            if (pMatchAddr46->sa.sa_family != AF_INET) {
+                continue;
+            }
+            if (pMatchAddr46->ia.sin_addr.s_addr != htonl(INADDR_ANY)) {
+                if (pIfinfo->iiAddress.AddressIn.sin_addr.s_addr != pMatchAddr46->ia.sin_addr.s_addr) {
+                    continue;
+                }
+            }
+        }
+
+        pNewNode = (osiSockAddrNode *) calloc (1, sizeof(*pNewNode));
+        if (pNewNode==NULL) {
+            errlogPrintf ("osiSockDiscoverBroadcastAddresses(): no memory available for configuration\n");
+            return;
+        }
+
+        if (pIfinfo->iiAddress.Address.sa_family == AF_INET &&
+                pIfinfo->iiFlags & IFF_BROADCAST) {
+            const unsigned mask = pIfinfo->iiNetmask.AddressIn.sin_addr.s_addr;
+            const unsigned bcast = pIfinfo->iiBroadcastAddress.AddressIn.sin_addr.s_addr;
+            const unsigned addr = pIfinfo->iiAddress.AddressIn.sin_addr.s_addr;
+            unsigned result = (addr & mask) | (bcast &~mask);
+            pNewNode->addr46.ia.sin_family = AF_INET;
+            pNewNode->addr46.ia.sin_addr.s_addr = result;
+            pNewNode->addr46.ia.sin_port = htons ( 0 );
+        }
+        else {
+            pNewNode->addr46.sa = pIfinfo->iiBroadcastAddress.Address;
+        }
+
+        /*
+         * LOCK applied externally
+         */
+        ellAdd (pList, &pNewNode->node);
+    }
+
+    free (pIfinfoList);
+}
+
+/*
+ * osiLocalAddrOnce ()
+ */
+static void osiLocalAddrOnce (void *raw)
 {
     SOCKET              *psocket = raw;
-    osiSockAddr         addr;
+    osiSockAddr46       addr46;
     int                 status;
     INTERFACE_INFO      *pIfinfo;
     INTERFACE_INFO      *pIfinfoList = NULL;
@@ -57,8 +201,8 @@ static void osiLocalAddrOnce ( void *raw )
     DWORD               numifs;
     DWORD               cbBytesReturned;
 
-    memset ( (void *) &addr, '\0', sizeof ( addr ) );
-    addr.sa.sa_family = AF_UNSPEC;
+    memset ( (void *) &addr46, '\0', sizeof ( addr46 ) );
+    addr46.sa.sa_family = AF_UNSPEC;
 
     /* only valid for winsock 2 and above */
     if ( wsaMajorVersion() < 2 ) {
@@ -98,14 +242,14 @@ static void osiLocalAddrOnce ( void *raw )
             continue;
         }
 
-        addr.sa = pIfinfo->iiAddress.Address;
+        addr46.sa = pIfinfo->iiAddress.Address;
 
         /* Work around MS Winsock2 bugs */
-        if (addr.sa.sa_family == 0) {
-            addr.sa.sa_family = AF_INET;
+        if (addr46.sa.sa_family == 0) {
+            addr46.sa.sa_family = AF_INET;
         }
 
-        osiLocalAddrResult = addr;
+        osiLocalAddrResult = addr46;
         free ( pIfinfoList );
         return;
     }
@@ -114,140 +258,18 @@ static void osiLocalAddrOnce ( void *raw )
                 "osiLocalAddr(): only loopback found\n");
 fail:
     /* fallback to loopback */
-    memset ( (void *) &addr, '\0', sizeof ( addr ) );
-    addr.ia.sin_family = AF_INET;
-    addr.ia.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    osiLocalAddrResult = addr;
+    memset ( (void *) &addr46, '\0', sizeof ( addr46 ) );
+    addr46.ia.sin_family = AF_INET;
+    addr46.ia.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    osiLocalAddrResult = addr46;
 
     free ( pIfinfoList );
 }
 
-LIBCOM_API osiSockAddr epicsStdCall osiLocalAddr (SOCKET socket)
+
+LIBCOM_API osiSockAddr46 epicsStdCall osiLocalAddr (SOCKET socket)
 {
     epicsThreadOnce(&osiLocalAddrId, osiLocalAddrOnce, (void*)&socket);
     return osiLocalAddrResult;
 }
 
-/*
- * osiSockDiscoverBroadcastAddresses ()
- */
-LIBCOM_API void epicsStdCall osiSockDiscoverBroadcastAddresses
-     (ELLLIST *pList, SOCKET socket, const osiSockAddr *pMatchAddr)
-{
-    int                 status;
-    INTERFACE_INFO      *pIfinfo;
-    INTERFACE_INFO      *pIfinfoList;
-    unsigned            nelem;
-    int                 numifs;
-    DWORD               cbBytesReturned;
-    osiSockAddrNode     *pNewNode;
-
-    if ( pMatchAddr->sa.sa_family == AF_INET  ) {
-        if ( pMatchAddr->ia.sin_addr.s_addr == htonl (INADDR_LOOPBACK) ) {
-            pNewNode = (osiSockAddrNode *) calloc (1, sizeof (*pNewNode) );
-            if ( pNewNode == NULL ) {
-                return;
-            }
-            pNewNode->addr.ia.sin_family = AF_INET;
-            pNewNode->addr.ia.sin_port = htons ( 0 );
-            pNewNode->addr.ia.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
-            ellAdd ( pList, &pNewNode->node );
-            return;
-        }
-    }
-
-    /* only valid for winsock 2 and above */
-    if (wsaMajorVersion() < 2 ) {
-        fprintf(stderr, "Need to set EPICS_CA_AUTO_ADDR_LIST=NO for winsock 1\n");
-        return;
-    }
-
-    nelem = 100;
-    pIfinfoList = (INTERFACE_INFO *) calloc(nelem, sizeof(INTERFACE_INFO));
-    if(!pIfinfoList){
-        return;
-    }
-
-    status = WSAIoctl (socket, SIO_GET_INTERFACE_LIST,
-                       NULL, 0,
-                       (LPVOID)pIfinfoList, nelem*sizeof(INTERFACE_INFO),
-                       &cbBytesReturned, NULL, NULL);
-
-    if (status != 0 || cbBytesReturned == 0) {
-        fprintf(stderr, "WSAIoctl SIO_GET_INTERFACE_LIST failed %d\n",WSAGetLastError());
-        free(pIfinfoList);
-        return;
-    }
-
-    numifs = cbBytesReturned/sizeof(INTERFACE_INFO);
-    for (pIfinfo = pIfinfoList; pIfinfo < (pIfinfoList+numifs); pIfinfo++){
-
-        /*
-         * don't bother with interfaces that have been disabled
-         */
-        if (!(pIfinfo->iiFlags & IFF_UP)) {
-            continue;
-        }
-
-        if (pIfinfo->iiFlags & IFF_LOOPBACK) {
-            continue;
-        }
-
-        /*
-         * work around WS2 bug
-         */
-        if (pIfinfo->iiAddress.Address.sa_family != AF_INET) {
-            if (pIfinfo->iiAddress.Address.sa_family == 0) {
-                pIfinfo->iiAddress.Address.sa_family = AF_INET;
-            }
-        }
-
-        /*
-         * if it isn't a wildcarded interface then look for
-         * an exact match
-         */
-        if (pMatchAddr->sa.sa_family != AF_UNSPEC) {
-            if (pIfinfo->iiAddress.Address.sa_family != pMatchAddr->sa.sa_family) {
-                continue;
-            }
-            if (pIfinfo->iiAddress.Address.sa_family != AF_INET) {
-                continue;
-            }
-            if (pMatchAddr->sa.sa_family != AF_INET) {
-                continue;
-            }
-            if (pMatchAddr->ia.sin_addr.s_addr != htonl(INADDR_ANY)) {
-                if (pIfinfo->iiAddress.AddressIn.sin_addr.s_addr != pMatchAddr->ia.sin_addr.s_addr) {
-                    continue;
-                }
-            }
-        }
-
-        pNewNode = (osiSockAddrNode *) calloc (1, sizeof(*pNewNode));
-        if (pNewNode==NULL) {
-            errlogPrintf ("osiSockDiscoverBroadcastAddresses(): no memory available for configuration\n");
-            return;
-        }
-
-        if (pIfinfo->iiAddress.Address.sa_family == AF_INET &&
-                pIfinfo->iiFlags & IFF_BROADCAST) {
-            const unsigned mask = pIfinfo->iiNetmask.AddressIn.sin_addr.s_addr;
-            const unsigned bcast = pIfinfo->iiBroadcastAddress.AddressIn.sin_addr.s_addr;
-            const unsigned addr = pIfinfo->iiAddress.AddressIn.sin_addr.s_addr;
-            unsigned result = (addr & mask) | (bcast &~mask);
-            pNewNode->addr.ia.sin_family = AF_INET;
-            pNewNode->addr.ia.sin_addr.s_addr = result;
-            pNewNode->addr.ia.sin_port = htons ( 0 );
-        }
-        else {
-            pNewNode->addr.sa = pIfinfo->iiBroadcastAddress.Address;
-        }
-
-        /*
-         * LOCK applied externally
-         */
-        ellAdd (pList, &pNewNode->node);
-    }
-
-    free (pIfinfoList);
-}

--- a/modules/libcom/src/osi/osdNetIfAddrs.c
+++ b/modules/libcom/src/osi/osdNetIfAddrs.c
@@ -21,34 +21,126 @@
 #include "errlog.h"
 #include "epicsThread.h"
 
-#ifdef DEBUG
+#ifdef NETDEBUG
 #   define ifDepenDebugPrintf(argsInParen) printf argsInParen
 #else
 #   define ifDepenDebugPrintf(argsInParen)
 #endif
 
-static osiSockAddr      osiLocalAddrResult;
+static osiSockAddr46     osiLocalAddrResult;
 static epicsThreadOnceId osiLocalAddrId = EPICS_THREAD_ONCE_INIT;
+
+
+
+static int matchMatchAddress(const osiSockAddr46 *pAddrToMatch46,
+                             const osiSockAddr46 *pAddr46)
+{
+    int match_ret = 0;
+#ifdef NETDEBUG
+    char buf1[64];
+    char buf2[64];
+    const static char* fname = "osiSockDiscoverBroadcastAddresses()";
+    epicsSocket46IpOnlyToDotted(&pAddrToMatch46->sa, buf1, sizeof(buf1));
+    epicsSocket46IpOnlyToDotted(&pAddr46->sa, buf2, sizeof(buf2));
+#endif
+    if ( ( pAddrToMatch46->sa.sa_family == AF_INET ) &&
+         ( pAddr46->sa.sa_family == AF_INET ) ) {
+        if ( pAddrToMatch46->ia.sin_addr.s_addr == htonl (INADDR_ANY) ) {
+            /* INADDR_ANY will match all interfaces/addresses */
+            match_ret = 1;
+        } else {
+            const struct sockaddr_in *pInetAddr = &pAddr46->ia;
+            if ( pInetAddr->sin_addr.s_addr == pAddrToMatch46->ia.sin_addr.s_addr ) {
+                match_ret = 1;
+            } else {
+                ifDepenDebugPrintf ( ("%s %s:%d: '%s did not match '%s'\n",
+                                      fname, __FILE__, __LINE__,
+                                      buf1, buf2) );
+            }
+        }
+    }
+#if EPICS_HAS_IPV6
+    else if ( ( pAddrToMatch46->sa.sa_family == AF_INET6 ) &&
+              ( pAddr46->sa.sa_family == AF_INET6 ) ) {
+        if ( !memcmp(&pAddrToMatch46->in6.sin6_addr, &in6addr_any, sizeof(in6addr_any)) ) {
+            /*
+             * in6addr_any will match all interfaces/addresses
+             * TODO, may be:  match scope_id */
+            match_ret = 1;
+        } else {
+            const struct sockaddr_in6 *pInetAddr6 = &pAddrToMatch46->in6;
+            if (memcmp(&pAddrToMatch46->in6.sin6_addr,
+                        &pInetAddr6->sin6_addr,
+                        sizeof(pInetAddr6->sin6_addr) ) ) {
+                match_ret = 1;
+            } else {
+                ifDepenDebugPrintf ( ("%s %s:%d: '%s did not match '%s'\n",
+                                      fname, __FILE__, __LINE__,
+                                      buf1, buf2 ) );
+            }
+        }
+    }
+#endif
+    return match_ret;
+}
+
+static int copyRemoteAddressOK(osiSockAddrNode *pNewNode,
+                               osiSockAddr46 *pRemoteAddr46,
+                               const char* broadOrDstName)
+{
+    char buf[64];
+    int ret_ok = 0;
+#ifdef NETDEBUG
+    const static char* fname = "osiSockDiscoverBroadcastAddresses()";
+#endif
+    if  ( ! pRemoteAddr46 ) {
+        snprintf ( buf, sizeof(buf), "%s", "<NULL>" );
+    } else if ( ( pRemoteAddr46->sa.sa_family == AF_INET ) &&
+                ( pRemoteAddr46->ia.sin_addr.s_addr != INADDR_ANY ) ) {
+        pNewNode->addr46.ia = pRemoteAddr46->ia; /* struct copy */
+        ret_ok = 1;
+    }
+#if EPICS_HAS_IPV6
+    else if ( ( pRemoteAddr46 ) && ( pRemoteAddr46->sa.sa_family == AF_INET6 ) ) {
+        pNewNode->addr46.in6 = pRemoteAddr46->in6;  /* struct copy */
+        ret_ok = 1;
+    }
+#endif
+#ifdef NETDEBUG
+    {
+        if (pRemoteAddr46) {
+            epicsSocket46IpOnlyToDotted(&pRemoteAddr46->sa, buf, sizeof(buf));
+        }
+        ifDepenDebugPrintf (("%s %s:%d:  %s='%s' ret_ok=%d\n",
+                             fname, __FILE__, __LINE__,
+                             broadOrDstName, buf, ret_ok));
+    }
+#endif
+    return ret_ok;
+}
+
 
 /*
  * osiSockDiscoverBroadcastAddresses ()
  */
 LIBCOM_API void epicsStdCall osiSockDiscoverBroadcastAddresses
-     (ELLLIST *pList, SOCKET socket, const osiSockAddr *pMatchAddr)
+     (ELLLIST *pList, SOCKET socket, const osiSockAddr46 *pMatchAddr46)
 {
     osiSockAddrNode *pNewNode;
     struct ifaddrs *ifa;
-
-    if ( pMatchAddr->sa.sa_family == AF_INET  ) {
-        if ( pMatchAddr->ia.sin_addr.s_addr == htonl (INADDR_LOOPBACK) ) {
+#ifdef NETDEBUG
+    const static char* fname = "osiSockDiscoverBroadcastAddresses()";
+#endif
+    if ( pMatchAddr46->sa.sa_family == AF_INET  ) {
+        if ( pMatchAddr46->ia.sin_addr.s_addr == htonl (INADDR_LOOPBACK) ) {
             pNewNode = (osiSockAddrNode *) calloc (1, sizeof (*pNewNode) );
             if ( pNewNode == NULL ) {
                 errlogPrintf ( "osiSockDiscoverBroadcastAddresses(): no memory available for configuration\n" );
                 return;
             }
-            pNewNode->addr.ia.sin_family = AF_INET;
-            pNewNode->addr.ia.sin_port = htons ( 0 );
-            pNewNode->addr.ia.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
+            pNewNode->addr46.ia.sin_family = AF_INET;
+            pNewNode->addr46.ia.sin_port = htons ( 0 );
+            pNewNode->addr46.ia.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
             ellAdd ( pList, &pNewNode->node );
             return;
         }
@@ -66,39 +158,72 @@ LIBCOM_API void epicsStdCall osiSockDiscoverBroadcastAddresses
               continue;
         }
 
-        ifDepenDebugPrintf (("osiSockDiscoverBroadcastAddresses(): found IFACE: %s\n",
-            ifa->ifa_name));
-
         /*
          * If its not an internet interface then don't use it
          */
-        if ( ifa->ifa_addr->sa_family != AF_INET ) {
-             ifDepenDebugPrintf ( ("osiSockDiscoverBroadcastAddresses(): interface \"%s\" was not AF_INET\n", ifa->ifa_name) );
+        if ( ! ( epicsSocket46IsAF_INETorAF_INET6 ( ifa->ifa_addr->sa_family ) ) ) {
+#if 0
+             ifDepenDebugPrintf ( ("%s %s:%d: interface \"%s\" was not AF_INET(6)\n",
+                                   fname, __FILE__, __LINE__,
+                                   ifa->ifa_name) );
+#endif
              continue;
         }
+        ifDepenDebugPrintf (("%s %s:%d: found IFACE: %s flags=0x%08x family=%d%s%s interfaceIndex=%u\n",
+                             fname, __FILE__, __LINE__,
+                             ifa->ifa_name, ifa->ifa_flags, ifa->ifa_addr->sa_family,
+                             ifa->ifa_addr->sa_family == AF_INET ? " (AF_INET)" : "",
+                             ifa->ifa_addr->sa_family == AF_INET6 ? " (AF_INET6)" : "",
+                             if_nametoindex (ifa->ifa_name)));
 
+#ifdef NETDEBUG
+        {
+            const struct sockaddr *pSockAddr = (struct sockaddr *) ifa->ifa_addr;
+            char buf[64];
+            epicsSocket46IpOnlyToDotted(pSockAddr, buf, sizeof(buf));
+            ifDepenDebugPrintf (("%s %s:%d: interface  \"%s\" has addr '%s'\n",
+                                 fname, __FILE__, __LINE__,
+                                 ifa->ifa_name, buf));
+        }
+#endif
         /*
          * if it isn't a wildcarded interface then look for
          * an exact match
          */
-        if ( pMatchAddr->sa.sa_family != AF_UNSPEC ) {
-            if ( pMatchAddr->sa.sa_family != AF_INET ) {
+        if ( pMatchAddr46->sa.sa_family != AF_UNSPEC ) {
+            osiSockAddr46 addr46;
+            int match_ok = 0;
+            memset(&addr46, 0, sizeof(addr46));
+            if (ifa->ifa_addr->sa_family == AF_INET) {
+                 struct sockaddr_in *pInetAddr = (struct sockaddr_in *) ifa->ifa_addr;
+                 addr46.ia = *pInetAddr;
+                 match_ok = matchMatchAddress(pMatchAddr46, &addr46);
+            }
+#if EPICS_HAS_IPV6
+            else if (ifa->ifa_addr->sa_family == AF_INET6) {
+                struct sockaddr_in6 *pInetAddr6 = (struct sockaddr_in6 *) ifa->ifa_addr;
+                addr46.in6 = *pInetAddr6;
+                /* TB: Need to verify, if this is OK */
+                addr46.in6.sin6_scope_id = if_nametoindex (ifa->ifa_name);
+                match_ok = matchMatchAddress(pMatchAddr46, &addr46);
+            }
+#endif
+            if (!match_ok) {
+                ifDepenDebugPrintf ( ("%s %s:%d: net intf \"%s\" did not match\n",
+                                      fname, __FILE__, __LINE__,
+                                      ifa->ifa_name) );
                 continue;
             }
-            if ( pMatchAddr->ia.sin_addr.s_addr != htonl (INADDR_ANY) ) {
-                 struct sockaddr_in *pInetAddr = (struct sockaddr_in *) ifa->ifa_addr;
-                 if ( pInetAddr->sin_addr.s_addr != pMatchAddr->ia.sin_addr.s_addr ) {
-                     ifDepenDebugPrintf ( ("osiSockDiscoverBroadcastAddresses(): net intf \"%s\" didnt match\n", ifa->ifa_name) );
-                     continue;
-                 }
-            }
+
         }
 
         /*
          * don't bother with interfaces that have been disabled
          */
         if ( ! ( ifa->ifa_flags & IFF_UP ) ) {
-             ifDepenDebugPrintf ( ("osiSockDiscoverBroadcastAddresses(): net intf \"%s\" was down\n", ifa->ifa_name) );
+             ifDepenDebugPrintf ( ("%s %s:%d: net intf \"%s\" was down\n",
+                                   fname, __FILE__, __LINE__,
+                                   ifa->ifa_name) );
              continue;
         }
 
@@ -106,7 +231,9 @@ LIBCOM_API void epicsStdCall osiSockDiscoverBroadcastAddresses
          * don't use the loop back interface
          */
         if ( ifa->ifa_flags & IFF_LOOPBACK ) {
-             ifDepenDebugPrintf ( ("osiSockDiscoverBroadcastAddresses(): ignoring loopback interface: \"%s\"\n", ifa->ifa_name) );
+             ifDepenDebugPrintf ( ("%s %s:%d: ignoring loopback interface: \"%s\"\n",
+                                   fname, __FILE__, __LINE__,
+                                   ifa->ifa_name) );
              continue;
         }
 
@@ -116,7 +243,7 @@ LIBCOM_API void epicsStdCall osiSockDiscoverBroadcastAddresses
             freeifaddrs ( ifaddr );
             return;
         }
-
+        pNewNode->interfaceIndex = if_nametoindex (ifa->ifa_name);
         /*
          * If this is an interface that supports
          * broadcast use the broadcast address.
@@ -128,30 +255,65 @@ LIBCOM_API void epicsStdCall osiSockDiscoverBroadcastAddresses
          * interface.
          */
         if ( ifa->ifa_flags & IFF_BROADCAST ) {
-            osiSockAddr baddr;
-            baddr.sa = *ifa->ifa_broadaddr;
-            if (baddr.ia.sin_family==AF_INET && baddr.ia.sin_addr.s_addr != INADDR_ANY) {
-                pNewNode->addr.sa = *ifa->ifa_broadaddr;
-                ifDepenDebugPrintf ( ( "found broadcast addr = %08x\n", ntohl ( baddr.ia.sin_addr.s_addr ) ) );
-            } else {
-                ifDepenDebugPrintf ( ( "Ignoring broadcast addr = %08x\n", ntohl ( baddr.ia.sin_addr.s_addr ) ) );
-                free ( pNewNode );
-                continue;
+            if ( ifa->ifa_addr->sa_family == AF_INET )  {
+                if (!copyRemoteAddressOK(pNewNode,
+                                         (osiSockAddr46 *)ifa->ifa_broadaddr,
+                                         "broadcastaddr") ) {
+                  free ( pNewNode );
+                  pNewNode = NULL;
+                }
             }
+#if EPICS_HAS_IPV6
+            else if ( ifa->ifa_addr->sa_family == AF_INET6 )  {
+              /*
+               * IPv6 has no broadcast, even if IFF_BROADCAST is set
+               * we need to use multicast
+               */
+                osiSockAddr46 addrMulticast46;
+                if (epicsSocket46addr6toMulticastOK((osiSockAddr46 *)ifa->ifa_addr,
+                                                    &addrMulticast46)) {
+                    pNewNode->addr46 = addrMulticast46; /* struct copy */
+                    pNewNode->addr46.in6.sin6_scope_id = pNewNode->interfaceIndex;
+                    pNewNode->addr46.sa.sa_family = ifa->ifa_addr->sa_family;
+                } else {
+                  free ( pNewNode );
+                  pNewNode = NULL;
+                }
+            }
+#endif
         }
 #if defined (IFF_POINTOPOINT)
-        else if ( ifa->ifa_flags & IFF_POINTOPOINT ) {
-            pNewNode->addr.sa = *ifa->ifa_dstaddr;
+        else if ( ifa->ifa_flags & IFF_POINTOPOINT )  {
+          /*
+           * It is point-to-point, ifa->ifa_dstaddr is != NULL and
+           * the family is valid
+           */
+          if (!copyRemoteAddressOK(pNewNode,
+                                   (osiSockAddr46 *)ifa->ifa_dstaddr,
+                                   "POINTOPOINTdestaddr") ) {
+                free ( pNewNode );
+                pNewNode = NULL;
+            }
         }
 #endif
         else {
-            ifDepenDebugPrintf ( ( "osiSockDiscoverBroadcastAddresses(): net intf \"%s\": not point to point or bcast?\n", ifa->ifa_name ) );
             free ( pNewNode );
-            continue;
+            pNewNode = NULL;
         }
-
-        ifDepenDebugPrintf ( ("osiSockDiscoverBroadcastAddresses(): net intf \"%s\" found\n", ifa->ifa_name) );
-
+        if ( pNewNode == NULL ) {
+            ifDepenDebugPrintf ( ( "%s %s:%d: IFACE '%s': ignored, no point to point or bcast?\n",
+                                   fname, __FILE__, __LINE__,
+                                   ifa->ifa_name ) );
+            continue;
+        } else {
+            const struct sockaddr *pSockAddr = &pNewNode->addr46.sa;
+            char buf[64];
+            epicsSocket46IpOnlyToDotted(pSockAddr, buf, sizeof(buf));
+            ifDepenDebugPrintf (("%s %s:%d: IFACE '%s': added to list, family=%d interfaceIndex=%u addr='%s'\n",
+                                 fname, __FILE__, __LINE__,
+                                 ifa->ifa_name, ifa->ifa_addr->sa_family,
+                                 pNewNode->interfaceIndex, buf));
+        }
         /*
          * LOCK applied externally
          */
@@ -179,12 +341,8 @@ static void osiLocalAddrOnce (void *raw)
         }
 
         if ( ! ( ifa->ifa_flags & IFF_UP ) ) {
-            ifDepenDebugPrintf ( ("osiLocalAddrOnce(): net intf %s was down\n", ifa->ifa_name) );
-            continue;
-        }
-
-        if ( ifa->ifa_addr->sa_family != AF_INET ) {
-            ifDepenDebugPrintf ( ("osiLocalAddrOnce(): interface %s was not AF_INET\n", ifa->ifa_name) );
+            ifDepenDebugPrintf ( ("osiLocalAddrOnce(): net intf %s was down\n",
+                                  ifa->ifa_name) );
             continue;
         }
 
@@ -192,7 +350,14 @@ static void osiLocalAddrOnce (void *raw)
          * don't use the loop back interface
          */
         if ( ifa->ifa_flags & IFF_LOOPBACK ) {
-            ifDepenDebugPrintf ( ("osiLocalAddrOnce(): ignoring loopback interface: %s\n", ifa->ifa_name) );
+            ifDepenDebugPrintf ( ("osiLocalAddrOnce(): ignoring loopback interface: '%s' family=%d\n",
+                                  ifa->ifa_name, ifa->ifa_addr->sa_family) );
+            continue;
+        }
+
+        if ( ! ( epicsSocket46IsAF_INETorAF_INET6 ( ifa->ifa_addr->sa_family ) ) ) {
+            ifDepenDebugPrintf ( ("osiLocalAddrOnce(): interface \"%s\" was not AF_INET/AF_INET6 (%d/%d) but %d\n",
+                                  ifa->ifa_name, AF_INET, AF_INET6, ifa->ifa_addr->sa_family) );
             continue;
         }
 
@@ -206,7 +371,7 @@ static void osiLocalAddrOnce (void *raw)
     errlogPrintf (
         "osiLocalAddr(): only loopback found\n");
     /* fallback to loopback */
-    osiSockAddr addr;
+    osiSockAddr46 addr;
     memset ( (void *) &addr, '\0', sizeof ( addr ) );
     addr.ia.sin_family = AF_INET;
     addr.ia.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
@@ -216,7 +381,7 @@ static void osiLocalAddrOnce (void *raw)
 }
 
 
-LIBCOM_API osiSockAddr epicsStdCall osiLocalAddr (SOCKET socket)
+LIBCOM_API osiSockAddr46 epicsStdCall osiLocalAddr (SOCKET socket)
 {
     epicsThreadOnce(&osiLocalAddrId, osiLocalAddrOnce, &socket);
     return osiLocalAddrResult;

--- a/modules/libcom/src/osi/osiSock.c
+++ b/modules/libcom/src/osi/osiSock.c
@@ -20,12 +20,48 @@
 #include "epicsAssert.h"
 #include "epicsSignal.h"
 #include "epicsStdio.h"
+#include "errlog.h"
 #include "osiSock.h"
+
+#if EPICS_HAS_IPV6
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#endif
 
 #define nDigitsDottedIP 4u
 #define chunkSize 8u
 
 #define makeMask(NBITS) ( ( 1u << ( (unsigned) NBITS) ) - 1u )
+
+
+static void osiSockIPv4toIPv6(const osiSockAddr46 *pAddr46Input,
+                              osiSockAddr46 *pAddr46Output)
+{
+#if EPICS_HAS_IPV6
+    if (pAddr46Input->sa.sa_family == AF_INET) {
+        const struct sockaddr_in * paddrInput4 = (const struct sockaddr_in *) pAddr46Input;
+        struct sockaddr_in6 *pOut6 = (struct sockaddr_in6 *)pAddr46Output;
+
+        unsigned int ipv4addr = htonl ( paddrInput4->sin_addr.s_addr );
+        /* RFC3493: IPv4-mapped IPv6 address from RFC 2373 */
+        memset(pAddr46Output, 0, sizeof(*pAddr46Output));
+        pOut6->sin6_addr.s6_addr[10] = 0xFF;
+        pOut6->sin6_addr.s6_addr[11] = 0xFF;
+        pOut6->sin6_addr.s6_addr[12] = (ipv4addr >> 24) & 0xFF;
+        pOut6->sin6_addr.s6_addr[13] = (ipv4addr >> 16) & 0xFF;
+        pOut6->sin6_addr.s6_addr[14] = (ipv4addr >>  8) & 0xFF;
+        pOut6->sin6_addr.s6_addr[15] = ipv4addr & 0xFF;
+        pOut6->sin6_family = AF_INET6;
+        pOut6->sin6_port = paddrInput4->sin_port;
+    }
+    else
+#endif
+    {
+        memcpy(pAddr46Output, pAddr46Input, sizeof(*pAddr46Output));
+    }
+}
+
 
 /*
  * sockAddrAreIdentical()
@@ -64,10 +100,25 @@ unsigned epicsStdCall sockAddrToA (
     if ( bufSize < 1 ) {
         return 0;
     }
-
+#if EPICS_HAS_IPV6
+    if ( paddr->sa_family == AF_INET6 ) {
+        unsigned ret;
+        int gai_ecode = getnameinfo(paddr, sizeof(struct sockaddr_in6), pBuf, bufSize,
+                                    NULL, 0,  NI_NAMEREQD);
+        if (!gai_ecode) {
+            return (unsigned)strlen(pBuf);
+        }
+        ret = sockAddrToDottedIP ( paddr, pBuf, bufSize );
+#ifdef NETDEBUG
+        fprintf (stdout,  "getnameinfo(%s) failed: %s\n",
+                      pBuf, gai_strerror(gai_ecode) );
+#endif
+        return ret;
+    } else
+#endif
     if ( paddr->sa_family != AF_INET ) {
         static const char * pErrStr = "<Ukn Addr Type>";
-        unsigned len = strlen ( pErrStr );
+        unsigned len = ( unsigned ) strlen ( pErrStr );
         if ( len < bufSize ) {
             strcpy ( pBuf, pErrStr );
             return len;
@@ -118,9 +169,13 @@ unsigned epicsStdCall ipAddrToA (
 unsigned epicsStdCall sockAddrToDottedIP ( 
     const struct sockaddr * paddr, char * pBuf, unsigned bufSize )
 {
-    if ( paddr->sa_family != AF_INET ) {
+    if ( ( paddr->sa_family != AF_INET )
+#if EPICS_HAS_IPV6
+         && ( paddr->sa_family != AF_INET6 )
+#endif
+                                              )  {
         const char * pErrStr = "<Ukn Addr Type>";
-        unsigned errStrLen = strlen ( pErrStr );
+        unsigned errStrLen = ( unsigned ) strlen ( pErrStr );
         if ( errStrLen < bufSize ) {
             strcpy ( pBuf, pErrStr );
             return errStrLen;
@@ -142,39 +197,107 @@ unsigned epicsStdCall sockAddrToDottedIP (
  * ipAddrToDottedIP ()
  */
 unsigned epicsStdCall ipAddrToDottedIP ( 
-    const struct sockaddr_in *paddr, char *pBuf, unsigned bufSize )
+    const struct sockaddr_in *pAddr, char *pBuf, unsigned bufSize )
 {
     static const char * pErrStr = "<IPA>";
-    unsigned chunk[nDigitsDottedIP];
-    unsigned addr = ntohl ( paddr->sin_addr.s_addr );
     unsigned strLen;
     unsigned i;
-    int status;
+    int status = 0;
 
     if ( bufSize == 0u ) {
         return 0u;
     }
 
-    for ( i = 0; i < nDigitsDottedIP; i++ ) {
-        chunk[i] = addr & makeMask ( chunkSize );
-        addr >>= chunkSize;
-    }
+    *pBuf = '\0';
+    if (pAddr->sin_family == AF_INET) {
+        unsigned chunk[nDigitsDottedIP];
+        unsigned addr = ntohl ( pAddr->sin_addr.s_addr );
+        for ( i = 0; i < nDigitsDottedIP; i++ ) {
+            chunk[i] = addr & makeMask ( chunkSize );
+            addr >>= chunkSize;
+        }
 
-    /*
-     * inet_ntoa() isn't used because it isn't thread safe
-     * (and the replacements are not standardized)
-     */
-    status = epicsSnprintf (
-                pBuf, bufSize, "%u.%u.%u.%u:%hu",
-                chunk[3], chunk[2], chunk[1], chunk[0],
-                ntohs ( paddr->sin_port ) );
+        /*
+         * inet_ntoa() isnt used because it isnt thread safe
+         * (and the replacements are not standardized)
+         */
+        status = epicsSnprintf (
+                                pBuf, bufSize, "%u.%u.%u.%u:%hu",
+                                chunk[3], chunk[2], chunk[1], chunk[0],
+                                ntohs ( pAddr->sin_port ) );
+#if EPICS_HAS_IPV6
+    } else if (pAddr->sin_family == AF_INET6) {
+        struct sockaddr_in6 *pAddr6 = (struct sockaddr_in6 *)pAddr;
+        if (IN6_IS_ADDR_V4MAPPED(&pAddr6->sin6_addr)) {
+            /* https://datatracker.ietf.org/doc/html/rfc5156 */
+            status = epicsSnprintf(pBuf, bufSize, "::FFFF:%u.%u.%u.%u:%hu",
+                                   pAddr6->sin6_addr.s6_addr[12],
+                                   pAddr6->sin6_addr.s6_addr[13],
+                                   pAddr6->sin6_addr.s6_addr[14],
+                                   pAddr6->sin6_addr.s6_addr[15],
+                                   ntohs(pAddr6->sin6_port));
+        } else {
+#ifdef IF_NAMESIZE
+            char if_name_or_number[IF_NAMESIZE];
+            if ( ! if_indextoname((unsigned int)pAddr6->sin6_scope_id, &if_name_or_number[0]) ) {
+#else
+            char if_name_or_number[16];
+            {
+#endif
+                snprintf(if_name_or_number, sizeof(if_name_or_number),
+                         "%u", (unsigned int)pAddr6->sin6_scope_id);
+            }
+            status = epicsSnprintf (pBuf, bufSize,
+                                    "[%x:%x:%x:%x:%x:%x:%x:%x%%%s]:%hu",
+                                    (pAddr6->sin6_addr.s6_addr[0] << 8) +
+                                    pAddr6->sin6_addr.s6_addr[1],
+                                    (pAddr6->sin6_addr.s6_addr[2] << 8) +
+                                    pAddr6->sin6_addr.s6_addr[3],
+                                    (pAddr6->sin6_addr.s6_addr[4] << 8) +
+                                    pAddr6->sin6_addr.s6_addr[5],
+                                    (pAddr6->sin6_addr.s6_addr[6] << 8) +
+                                    pAddr6->sin6_addr.s6_addr[7],
+                                    (pAddr6->sin6_addr.s6_addr[8] << 8) +
+                                    pAddr6->sin6_addr.s6_addr[9],
+                                    (pAddr6->sin6_addr.s6_addr[10] << 8) +
+                                    pAddr6->sin6_addr.s6_addr[11],
+                                    (pAddr6->sin6_addr.s6_addr[12] << 8) +
+                                    pAddr6->sin6_addr.s6_addr[13],
+                                    (pAddr6->sin6_addr.s6_addr[14] << 8) +
+                                    pAddr6->sin6_addr.s6_addr[15],
+                                    if_name_or_number,
+                                    ntohs(pAddr6->sin6_port));
+        }
+    } else {
+        /*
+         *  This is for debugging only, assuming a struct defined in
+         *  https://datatracker.ietf.org/doc/html/rfc3493
+         *  2 fam, 2 port, 4 flowinfo, 16 Ipv6, 4 scope 
+         */
+        unsigned char *pRawBytes =(unsigned char *)pAddr;
+        status = epicsSnprintf(pBuf, bufSize, "%02x%02x %02x%02x %02x%02x%02x%02x %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+                               pRawBytes[0],  pRawBytes[1],
+                               pRawBytes[2],  pRawBytes[3],
+                               pRawBytes[4],  pRawBytes[5],
+                               pRawBytes[6],  pRawBytes[7],
+                               pRawBytes[8],  pRawBytes[9],
+                               pRawBytes[10], pRawBytes[11],
+                               pRawBytes[12], pRawBytes[13],
+                               pRawBytes[14], pRawBytes[15],
+                               pRawBytes[16], pRawBytes[17],
+                               pRawBytes[18], pRawBytes[19],
+                               pRawBytes[20], pRawBytes[21],
+                               pRawBytes[22], pRawBytes[23]
+                               );
+#endif
+    }
     if ( status > 0 ) {
         strLen = ( unsigned ) status;
         if ( strLen < bufSize - 1 ) {
             return strLen;
         }
     }
-    strLen = strlen ( pErrStr );
+    strLen = ( unsigned ) strlen ( pErrStr );
     if ( strLen < bufSize ) {
         strcpy ( pBuf, pErrStr );
         return strLen;
@@ -186,3 +309,607 @@ unsigned epicsStdCall ipAddrToDottedIP (
     }
 }
 
+/*
+ * this version sets the file control flags so that
+ * the socket will be closed if the user uses exec()
+ * as is the case with third party tools such as TCL/TK
+ */
+#ifdef NETDEBUG
+LIBCOM_API SOCKET epicsStdCall epicsSocket46CreateFL ( 
+    const char *filename, int lineno,
+    int domain, int type, int protocol )
+{
+    char *domain_family_str = "";
+    char *type_str = "";
+    if (domain == AF_INET) {
+        domain_family_str = "AF_INET";
+    } else if (domain == AF_INET6) {
+        domain_family_str = "AF_INET6";
+    }
+    if (type == SOCK_DGRAM) {
+        type_str = "DGRAM";
+    } else if (type == SOCK_STREAM) {
+        type_str = "STREAM";
+    }
+    SOCKET sock = epicsSocketCreate( domain, type, protocol );
+    epicsPrintf ("epicsSocketCreate(%s:%d) (%s %s) socket=%lu\n",
+                 filename, lineno, domain_family_str, type_str, (unsigned long)sock);
+    return sock;
+}
+#endif
+
+/*
+ * Wrapper around bind()
+ * Make sure that the right length is passed into bind()
+ */
+LIBCOM_API int epicsStdCall epicsSocket46BindFL(const char* filename, int lineno,
+                                                SOCKET sock,
+                                                const osiSockAddr46 *pAddr46)
+{
+    osiSocklen_t socklen = ( osiSocklen_t ) sizeof ( pAddr46->ia ) ;
+    int status;
+#if EPICS_HAS_IPV6
+    if (pAddr46->sa.sa_family == AF_INET6) {
+      socklen = ( osiSocklen_t ) sizeof ( pAddr46->in6 ) ;
+    }
+#endif
+    status = bind(sock, &pAddr46->sa, socklen);
+#ifdef NETDEBUG
+    /* if (status < 0) */ {
+        char buf[64];
+        char sockErrBuf[64];
+        epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
+        sockAddrToDottedIP(&pAddr46->sa, buf, sizeof(buf));
+        epicsPrintf("%s:%d: bind(%lu) address='%s' socklen=%u status=%d: %s\n",
+                     filename, lineno,
+                     (unsigned long)sock,
+                     buf, (unsigned)socklen,
+                     status, status < 0 ? sockErrBuf : "");
+    }
+#endif
+    return status;
+}
+
+
+LIBCOM_API int epicsStdCall epicsSocket46BindLocalPortFL(const char* filename, int lineno,
+                                                         SOCKET sock, unsigned short port)
+
+{
+    osiSockAddr46 addr46;
+    int addressFamily = epicsSocket46GetDefaultAddressFamily();
+    memset ( (char *)&addr46, 0 , sizeof (addr46) );
+    addr46.sa.sa_family = addressFamily;
+#if EPICS_HAS_IPV6
+    if ( addressFamily == AF_INET6 ) {
+        addr46.in6.sin6_addr = in6addr_any;
+        addr46.in6.sin6_port = htons ( port );
+    }
+    else
+#endif
+    {
+        addr46.ia.sin_addr.s_addr = htonl ( INADDR_ANY );
+        addr46.ia.sin_port = htons ( port );
+    }
+    return epicsSocket46BindFL(filename, lineno, sock, &addr46);
+}
+
+
+/*
+ * Wrapper around connect()
+ */
+LIBCOM_API int epicsStdCall epicsSocket46ConnectFL(const char *filename, int lineno,
+                                                   SOCKET sock,
+                                                   const osiSockAddr46 *pAddr46)
+{
+    osiSockAddr46 addr46Output;
+    int status;
+#if EPICS_HAS_IPV6
+    osiSocklen_t socklen = sizeof(addr46Output.in6);
+#else
+    osiSocklen_t socklen = sizeof(addr46Output.ia);
+#endif
+    osiSockIPv4toIPv6(pAddr46, &addr46Output);
+    /* Now we have an IPv6 address. use the size of it when calling connect() */
+    status = connect(sock, &addr46Output.sa, socklen);
+
+#ifdef NETDEBUG
+    {
+        char bufIn[64];
+        char bufOut[64];
+        char sockErrBuf[64];
+        epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
+        sockAddrToDottedIP(&pAddr46->sa, bufIn, sizeof(bufIn));
+        sockAddrToDottedIP(&addr46Output.sa, bufOut, sizeof(bufOut));
+        epicsPrintf("%s:%d: connect(%lu) address='%s' (%s) status=%d %s\n",
+                    filename, lineno,
+                    (unsigned long)sock,
+                    bufIn,
+                    pAddr46->sa.sa_family != addr46Output.sa.sa_family ? bufOut : "",
+                    status, status < 0 ? sockErrBuf : "");
+    }
+#endif
+    return status;
+}
+
+LIBCOM_API int epicsStdCall epicsSocket46SendtoFL(const char *filename, int lineno,
+                                                  SOCKET sock,
+                                                  const void* buf, size_t len, int flags,
+                                                  const osiSockAddr46 *pAddr46)
+{
+    osiSocklen_t socklen = ( osiSocklen_t ) sizeof ( pAddr46->ia ) ;
+    int status;
+#if EPICS_HAS_IPV6
+    if (pAddr46->sa.sa_family == AF_INET6) {
+      socklen = ( osiSocklen_t ) sizeof ( pAddr46->in6 ) ;
+    }
+#endif
+    status = sendto(sock, buf, len, flags, &pAddr46->sa, socklen ) ;
+
+#ifdef NETDEBUG
+    {
+        char bufIn[64];
+        char sockErrBuf[64];
+        epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
+        sockAddrToDottedIP(&pAddr46->sa, bufIn, sizeof(bufIn));
+        epicsPrintf("%s:%d: sendto(%lu) address='%s' len=%u status=%d %s\n",
+                    filename, lineno,
+                    (unsigned long)sock,
+                    bufIn,
+                    (unsigned)len,
+                    status, status < 0 ? sockErrBuf : "");
+    }
+#endif
+    return status;
+}
+
+
+LIBCOM_API int epicsStdCall epicsSocket46RecvfromFL(const char *filename, int lineno,
+                                                    SOCKET sock,
+                                                    void* buf, size_t len, int flags,
+                                                    osiSockAddr46 *pAddr46)
+{
+    int status;
+    osiSocklen_t socklen = sizeof(*pAddr46);
+    status = recvfrom(sock, buf, len, flags, &pAddr46->sa, &socklen);
+#ifdef NETDEBUG
+    {
+        char bufDotted[64];
+        char sockErrBuf[64];
+        epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
+        sockAddrToDottedIP(&pAddr46->sa, bufDotted, sizeof(bufDotted));
+        epicsPrintf("%s:%d: recvfrom(%lu) buflen=%u address='%s' status=%d %s\n",
+                    filename, lineno,
+                    (unsigned long)sock,
+                    (unsigned)len, bufDotted,
+                    status, status < 0 ? sockErrBuf : "");
+    }
+#endif
+    return status;
+}
+
+
+LIBCOM_API int epicsStdCall epicsSocket46AcceptFL(const char *filename, int lineno,
+                                                  SOCKET sock,
+                                                  osiSockAddr46 *pAddr46)
+{
+    int status;
+    osiSocklen_t socklen = sizeof(*pAddr46);
+    status = epicsSocketAccept(sock, &pAddr46->sa, &socklen);
+#ifdef NETDEBUG
+    {
+        char buf[64];
+        char sockErrBuf[64];
+        epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
+        sockAddrToDottedIP(&pAddr46->sa, buf, sizeof(buf));
+        epicsPrintf("%s:%d: accept(%lu) address='%s' status=%d (%s)\n",
+                    filename, lineno,
+                    (unsigned long)sock,
+                    buf,
+                    status, status < 0 ? sockErrBuf : "");
+    }
+#endif
+    return status;
+}
+
+
+LIBCOM_API int epicsStdCall sockIPsAreIdentical46FL(const char *filename, int lineno,
+                                                    const osiSockAddr46 *pAddr1,
+                                                    const osiSockAddr46 *pAddr2)
+{
+    int ret = 0;
+    if (pAddr1->sa.sa_family == AF_INET && pAddr2->sa.sa_family == AF_INET &&
+        pAddr1->ia.sin_addr.s_addr == pAddr2->ia.sin_addr.s_addr) {
+        ret = 1;
+#if EPICS_HAS_IPV6
+    } else if (pAddr1->sa.sa_family == AF_INET6 && pAddr2->sa.sa_family == AF_INET6 &&
+               !memcmp(&pAddr1->in6.sin6_addr, &pAddr2->in6.sin6_addr,
+                       sizeof(pAddr2->in6.sin6_addr))&&
+               pAddr1->in6.sin6_scope_id == pAddr2->in6.sin6_scope_id) {
+        ret = 1;
+#endif
+    }
+#ifdef NETDEBUG
+    {
+        char buf1[64];
+        char buf2[64];
+        sockAddrToDottedIP(&pAddr1->sa, buf1, sizeof(buf1));
+        sockAddrToDottedIP(&pAddr2->sa, buf2, sizeof(buf2));
+        epicsPrintf("%s:%d: sockIPsAreIdentical46 addr1='%s' addr2='%s' ret=%d\n",
+                     filename, lineno,
+                    buf1, buf2, ret);
+    }
+#endif
+    return ret;
+}
+
+LIBCOM_API int epicsStdCall sockAddrAreIdentical46FL(const char *filename, int lineno,
+                                                     const osiSockAddr46 *pAddr1,
+                                                     const osiSockAddr46 *pAddr2)
+{
+    int ret = 0;
+    if (pAddr1->sa.sa_family == AF_INET && pAddr2->sa.sa_family == AF_INET &&
+        pAddr1->ia.sin_addr.s_addr == pAddr2->ia.sin_addr.s_addr &&
+        pAddr1->ia.sin_port == pAddr2->ia.sin_port) {
+        ret = 1;
+#if EPICS_HAS_IPV6
+    } else if (pAddr1->sa.sa_family == AF_INET6 && pAddr2->sa.sa_family == AF_INET6 &&
+               !memcmp(&pAddr1->in6.sin6_addr, &pAddr2->in6.sin6_addr,
+                       sizeof(pAddr2->in6.sin6_addr)) &&
+               pAddr1->in6.sin6_port == pAddr2->in6.sin6_port &&
+               pAddr1->in6.sin6_scope_id == pAddr2->in6.sin6_scope_id) {
+        ret = 1;
+#endif
+    }
+#ifdef NETDEBUGX2
+    {
+        char buf1[64];
+        char buf2[64];
+        sockAddrToDottedIP(&pAddr1->sa, buf1, sizeof(buf1));
+        sockAddrToDottedIP(&pAddr2->sa, buf2, sizeof(buf2));
+        epicsPrintf("%s:%d: sockAddrAreIdentical46 addr1='%s' addr2='%s' ret=%d\n",
+                     filename, lineno,
+                    buf1, buf2, ret);
+    }
+#endif
+    return ret;
+}
+
+LIBCOM_API int epicsStdCall sockPortAreIdentical46FL(const char *filename, int lineno,
+                                                     const osiSockAddr46 *pAddr1,
+                                                     const osiSockAddr46 *pAddr2)
+{
+#ifdef NETDEBUG
+    {
+        char buf1[64];
+        char buf2[64];
+        sockAddrToDottedIP(&pAddr1->sa, buf1, sizeof(buf1));
+        sockAddrToDottedIP(&pAddr2->sa, buf2, sizeof(buf2));
+        epicsPrintf("%s:%d: sockPortAreIdentical46 addr1='%s' addr2='%s'\n",
+                     filename, lineno,
+                     buf1, buf2);
+    }
+#endif
+    if (pAddr1->sa.sa_family == AF_INET && pAddr2->sa.sa_family == AF_INET &&
+        pAddr1->ia.sin_port == pAddr2->ia.sin_port) {
+        return 1;
+#if EPICS_HAS_IPV6
+    } else if (pAddr1->sa.sa_family == AF_INET6 && pAddr2->sa.sa_family == AF_INET6 &&
+               pAddr1->in6.sin6_port == pAddr2->in6.sin6_port) {
+        return 1;
+#endif
+    }
+    return 0;
+}
+
+LIBCOM_API int epicsStdCall epicsSocket46portFromAddress(osiSockAddr46 *paddr)
+{
+    if (paddr->ia.sin_family == AF_INET) {
+        return ntohs(paddr->ia.sin_port);
+#if EPICS_HAS_IPV6
+    } else if (paddr->in6.sin6_family == AF_INET6) {
+        return ntohs(paddr->in6.sin6_port);
+#endif
+    }
+#ifndef NETDEBUG
+    epicsPrintf("%s:%d: epicsSocket46portFromAddress invalid family: %d\n",
+                    __FILE__, __LINE__,
+                    paddr->ia.sin_family);
+#endif
+    return -1;
+}
+
+/*
+ * AF_INET or AF_INET6
+ */
+LIBCOM_API int epicsStdCall epicsSocket46GetDefaultAddressFamily(void)
+{
+#if EPICS_HAS_IPV6
+    return AF_INET6;
+#else
+    return AF_INET;
+#endif
+}
+
+/*
+ * The family is AF_INET or AF_INET6
+ * When EPICS_HAS_IPV6 os not set: Only AF_INET
+ */
+LIBCOM_API int epicsStdCall epicsSocket46IsAF_INETorAF_INET6(int family)
+{
+    if (family == AF_INET) return 1;
+#if EPICS_HAS_IPV6
+    if (family == AF_INET6) return 1;
+#endif
+    return 0;
+}
+
+LIBCOM_API int epicsSocket46IpOnlyToDotted(const struct sockaddr *pAddr,
+                                       char *pBuf, unsigned bufSize)
+{
+    unsigned strLen;
+    int status = -1;
+    if (!bufSize) return 0;
+
+    *pBuf = '\0';
+    if (pAddr->sa_family == AF_INET) {
+        const struct sockaddr_in *pIa = (const struct sockaddr_in *)pAddr;
+        unsigned addr = ntohl(pIa->sin_addr.s_addr);
+        /*
+         * inet_ntoa() isnt used because it isnt thread safe
+         * (and the replacements are not standardized)
+         */
+        status = epicsSnprintf(pBuf, bufSize, "%u.%u.%u.%u",
+                               (addr >> 24) & 0xFF,
+                               (addr >> 16) & 0xFF,
+                               (addr >> 8) & 0xFF,
+                               (addr) & 0xFF);
+    }
+#if EPICS_HAS_IPV6
+    else if (pAddr->sa_family == AF_INET6) {
+        const struct sockaddr_in6 *pIn6 = (const struct sockaddr_in6 *)pAddr;
+        if (IN6_IS_ADDR_V4MAPPED(&pIn6->sin6_addr)) {
+            /* https://datatracker.ietf.org/doc/html/rfc5156 */
+            status = epicsSnprintf(pBuf, bufSize, "::FFFF:%u.%u.%u.%u",
+                                   pIn6->sin6_addr.s6_addr[12],
+                                   pIn6->sin6_addr.s6_addr[13],
+                                   pIn6->sin6_addr.s6_addr[14],
+                                   pIn6->sin6_addr.s6_addr[15]);
+        } else {
+#ifdef IF_NAMESIZE
+            char if_name_or_number[IF_NAMESIZE];
+            if ( ! if_indextoname((unsigned int)pIn6->sin6_scope_id, &if_name_or_number[0]) ) {
+#else
+            char if_name_or_number[16];
+            {
+#endif
+                snprintf(if_name_or_number, sizeof(if_name_or_number),
+                         "%u", (unsigned int)pIn6->sin6_scope_id);
+            }
+            status = epicsSnprintf (pBuf, bufSize,
+                                    "[%x:%x:%x:%x:%x:%x:%x:%x%%%s]",
+                                    (pIn6->sin6_addr.s6_addr[0] << 8) +
+                                    pIn6->sin6_addr.s6_addr[1],
+                                    (pIn6->sin6_addr.s6_addr[2] << 8) +
+                                    pIn6->sin6_addr.s6_addr[3],
+                                    (pIn6->sin6_addr.s6_addr[4] << 8) +
+                                    pIn6->sin6_addr.s6_addr[5],
+                                    (pIn6->sin6_addr.s6_addr[6] << 8) +
+                                    pIn6->sin6_addr.s6_addr[7],
+                                    (pIn6->sin6_addr.s6_addr[8] << 8) +
+                                    pIn6->sin6_addr.s6_addr[9],
+                                    (pIn6->sin6_addr.s6_addr[10] << 8) +
+                                    pIn6->sin6_addr.s6_addr[11],
+                                    (pIn6->sin6_addr.s6_addr[12] << 8) +
+                                    pIn6->sin6_addr.s6_addr[13],
+                                    (pIn6->sin6_addr.s6_addr[14] << 8) +
+                                    pIn6->sin6_addr.s6_addr[15],
+                                    if_name_or_number);
+        }
+    } else {
+        /*
+         *  This is for debugging only, assuming a struct defined
+         *  See https://datatracker.ietf.org/doc/html/rfc3493
+         *  2 fam, 2 port, 4 flowinfo, 16 Ipv6, 4 scope 
+         */
+        unsigned char *pRawBytes =(unsigned char *)pAddr;
+        status = epicsSnprintf(pBuf, bufSize, "%02x%02x %02x%02x %02x%02x%02x%02x %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+                               pRawBytes[0],  pRawBytes[1],
+                               pRawBytes[2],  pRawBytes[3],
+                               pRawBytes[4],  pRawBytes[5],
+                               pRawBytes[6],  pRawBytes[7],
+                               pRawBytes[8],  pRawBytes[9],
+                               pRawBytes[10], pRawBytes[11],
+                               pRawBytes[12], pRawBytes[13],
+                               pRawBytes[14], pRawBytes[15],
+                               pRawBytes[16], pRawBytes[17],
+                               pRawBytes[18], pRawBytes[19],
+                               pRawBytes[20], pRawBytes[21],
+                               pRawBytes[22], pRawBytes[23]
+                               );
+    }
+#else
+    else {
+        /*
+         *  This is for debugging only, assuming a struct defined
+         *  See https://datatracker.ietf.org/doc/html/rfc3493
+         *  2 fam, 2 port, 4 IPv4
+         */
+        unsigned char *pRawBytes =(unsigned char *)pAddr;
+        status = epicsSnprintf(pBuf, bufSize, "%02x%02x %02x%02x %02x%02x%02x%02x",
+                               pRawBytes[0],  pRawBytes[1],
+                               pRawBytes[2],  pRawBytes[3],
+                               pRawBytes[4],  pRawBytes[5],
+                               pRawBytes[6],  pRawBytes[7]
+                               );
+    }
+
+#endif
+    if (status > 0) {
+        strLen = (unsigned) status;
+        if (strLen < bufSize - 1) {
+            return strLen;
+        }
+    }
+    return -1;
+}
+
+LIBCOM_API void epicsSocket46optIPv6MultiCast_FL(const char* filename, int lineno,
+                                                 SOCKET sock,
+                                                 unsigned int interfaceIndex)
+{
+#ifdef NETDEBUG
+    epicsPrintf("%s:%d: epicsSocket46optIPv6MultiCast(%lu) interfaceIndex=%u\n",
+                filename, lineno,
+                (unsigned long)sock, interfaceIndex);
+#endif
+#if EPICS_HAS_IPV6
+    {
+        int status = setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_IF,
+                                (char*)&interfaceIndex, sizeof(interfaceIndex));
+
+        if ( status )
+        {
+            char sockErrBuf[64];
+            epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
+            epicsPrintf("%s:%d: epicsSocket46optIPv6MultiCast_IF(%lu)status=%d %s\n",
+                         filename, lineno,
+                         (unsigned long)sock,
+                         status, status < 0 ? sockErrBuf : "");
+        }
+    }
+    {
+        int hops = 1;
+        /* Set TTL of multicast packet */
+        int status = setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS,
+                                (char*)&hops, sizeof(hops));
+
+        if ( status )
+        {
+            char sockErrBuf[64];
+            epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
+            epicsPrintf("%s:%d: epicsSocket46optIPv6MultiCast_HOPS(%lu) hops=%d status=%d %s\n",
+                         filename, lineno,
+                         (unsigned long)sock,
+                         hops,
+                         status, status < 0 ? sockErrBuf : "");
+        }
+    }
+    {
+        int loop_on = 1;
+        int status = setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_LOOP,
+                                (char*)&loop_on, sizeof(loop_on));
+        if ( status )
+        {
+            char sockErrBuf[64];
+            epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
+            epicsPrintf("%s:%d: epicsSocket46optIPv6MultiCast_LOOP(%lu) loop_on=%d status=%d %s\n",
+                         filename, lineno,
+                         (unsigned long)sock,
+                         loop_on,
+                         status, status < 0 ? sockErrBuf : "");
+        }
+    }
+    {
+        struct ipv6_mreq group;
+        osiSockAddr46 empty46;
+        osiSockAddr46 addr46;
+        int status;
+        memset(&group, 0, sizeof(group));
+        memset(&empty46, 0, sizeof(empty46));
+        empty46.sa.sa_family = AF_INET6;
+        epicsSocket46addr6toMulticastOK(&empty46, &addr46);
+        memcpy(&group.ipv6mr_multiaddr,
+               &addr46.in6.sin6_addr.s6_addr,
+               sizeof(group.ipv6mr_multiaddr.s6_addr));
+        group.ipv6mr_interface = interfaceIndex;
+        status = setsockopt(sock, IPPROTO_IPV6, IPV6_JOIN_GROUP,
+                            (char*)&group, sizeof(group));
+#ifndef NETDEBUG
+        if ( status )
+#endif
+        {
+            char sockErrBuf[64];
+            epicsSocketConvertErrnoToString (sockErrBuf, sizeof ( sockErrBuf ) );
+            epicsPrintf("%s:%d: epicsSocket46optIPv6MultiCast_GROUP(%lu) sizeof(group)=%u status=%d %s\n",
+                         filename, lineno,
+                         (unsigned long)sock, (unsigned)sizeof(group),
+                         status, status < 0 ? sockErrBuf : "");
+            if ( ( status ) && (sizeof(group) >= 20 ) )
+            {
+                unsigned char *pRawBytes = (unsigned char *)&group;
+                epicsPrintf("%s:%d: rawBytesGroup=%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x\n",
+                                  __FILE__, __LINE__,
+                                  pRawBytes[0],
+                                  pRawBytes[1],
+                                  pRawBytes[2],
+                                  pRawBytes[3],
+                                  pRawBytes[4],
+                                  pRawBytes[5],
+                                  pRawBytes[6],
+                                  pRawBytes[7],
+                                  pRawBytes[8],
+                                  pRawBytes[9],
+                                  pRawBytes[10],
+                                  pRawBytes[11],
+                                  pRawBytes[12],
+                                  pRawBytes[13],
+                                  pRawBytes[14],
+                                  pRawBytes[15],
+                                  pRawBytes[16],
+                                  pRawBytes[17],
+                                  pRawBytes[18],
+                                  pRawBytes[19]);
+
+            }
+        }
+    }
+#endif
+}
+
+LIBCOM_API int epicsSocket46addr6toMulticastOKFL(const char* filename, int lineno,
+                                                 const osiSockAddr46 *pAddrInterface,
+                                                 osiSockAddr46 *pAddrMulticast)
+{
+#if EPICS_HAS_IPV6
+    struct sockaddr_in6 *pAddr6 = &pAddrMulticast->in6;
+    memcpy(pAddrMulticast, pAddrInterface, sizeof(*pAddrMulticast));
+    if (pAddrInterface->sa.sa_family == AF_INET6) {
+        /*
+         * If I understand
+         * https://www.rfc-editor.org/rfc/rfc2375.html
+         * correctly, we can use "All Nodes Address"
+         */
+        pAddr6->sin6_addr.s6_addr[0] = 0xff;
+        pAddr6->sin6_addr.s6_addr[1] = 0x02;
+        pAddr6->sin6_addr.s6_addr[2] = 0;
+        pAddr6->sin6_addr.s6_addr[3] = 0;
+        pAddr6->sin6_addr.s6_addr[4] = 0;
+        pAddr6->sin6_addr.s6_addr[5] = 0;
+        pAddr6->sin6_addr.s6_addr[6] = 0;
+        pAddr6->sin6_addr.s6_addr[7] = 0;
+        pAddr6->sin6_addr.s6_addr[8] = 0;
+        pAddr6->sin6_addr.s6_addr[9] = 0;
+        pAddr6->sin6_addr.s6_addr[10] = 0;
+        pAddr6->sin6_addr.s6_addr[11] = 0;
+        pAddr6->sin6_addr.s6_addr[12] = 0;
+        pAddr6->sin6_addr.s6_addr[13] = 0;
+        pAddr6->sin6_addr.s6_addr[14] = 0;
+        pAddr6->sin6_addr.s6_addr[15] = 1;
+    }
+#ifdef NETDEBUGX2
+    {
+        char bufIn[64];
+        char bufOut[64];
+        sockAddrToDottedIP(&pAddrInterface->sa, bufIn, sizeof(bufIn));
+        sockAddrToDottedIP(&pAddrMulticast->sa, bufOut, sizeof(bufOut));
+        epicsPrintf("%s:%d: epicsSocket46addr6toMulticastOK address='%s' multicast='%s'\n",
+                    filename, lineno,
+                    bufIn, bufOut);
+    }
+#endif
+    if (pAddrInterface->sa.sa_family != AF_INET6) {
+        return 0; /* error */
+    }
+#endif
+    return 1;
+}

--- a/modules/libcom/test/ipAddrToAsciiTest.cpp
+++ b/modules/libcom/test/ipAddrToAsciiTest.cpp
@@ -82,7 +82,7 @@ void doLookup(ipAddrToAsciiEngine& engine)
 
     ipAddrToAsciiTransaction& trn(engine.createTransaction());
     CB cb("cb");
-    osiSockAddr addr;
+    osiSockAddr46 addr;
     addr.ia.sin_family = AF_INET;
     addr.ia.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     addr.ia.sin_port = htons(42);
@@ -110,7 +110,7 @@ void doCancel()
     testOk1(&trn1!=&trn2);
     CB cb1("cb1"), cb2("cb2");
 
-    osiSockAddr addr;
+    osiSockAddr46 addr;
     addr.ia.sin_family = AF_INET;
     addr.ia.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     addr.ia.sin_port = htons(42);

--- a/modules/libcom/test/osiSockTest.c
+++ b/modules/libcom/test/osiSockTest.c
@@ -271,7 +271,7 @@ void udpSockFanoutTestRx(void* raw)
 }
 
 static
-void udpSockFanoutTestIface(const osiSockAddr* addr)
+void udpSockFanoutTestIface(const osiSockAddr46* pAddr46)
 {
     SOCKET sender;
     struct TInfo rx1, rx2;
@@ -280,7 +280,7 @@ void udpSockFanoutTestIface(const osiSockAddr* addr)
     int opt = 1;
     unsigned i;
     osiSockAddr any;
-    epicsUInt32 key = 0xdeadbeef ^ ntohl(addr->ia.sin_addr.s_addr);
+    epicsUInt32 key = 0xdeadbeef ^ ntohl(pAddr46->ia.sin_addr.s_addr);
     union CASearchU buf;
     int ret;
 
@@ -292,7 +292,7 @@ void udpSockFanoutTestIface(const osiSockAddr* addr)
     memset(&any, 0, sizeof(any));
     any.ia.sin_family = AF_INET;
     any.ia.sin_addr.s_addr = htonl(INADDR_ANY);
-    any.ia.sin_port = addr->ia.sin_port;
+    any.ia.sin_port = pAddr46->ia.sin_port;
 
     buf.msg.cmd = htons(6);
     buf.msg.size = htons(16);
@@ -326,7 +326,7 @@ void udpSockFanoutTestIface(const osiSockAddr* addr)
         testFail("Can't bind test socket rx2 %d", (int)SOCKERRNO);
 
     /* test to see if send is possible (not EPERM) */
-    ret = sendto(sender, buf.bytes, sizeof(buf.bytes), 0, &addr->sa, sizeof(*addr));
+    ret = sendto(sender, buf.bytes, sizeof(buf.bytes), 0, &pAddr46->sa, sizeof(pAddr46->ia));
     if(ret!=(int)sizeof(buf.bytes)) {
         testDiag("test sendto() error %d (%d)", ret, (int)SOCKERRNO);
         goto cleanup;
@@ -340,7 +340,7 @@ void udpSockFanoutTestIface(const osiSockAddr* addr)
         epicsThreadSleep(0.5);
 
         buf.msg.p1 = buf.msg.p2 = htonl(key + i);
-        ret = sendto(sender, buf.bytes, sizeof(buf.bytes), 0, &addr->sa, sizeof(*addr));
+        ret = sendto(sender, buf.bytes, sizeof(buf.bytes), 0, &pAddr46->sa, sizeof(pAddr46->ia));
         if(ret!=(int)sizeof(buf.bytes))
             testDiag("sendto() error %d (%d)", ret, (int)SOCKERRNO);
     }
@@ -370,7 +370,7 @@ void udpSockFanoutTest()
     ELLLIST ifaces = ELLLIST_INIT;
     ELLNODE *cur;
     SOCKET dummy;
-    osiSockAddr match;
+    osiSockAddr46 match;
     int foundNotLo = 0;
 
     testDiag("udpSockFanoutTest()");
@@ -388,16 +388,16 @@ void udpSockFanoutTest()
         char name[64];
         osiSockAddrNode* node = CONTAINER(cur, osiSockAddrNode, node);
 
-        node->addr.ia.sin_port = htons(5064);
-        (void)sockAddrToDottedIP(&node->addr.sa, name, sizeof(name));
+        node->addr46.ia.sin_port = htons(5064);
+        (void)sockAddrToDottedIP(&node->addr46.sa, name, sizeof(name));
 
         testDiag("Interface %s", name);
-        if(node->addr.ia.sin_addr.s_addr!=htonl(INADDR_LOOPBACK)) {
+        if(node->addr46.ia.sin_addr.s_addr!=htonl(INADDR_LOOPBACK)) {
             testDiag("Not LO");
             foundNotLo = 1;
         }
 
-        udpSockFanoutTestIface(&node->addr);
+        udpSockFanoutTestIface(&node->addr46);
     }
 
     ellFree(&ifaces);


### PR DESCRIPTION
Prepare EPICS Base to handle IPv6:

The socket interface got a new structure, "osiSockAddr46"
There is a compiler flag, EPICS_HAS_IPV6, which must be set to 1,
if IPv6 is enabled at all.
osiSock.c got new functions, that deal with IPv6:

epicsSocket46GetDefaultAddressFamily()
epicsSocket46Create()
epicsSocket46Recvfrom()
epicsSocket46Sendto()
epicsSocket46Connect()
epicsSocket46Accept()

They all work with osiSockAddr46.
Unless -DEPICS_HAS_IPV6=1 is used, there is no change (yet).

Backward compatiblity:
The "union osiSockAddr" is left unchanged, so that code relying
on its structure is not affected.
However, osiSockAddr is too short to hold IPv6 addresses.
Code that that needs IPv6 can do it's own business, or use use the
epicsSocket46xxx functions mentioned above.

For EPICS base this has been done. Most variables using osiSockAddr46
have been renamed. E.g. from addr into addr46. Not all of them.

Start testing, using IPv6:
  caget, camonitor can work via IPV6 like this:
  $ export EPICS_CA_AUTO_ADDR_LIST=NO
  $ export EPICS_CA_ADDR_LIST='[2001:db8:1:0:0:1:2:3]'
  cainfo IOC:m1

  Using link local addresses:
    Find out the link-local address of your IOC.
    e.g. fe80::3958:418:65b8:230c
    Find out the interface of your client, sitting on the same network
    switch as the IOC.
    $ ifconfig
    # or
    $ ip addr show
    in my case it is "en0"
    # ping the IOC:
    $ ping6 fe80::3958:418:65b8:230c
      ping6: sendmsg: No route to host
    # That didn't work, we new this.
    # Compose a proper adress, combining the remote IPv6 with
    # our local interface name:
    $ ping6 fe80::3958:418:65b8:230c%en0
    16 bytes from fe80::3958:418:65b8:230c%en0
    # with this knowledge, we can use cainfo:
    $ export EPICS_CA_AUTO_ADDR_LIST=NO
    $ export EPICS_CA_ADDR_LIST='[fe80::3958:418:65b8:230c%en0]'
    $ cainfo IOC:m1

TODO, unordered:
- Some cleanup...
- Check what ipAddrToA() and sockAddrToA() are doing. Do we need both ?
- Find out how IPv6 multicast is working
- Get an official multicast address from IANA ?
- Do we need to change the repeater ? Or is multicast workig "as is" ?
- VxWorks, RTEMS, Windows, other OS ?
- EPICS Base 7 only, or 3.15 as well ?
- Define new EPICS variables.
- pvAccess
- gateways
- Check access control (based on IP addresses)
- asyn (I have made a "prof of concept", code on request)