### PR TITLE
Fix regressTest regression

### DIFF
--- a/modules/database/src/ioc/db/dbCa.c
+++ b/modules/database/src/ioc/db/dbCa.c
@@ -196,6 +196,53 @@ static void caLinkDec(caLink *pca)
     if (callback) callback(userPvt);
 }
 
+struct waitPvt {
+    caLink *pca;
+    epicsEventId evt;
+};
+
+static
+void testdbCaWaitForUpdateCountCB(void *raw)
+{
+    struct waitPvt *pvt = raw;
+
+    epicsMutexMustLock(pvt->pca->lock);
+    epicsEventMustTrigger(pvt->evt);
+    epicsMutexUnlock(pvt->pca->lock);
+}
+
+void testdbCaWaitForUpdateCount(DBLINK *plink, unsigned long cnt)
+{
+
+    caLink *pca;
+    epicsEventId evt = epicsEventMustCreate(epicsEventEmpty);
+
+    dbScanLock(plink->precord);
+
+    pca = (caLink *)plink->value.pv_link.pvt;
+
+    assert(plink->type==CA_LINK);
+    epicsMutexMustLock(pca->lock);
+    assert(!pca->monitor && !pca->userPvt);
+
+    while(pca->nUpdate < cnt) {
+        struct waitPvt pvt = {pca, evt};
+        pca->monitor = &testdbCaWaitForUpdateCountCB;
+        pca->userPvt = &pvt;
+        epicsMutexUnlock(pca->lock);
+        dbScanUnlock(plink->precord);
+        epicsEventMustWait(evt);
+        dbScanLock(plink->precord);
+        epicsMutexMustLock(pca->lock);
+        pca->monitor = NULL;
+        pca->userPvt = NULL;
+    }
+
+    epicsEventDestroy(evt);
+    epicsMutexUnlock(pca->lock);
+    dbScanUnlock(plink->precord);
+}
+
 /* Block until worker thread has processed all previously queued actions.
  * Does not prevent additional actions from being queued.
  */
@@ -234,16 +281,23 @@ void dbCaSync(void)
 
 DBCORE_API unsigned long dbCaGetUpdateCount(struct link *plink)
 {
-    caLink *pca = (caLink *)plink->value.pv_link.pvt;
+    caLink *pca;
     unsigned long ret;
 
-    if (!pca) return (unsigned long)-1;
+    dbScanLock(plink->precord);
+    pca= (caLink *)plink->value.pv_link.pvt;
+
+    if (!pca) {
+        dbScanUnlock(plink->precord);
+        return (unsigned long)-1;
+    }
 
     epicsMutexMustLock(pca->lock);
 
     ret = pca->nUpdate;
 
     epicsMutexUnlock(pca->lock);
+    dbScanUnlock(plink->precord);
 
     return ret;
 }
@@ -1058,6 +1112,7 @@ static void getAttribEventCallback(struct event_handler_args arg)
 
 static void dbCaTask(void *arg)
 {
+    epicsEventId requestSync = NULL;
     taskwdInsert(0, NULL, NULL);
     SEVCHK(ca_context_create(ca_enable_preemptive_callback),
         "dbCaTask calling ca_context_create");
@@ -1078,13 +1133,20 @@ static void dbCaTask(void *arg)
 
             epicsMutexMustLock(workListLock);
             if (!(pca = (caLink *)ellGet(&workList))){  /* Take off list head */
+                if(requestSync) {
+                    /* dbCaSync() requires workListLock to be held here */
+                    epicsEventMustTrigger(requestSync);
+                    requestSync = NULL;
+                }
                 epicsMutexUnlock(workListLock);
                 if (dbCaCtl == ctlExit) goto shutdown;
                 break; /* workList is empty */
             }
             link_action = pca->link_action;
-            if (link_action&CA_SYNC)
-                epicsEventMustTrigger((epicsEventId)pca->userPvt); /* dbCaSync() requires workListLock to be held here */
+            if (link_action&CA_SYNC) {
+                assert(!requestSync);
+                requestSync = pca->userPvt;
+            }
             pca->link_action = 0;
             if (link_action & CA_CLEAR_CHANNEL) --removesOutstanding;
             epicsMutexUnlock(workListLock);         /* Give back immediately */

--- a/modules/database/src/ioc/db/dbCa.c
+++ b/modules/database/src/ioc/db/dbCa.c
@@ -279,29 +279,6 @@ void dbCaSync(void)
     epicsEventDestroy(wake);
 }
 
