### PR TITLE
Hex in hw links

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -16,6 +16,13 @@ should also be read to understand what has changed since earlier releases.
 
 <!-- Insert new items immediately below here ... -->
 
+### Allow hexadecimal and octal numbers in hardware links
+
+Several types of hardware links (`VME_IO`, `CAMAC_IO`, etc) now accept
+hexadecimal and octal numbers. (Hexadecimal numbers had already been valid
+up to EPICS R3.15.) This change may introduce incompatibilities when using
+numbers with leading `0` as they will now be parsed as octal.
+
 ### Fix for `undefined` in configure/RELEASE files
 
 Prevents `Use of uninitialized value` warnings from convertRelease.pl.

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -2275,7 +2275,7 @@ long dbParseLink(const char *str, short ftype, dbLinkInfo *pinfo)
         }
 
         /* generalized extraction of ID character and integer pairs (eg. "#C15 S14") */
-        ret = sscanf(pinfo->target, "# %c%d %c%d %c%d %c%d %c%d %c",
+        ret = sscanf(pinfo->target, "# %c%i %c%i %c%i %c%i %c%i %c",
                      &pinfo->hwid[0], &pinfo->hwnums[0],
                      &pinfo->hwid[1], &pinfo->hwnums[1],
                      &pinfo->hwid[2], &pinfo->hwnums[2],

--- a/modules/database/test/ioc/db/dbPutLinkTest.c
+++ b/modules/database/test/ioc/db/dbPutLinkTest.c
@@ -61,6 +61,7 @@ static const struct testParseDataT {
     TEST_PV_LINK(" world MSICP", "world", pvlOptMSI|pvlOptCP),
 
     {"#C14 S145 @testing", {VME_IO, "testing", 0, "CS", {14, 145}}},
+    {"#C14 S0x1b @testing", {VME_IO, "testing", 0, "CS", {14, 0x1b}}},
     {"#C14 S145", {VME_IO, "", 0, "CS", {14, 145}}},
     {"#B11 C12 N13 A14 F15 @cparam", {CAMAC_IO, "cparam", 0, "BCNAF", {11, 12, 13, 14, 15}}},
     {"#B11 C12 N13 A14 F15", {CAMAC_IO, "", 0, "BCNAF", {11, 12, 13, 14, 15}}},
@@ -700,7 +701,7 @@ void testTSEL(void)
 
 MAIN(dbPutLinkTest)
 {
-    testPlan(342);
+    testPlan(348);
     testLinkParse();
     testLinkFailParse();
     testCADBSet();


### PR DESCRIPTION
Re-allow hex numbers in hardware links