### PR TITLE
It is not recommended to mix putchar with printf

### DIFF
--- a/modules/libcom/src/misc/epicsUnitTest.c
+++ b/modules/libcom/src/misc/epicsUnitTest.c
@@ -163,7 +163,7 @@ int testOkV(int pass, const char *fmt, va_list pvar) {
     vprintf(fmt, pvar);
     if (todo)
         printf(" # TODO %s", todo);
-    putchar('\n');
+    printf("\n");
     fflush(stdout);
     epicsMutexUnlock(testLock);
     return pass;
@@ -219,7 +219,7 @@ int testDiag(const char *fmt, ...) {
     epicsMutexMustLock(testLock);
     printf("# ");
     vprintf(fmt, pvar);
-    putchar('\n');
+    printf("\n");
     fflush(stdout);
     epicsMutexUnlock(testLock);
     va_end(pvar);
@@ -231,7 +231,7 @@ void testAbort(const char *fmt, ...) {
     va_start(pvar, fmt);
     printf("Bail out! ");
     vprintf(fmt, pvar);
-    putchar('\n');
+    printf("\n");
     fflush(stdout);
     va_end(pvar);
     abort();


### PR DESCRIPTION
At least on vxWorks 6.9 the newlines are not printed in the test results. The (Linux) `putchar` man page says:

> **BUGS**
       It  is  not advisable to mix calls to output functions from the stdio library with low-level calls to write(2)
       for the file descriptor associated with the same output stream; the results will be undefined and very  proba‐
       bly not what you want.

On the other hand, the vxWorks manual claims:
> For example, printf( ) is a wrapper that calls the system call write( ).

This problem may affect more systems than just vxWorks. Generally better not mix `putchar()`, `puts()` and the like with the buffered `printf()` family of functions on the same file (including `stdout`).

BTW: For similar reasons do not mix `printf()` with `cout <<`.

Anyway, this patch fixes the problem.