-DBCORE_API unsigned long dbCaGetUpdateCount(struct link *plink)
-{
-    caLink *pca;
-    unsigned long ret;
-
-    dbScanLock(plink->precord);
-    pca= (caLink *)plink->value.pv_link.pvt;
-
-    if (!pca) {
-        dbScanUnlock(plink->precord);
-        return (unsigned long)-1;
-    }
-
-    epicsMutexMustLock(pca->lock);
-
-    ret = pca->nUpdate;
-
-    epicsMutexUnlock(pca->lock);
-    dbScanUnlock(plink->precord);
-
-    return ret;
-}
-
 void dbCaCallbackProcess(void *userPvt)
 {
     struct link *plink = (struct link *)userPvt;

--- a/modules/database/src/ioc/db/dbCa.h
+++ b/modules/database/src/ioc/db/dbCa.h
@@ -48,8 +48,12 @@ DBCORE_API long dbCaPutLink(struct link *plink,short dbrType,
 extern struct ca_client_context * dbCaClientContext;
 
 #ifdef EPICS_DBCA_PRIVATE_API
+/* Wait CA link work queue to become empty.  eg. after from dbPut() to OUT */
 DBCORE_API void dbCaSync(void);
+/* Get current number of data updates received. */
 DBCORE_API unsigned long dbCaGetUpdateCount(struct link *plink);
+/* Wait for the data update counter to reach the specified value. */
+DBCORE_API void testdbCaWaitForUpdateCount(DBLINK *plink, unsigned long cnt);
 #endif
 
 /* These macros are for backwards compatibility */

--- a/modules/database/src/ioc/db/dbCa.h
+++ b/modules/database/src/ioc/db/dbCa.h
@@ -50,8 +50,6 @@ extern struct ca_client_context * dbCaClientContext;
 #ifdef EPICS_DBCA_PRIVATE_API
 /* Wait CA link work queue to become empty.  eg. after from dbPut() to OUT */
 DBCORE_API void dbCaSync(void);
-/* Get current number of data updates received. */
-DBCORE_API unsigned long dbCaGetUpdateCount(struct link *plink);
 /* Wait for the data update counter to reach the specified value. */
 DBCORE_API void testdbCaWaitForUpdateCount(DBLINK *plink, unsigned long cnt);
 #endif

--- a/modules/database/test/ioc/db/dbCaLinkTest.c
+++ b/modules/database/test/ioc/db/dbCaLinkTest.c
@@ -51,13 +51,6 @@ static epicsEventId waitEvent;
 static unsigned waitCounter;
 
 static
-void waitForUpdateN(DBLINK *plink, unsigned long n)
-{
-    while(dbCaGetUpdateCount(plink)<n)
-        epicsThreadSleep(0.01);
-}
-
-static
 void putLink(DBLINK *plink, short dbr, const void*buf, long nReq)
 {
     long ret;
@@ -133,14 +126,14 @@ static void testNativeLink(void)
 
     testOk1(psrclnk->type==CA_LINK);
 
-    waitForUpdateN(psrclnk, 1);
+    testdbCaWaitForUpdateCount(psrclnk, 1);
 
     dbScanLock((dbCommon*)ptarg);
     ptarg->val = 42;
     db_post_events(ptarg, &ptarg->val, DBE_VALUE|DBE_ALARM|DBE_ARCHIVE);
     dbScanUnlock((dbCommon*)ptarg);
 
-    waitForUpdateN(psrclnk, 2);
+    testdbCaWaitForUpdateCount(psrclnk, 2);
 
     dbScanLock((dbCommon*)psrc);
     /* local CA_LINK connects immediately */
@@ -218,14 +211,14 @@ static void testStringLink(void)
 
     testOk1(psrclnk->type==CA_LINK);
 
-    waitForUpdateN(psrclnk, 1);
+    testdbCaWaitForUpdateCount(psrclnk, 1);
 
     dbScanLock((dbCommon*)ptarg);
     strcpy(ptarg->desc, "hello");
     db_post_events(ptarg, &ptarg->desc, DBE_VALUE|DBE_ALARM|DBE_ARCHIVE);
     dbScanUnlock((dbCommon*)ptarg);
 
-    waitForUpdateN(psrclnk, 2);
+    testdbCaWaitForUpdateCount(psrclnk, 2);
 
     dbScanLock((dbCommon*)psrc);
     /* local CA_LINK connects immediately */
@@ -400,7 +393,7 @@ static void testArrayLink(unsigned nsrc, unsigned ntarg)
     testIocInitOk();
     eltc(1);
 
-    waitForUpdateN(psrclnk, 1);
+    testdbCaWaitForUpdateCount(psrclnk, 1);
 
     bufsrc = psrc->bptr;
     buftarg= ptarg->bptr;
@@ -421,7 +414,7 @@ static void testArrayLink(unsigned nsrc, unsigned ntarg)
     db_post_events(ptarg, &ptarg->val, DBE_VALUE|DBE_ALARM|DBE_ARCHIVE);
     dbScanUnlock((dbCommon*)ptarg);
 
-    waitForUpdateN(psrclnk, 2);
+    testdbCaWaitForUpdateCount(psrclnk, 2);
 
     dbScanLock((dbCommon*)psrc);
     testDiag("fetch source.INP into source.BPTR");

--- a/modules/database/test/std/rec/regressLinkSevr.db
+++ b/modules/database/test/std/rec/regressLinkSevr.db
@@ -6,10 +6,11 @@ record(stringin, "si1") {
 }
 record(longin, "li1") {
   field(INP, "ai.SEVR")
+  field(FLNK, "si2")
 }
 
 record(stringin, "si2") {
-  field(INP, "ai.SEVR CP")
+  field(INP, "ai.SEVR CA")
   field(FLNK, "li2")
 }
 record(longin, "li2") {

--- a/modules/database/test/std/rec/regressLinkSevr.db
+++ b/modules/database/test/std/rec/regressLinkSevr.db
@@ -15,9 +15,4 @@ record(stringin, "si2") {
 }
 record(longin, "li2") {
   field(INP, "ai.SEVR CA")
-  field(FLNK, "cnt")
-}
-
-record(calc, "cnt") {
-  field(CALC, "VAL+1")
 }

--- a/modules/database/test/std/rec/regressTest.c
+++ b/modules/database/test/std/rec/regressTest.c
@@ -171,13 +171,13 @@ void testLongCalc(void)
 static
 void testLinkSevr(void)
 {
-    testMonitor *mon;
     dbChannel *chan;
-    startRegressTestIoc("regressLinkSevr.db");
-    dbCaSync(); /* wait for CA links to connect */
-    dbCaSync(); /* wait for initial update */
 
-    mon = testMonitorCreate("cnt", DBE_VALUE, 0);
+    startRegressTestIoc("regressLinkSevr.db");
+
+    /* wait for CA links to connect and receive an initial update */
+    testdbCaWaitForUpdateCount(dbGetDevLink(testdbRecordPtr("si2")), 1);
+    testdbCaWaitForUpdateCount(dbGetDevLink(testdbRecordPtr("li2")), 1);
 
     chan = dbChannelCreate("ai.SEVR");
     if(!chan)
@@ -196,8 +196,6 @@ void testLinkSevr(void)
     testdbGetFieldEqual("ai.SEVR", DBF_STRING, "INVALID");
 
     testdbPutFieldOk("si1.PROC", DBF_LONG, 1);
-    testMonitorWait(mon);
-    dbCaSync(); /* wait for update */
 
     testdbGetFieldEqual("si1", DBF_STRING, "INVALID");
     testdbGetFieldEqual("li1", DBF_LONG, INVALID_ALARM);
@@ -205,8 +203,6 @@ void testLinkSevr(void)
     testdbGetFieldEqual("si2", DBF_STRING, "INVALID");
     testTodoEnd();
     testdbGetFieldEqual("li2", DBF_LONG, INVALID_ALARM);
-
-    testMonitorDestroy(mon);
 
     testIocShutdownOk();
     testdbCleanup();

--- a/modules/database/test/std/rec/regressTest.c
+++ b/modules/database/test/std/rec/regressTest.c
@@ -197,6 +197,7 @@ void testLinkSevr(void)
 
     testdbPutFieldOk("si1.PROC", DBF_LONG, 1);
     testMonitorWait(mon);
+    dbCaSync(); /* wait for update */
 
     testdbGetFieldEqual("si1", DBF_STRING, "INVALID");
     testdbGetFieldEqual("li1", DBF_LONG, INVALID_ALARM);


### PR DESCRIPTION
Attempt to fix race condition in regressTest.  cf. https://github.com/epics-base/epics-base/discussions/162#discussioncomment-1460745

Removes the now unused private API `dbCaGetUpdateCount()` in favor of a new `testdbCaWaitForUpdateCount()` which covers the original use case in `dbCaLinkTest.c` as well as a new one in `regressTest.c`.

Changes `dbCaSync()` to wait for the dbCa worker queue to be empty.  Usage of `dbCaSync()` remains correct in the original case of synchronizing `dbPutField()` to an `OUT_LINK`.  However, it should not be used with an `IN_LINK`.