### PR TITLE
Make sure epicsInt8 is signed on all architectures

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -16,6 +16,17 @@ should also be read to understand what has changed since earlier releases.
 
 <!-- Insert new items immediately below here ... -->
 
+### Make sure epicsInt8 is signed on all architectures
+
+So far, `epicsInt8` and thus `DBF_CHAR` used to be unsigned on architectures
+where `char` is unsigned, for example on many PPC architectures.
+This had led to different behavior between architectures when converting
+`DBF_CHAR` to signed integer or to floating point types.
+
+WARNING: This fix may change behavior of existing databases on on architectures
+with unsigned `char` (many PPC) when using input links to read from `CHAR`
+waveforms. Architectures with signed `char` (usually x86) are unaffected.
+
 ### Fix for `undefined` in configure/RELEASE files
 
 Prevents `Use of uninitialized value` warnings from convertRelease.pl.

--- a/modules/ca/src/client/comBuf.h
+++ b/modules/ca/src/client/comBuf.h
@@ -88,6 +88,7 @@ public:
     bool push ( const T & value );
     template < class T >
     unsigned push ( const T * pValue, unsigned nElem );
+    unsigned push ( const char * pValue, unsigned nElem );
     unsigned push ( const epicsInt8 * pValue, unsigned nElem );
     unsigned push ( const epicsUInt8 * pValue, unsigned nElem );
     unsigned push ( const epicsOldString * pValue, unsigned nElem );
@@ -204,6 +205,11 @@ inline unsigned comBuf :: push ( const epicsInt8 *pValue, unsigned nElem )
 }
 
 inline unsigned comBuf :: push ( const epicsUInt8 *pValue, unsigned nElem )
+{
+    return copyInBytes ( pValue, nElem );
+}
+
+inline unsigned comBuf :: push ( const char *pValue, unsigned nElem )
 {
     return copyInBytes ( pValue, nElem );
 }

--- a/modules/ca/src/client/comQueRecv.cpp
+++ b/modules/ca/src/client/comQueRecv.cpp
@@ -46,7 +46,7 @@ void comQueRecv::clear ()
     this->nBytesPending = 0u;
 }
 
-unsigned comQueRecv::copyOutBytes ( epicsInt8 *pBuf, unsigned nBytes )
+unsigned comQueRecv::copyOutBytes ( char *pBuf, unsigned nBytes )
 {
     unsigned totalBytes = 0u;
     do {

--- a/modules/ca/src/client/comQueRecv.h
+++ b/modules/ca/src/client/comQueRecv.h
@@ -33,7 +33,7 @@ public:
     comQueRecv ( comBufMemoryManager & );
     ~comQueRecv ();
     unsigned occupiedBytes () const;
-    unsigned copyOutBytes ( epicsInt8 *pBuf, unsigned nBytes );
+    unsigned copyOutBytes ( char *pBuf, unsigned nBytes );
     unsigned removeBytes ( unsigned nBytes );
     void pushLastComBufReceived ( comBuf & );
     void clear ();

--- a/modules/libcom/src/misc/epicsTypes.h
+++ b/modules/libcom/src/misc/epicsTypes.h
@@ -41,7 +41,7 @@ typedef enum {
  * These are sufficient for all our current archs
  * @{
  */
-typedef char            epicsInt8;
+typedef signed char     epicsInt8;
 typedef unsigned char   epicsUInt8;
 typedef short           epicsInt16;
 typedef unsigned short  epicsUInt16;


### PR DESCRIPTION
epicsTypes.h used to define `epicsInt8` as `char` since the very first version. Is is and has always been wrong on architectures where `char` is signed, including some of the earliest architrectures supported by EPICS (PPC on vxWorks). `epicsInt8` is supposed to be signed on all architectures.
This has led to faulty conversions from `DBF_CHAR` fields to other field types on those architectures in cases where the high bit of the char was set. It affects other software, e.g. device support and drivers, as well if they convert `epicsInt8` to signed datatypes like `int`. 

A simple test case is:
```
record(longin, "init") {
  field(VAL, "-1")
  field(PINI, "YES")
  field(FLNK, "wf")
}
record (waveform, "wf") {
  field(FTVL, "CHAR")
  field(NELM, "1")
  field(INP, "init")
  field(FLNK, "longin")
}
record (longin, "longin") {
  field(INP, "wf")
  field(FLNK, "ai")
}
record (ai, "ai") {
  field(INP, "wf")
}
```

On architectures with signed `char` (x86 by default), the records "longin" and "ai" contain the value -1. On architectures with unsigned char (e.g. by default all PPC I checked), they contain the value 255 as if the waveform had the type `UCHAR`. This is wrong. 

This fix corrects the conversion of DBF_CHAR fields to signed types.

**However, some existing databases running on affected architectures (PPC) may expect or rely on this buggy behavior!**
Those databases should be modified to use `UCHAR` waveforms.
Luckily, no standard EPICS base record type has any `DBF_CHAR` fields. Thus, only `CHAR` waveform, aai, and aao records are affected.

Totally unrelated and not fixed here is the fact that the `caget` command line tool prints `DBF_CHAR` fields (and `DBF_UCHAR` - CA makes no difference) using a cast to `char`. This results in architecture dependent habavior on the client side. Most clients are probably x86 systems, and print those fields as signed numbers, while PPC clients print them as unsigned numbers. This is unrelated to the IOC or the transport layer. Internally, CA uses `dbr_char_t`, which is unsigned, for both, `DBF_CHAR` and `DBF_UCHAR`. Thus on the majority of systems, `caget` prints wrong results, but the impact of fixing it may be huge and the CA documentation does not specify the signedness of `dbr_char_t`.