### PR TITLE
Patch for RTEMS-mvme2700

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -11,14 +11,15 @@ MUNCH_SUFFIX = .boot
 define MUNCH_CMD
 	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< rtems
 	gzip -f9 rtems
-	$(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@ \
+	$(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@.elf \
 		 $(PROJECT_RELEASE)/lib/bootloader.o \
 		--just-symbols=$< \
 		-b binary rtems.gz \
-                --no-warn-mismatch \
+		--no-warn-mismatch \
 		-T $(PROJECT_RELEASE)/lib/ppcboot.lds \
 		-Map $<.map
-	rm -f rtems.gz
+	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary $@.elf $@
+	rm -f rtems.gz $@.elf
 endef
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS


### PR DESCRIPTION
When testing EPICS7 / RTEMS5 on an IOC I found a stack trace. I noticed the MVME-2700 was booting the elf formatted binary.
This patch solves the problem and it now boots fine.

```diff
diff --git a/configure/os/CONFIG.Common.RTEMS-mvme2700 b/configure/os/CONFIG.Common.RTEMS-mvme2700
index 0ee8ac862..82715277e 100644
--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -11,14 +11,15 @@ MUNCH_SUFFIX = .boot
 define MUNCH_CMD
        $(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< rtems
        gzip -f9 rtems
-       $(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@ \
+       $(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@.elf \
                 $(PROJECT_RELEASE)/lib/bootloader.o \
                --just-symbols=$< \
                -b binary rtems.gz \
-                --no-warn-mismatch \
+               --no-warn-mismatch \
                -T $(PROJECT_RELEASE)/lib/ppcboot.lds \
                -Map $<.map
-       rm -f rtems.gz
+       $(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary $@.elf $@
+       rm -f rtems.gz $@.elf
 endef
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS
```