### PR TITLE
Fix gdd string to double conversion

### DIFF
--- a/src/ca/legacy/gdd/aitConvert.cc
+++ b/src/ca/legacy/gdd/aitConvert.cc
@@ -50,14 +50,16 @@ bool getStringAsDouble ( const char * pString,
         ftmp = itmp;
     }
     else {
-	    int j = epicsScanDouble( pString, &ftmp );
-	    if ( j != 1 ) {
-		    j = sscanf ( pString,"%x", &itmp );
-            if ( j == 1 ) {
-                ftmp = itmp;
-            }
-            else {
-                return false;
+        int j = epicsScanDouble ( pString, &ftmp );
+        if ( j != 1 ) {
+            j = sscanf ( pString, "%lf", &ftmp );
+            if ( j != 1 ) {
+                j = sscanf ( pString, "%x", &itmp );
+                if ( j == 1 ) {
+                    ftmp = itmp;
+                } else {
+                    return false;
+                }
             }
         }
     }


### PR DESCRIPTION
This is an alternative fix for the issue described in https://github.com/epics-modules/pcas/issues/4 and https://github.com/epics-extensions/ca-gateway/issues/37
It keeps the call to `epicsScanDouble()` before trying `sscanf()` first with `"%lf"` (ignoring extra characters) then with `"%x"` (to catch hex numbers).