### PR TITLE
Warn of unsafe use of epicsThread after `fork()`

### DIFF
--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -330,12 +330,29 @@ int          status;
     a_p->usePolicy = arg.ok;
 }
 #endif
-
+
+/* 0 - In the process which loads libCom.
+ * 1 - In a newly fork()'d child process
+ * 2 - In a child which has been warned
+ */
+static int childAfterFork;
+
+static void childHook(void)
+{
+    epicsAtomicSetIntT(&childAfterFork, 1);
+}
 
 static void once(void)
 {
     epicsThreadOSD *pthreadInfo;
     int status;
+
+#ifdef __rtems__
+    (void)childHook;
+#else
+    status = pthread_atfork(NULL, NULL, &childHook);
+    checkStatusOnce(status, "pthread_atfork");
+#endif
 
     pthread_key_create(&getpthreadInfo,0);
     status = osdPosixMutexInit(&onceLock,PTHREAD_MUTEX_DEFAULT);
@@ -431,6 +448,11 @@ static void epicsThreadInit(void)
     static pthread_once_t once_control = PTHREAD_ONCE_INIT;
     int status = pthread_once(&once_control,once);
     checkStatusQuit(status,"pthread_once","epicsThreadInit");
+
+    if(epicsAtomicGetIntT(&childAfterFork)==1 &&  epicsAtomicCmpAndSwapIntT(&childAfterFork, 1, 2)==1) {
+        fprintf(stderr, "Warning: Undefined Behavior!\n"
+                        "         Detected use of epicsThread from child process after fork()\n");
+    }
 }
 
 LIBCOM_API

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -34,6 +34,10 @@
 #include <sys/mman.h> 
 #endif
 
+/* epicsStdio uses epicsThreadOnce(), require explicit use to avoid unexpected recursion */
+#define epicsStdioStdStreams
+#define epicsStdioStdPrintfEtc
+
 #include "epicsStdio.h"
 #include "ellLib.h"
 #include "epicsEvent.h"
@@ -942,7 +946,7 @@ LIBCOM_API void epicsStdCall epicsThreadShow(epicsThreadId showThread, unsigned 
     checkStatus(status,"pthread_mutex_unlock epicsThreadShowAll");
     if(status) return;
     if (!found)
-        printf("Thread %#lx (%lu) not found.\n", (unsigned long)showThread, (unsigned long)showThread);
+        epicsStdoutPrintf("Thread %#lx (%lu) not found.\n", (unsigned long)showThread, (unsigned long)showThread);
 }
 
 LIBCOM_API epicsThreadPrivateId epicsStdCall epicsThreadPrivateCreate(void)


### PR DESCRIPTION
```
Warning: Undefined Behavior!
         Detected use of epicsThread from child process after fork()
```

Add a warning about UB (cf. #211) if `epicsThreadInit()` is called from a child process after `fork()`.  Many, but not all unsafe code paths should trip this.  eg. `epicsThreadOnce()` and by extension `errlogPrintf()`, but not `epicsMutexLock()`.  My choice is mainly driven by an assumption that calls to `epicsThreadInit()` are not happening in "hot" code paths.

`pthread_atfork()` is used to detect a `fork()`, however a warning is only emitted if the child calls `epicsThreadInit()`, so it should not be triggered by eg. `osiSpawnDetachedProcess()` doing a `fork()` and then `execv()`.

This PR also changes `posix/osdThread.c` to avoid implicit calls to the epicsStdio redirection calls since these use `epicsThreadOnce()`.  I switched the only immediately obvious (to me) safe usage in `epicsThreadShow()` to explicitly call `epicsStdoutPrintf()`.