### PR TITLE
dbnd filter pass through DBE_ALARM|DBE_PROPERTY

### DIFF
--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -886,6 +886,8 @@ unsigned int    caEventMask
         if ( (dbChannelField(pevent->chan) == (void *)pField || pField==NULL) &&
             (caEventMask & pevent->select)) {
             db_field_log *pLog = db_create_event_log(pevent);
+            if(pLog)
+                pLog->mask = caEventMask & pevent->select;
             pLog = dbChannelRunPreChain(pevent->chan, pLog);
             if (pLog) db_queue_event_log(pevent, pLog);
         }

--- a/modules/database/src/std/filters/dbnd.c
+++ b/modules/database/src/std/filters/dbnd.c
@@ -20,7 +20,7 @@
 #include <chfPlugin.h>
 #include <recGbl.h>
 #include <epicsExit.h>
-#include <db_field_log.h>
+#include <dbAccess.h>
 #include <epicsExport.h>
 
 typedef struct myStruct {
@@ -81,8 +81,8 @@ static db_field_log* filter(void* pvt, dbChannel *chan, db_field_log *pfl) {
         status = dbFastGetConvertRoutine[pfl->field_type][DBR_DOUBLE]
                  (localAddr.pfield, (void*) &val, &localAddr);
         if (!status) {
-            send = 0;
-            recGblCheckDeadband(&my->last, val, my->hyst, &send, 1);
+            send = pfl->mask & ~(DBE_VALUE|DBE_LOG);
+            recGblCheckDeadband(&my->last, val, my->hyst, &send, pfl->mask & (DBE_VALUE|DBE_LOG));
             if (send && my->mode == 1) {
                 my->hyst = val * my->cval/100.;
             }

--- a/modules/database/test/std/filters/dbndTest.c
+++ b/modules/database/test/std/filters/dbndTest.c
@@ -13,6 +13,7 @@
 
 #include <string.h>
 
+#include "dbAccess.h"
 #include "dbStaticLib.h"
 #include "dbAccessDefs.h"
 #include "db_field_log.h"
@@ -46,6 +47,7 @@ static void fl_setup(dbChannel *chan, db_field_log *pfl) {
     pfl->stat = prec->stat;
     pfl->sevr = prec->sevr;
     pfl->time = prec->time;
+    pfl->mask = DBE_VALUE;
     pfl->field_type  = dbChannelFieldType(chan);
     pfl->field_size  = dbChannelFieldSize(chan);
     pfl->no_elements = dbChannelElements(chan);


### PR DESCRIPTION
From https://epics.anl.gov/tech-talk/2021/msg01761.php

```
one gets the following after ioc startup.

ACM:TEST:AO.{dbnd:{abs:1.5}}   <undefined> 0 UDF INVALID

one gets nothing after writing  the value 0 to ACM:TEST:A0

one gets nothing after writing  the value 1 to ACM:TEST:A0

one gets a monitor when writing the value 2 to ACM:TEST:A0

ACM:TEST:AO.{dbnd:{abs:1.5}}   2021-10-03 05:17:38.406470 2

What does that mean for a display manager? Should not the real value 0 then be given later from the monitor when 0 is written?
```

It occurs to me that with 235f8ed2fb85270a1b9edddbff6a1c5b10f484b9 the dbnd filter now has enough information to distinguish, and pass through, events with an alarm state change.