### PR TITLE
epicsSingleton.h: Fix inline mismatch for pInstance()

### DIFF
--- a/modules/libcom/src/cxxTemplates/epicsSingleton.h
+++ b/modules/libcom/src/cxxTemplates/epicsSingleton.h
@@ -29,7 +29,7 @@ public:
     void incrRefCount ( PBuild );
     typedef void ( * PDestroy ) ( void * );
     void decrRefCount ( PDestroy );
-    void * pInstance () const;
+    inline void * pInstance () const;
 private:
     void * _pInstance;
     std :: size_t _refCount;


### PR DESCRIPTION
Fix a compilation warning under Mingw:

```
g++ -D_MINGW -D__USE_MINGW_ANSI_STDIO -DBUILDING_libCa_API -O3 -Wall -m64 -DEPICS_BUILD_DLL -DEPICS_CALL_DLL -I. -I../O.Common -I. -I. -I.. -I../test -I../../../../../include/compiler/gcc -I../../../../../include/os/WIN32 -I../../../../../include -o netSubscription.obj -c ../netSubscription.cpp
In file included from ../localHostName.h:27,
from ../cac.h:32,
from ../netSubscription.cpp:30:
../../../../../include/epicsSingleton.h:164:15: warning: 'void* SingletonUntyped::pInstance() const' redeclared without dllimport attribute after being referenced with dll linkage
164 | inline void * SingletonUntyped :: pInstance () const
| ^~~~~~~~~~~~~~~~
----------------
```

Solution:
"void * pInstance () const;" is changed into
"inline void * pInstance () const;"