### PR TITLE
fixup MUNCH for BSPs using motorola_powerpc bootloader

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS-mvme2100
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2100
@@ -12,17 +12,31 @@ ARCH_DEP_CFLAGS += -DMY_DO_BOOTP=NULL
 ARCH_DEP_CFLAGS += -DHAVE_PPCBUG
 
 MUNCH_SUFFIX = .boot
+
+# The mvme2100 BSP (and others of the "motorola_powerpc" family
+# use a chain bootloader to relocate our executable from wherever
+# PPCBUG leaves it.  This bootloader includes our executable in
+# compressed form.
+#
+# Note that the file name "rtems.gz" is hard-coded in ppcboot.lds
+# so we create it in a sub-directory to avoid problems w/ parallel
+# make.
+#
+# Our process after creation of $< (eg. "iocfoo.elf")
+# 1. Extract executable code as "iocfoo.dir/rtems"
+# 2. Compress as "iocfoo.dir/rtems.gz"
+# 3. Link w/ bootloader to produce "iocfoo.boot" (which is an ELF executable)
 define MUNCH_CMD
-	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< rtems
-	gzip -f9 rtems
+	@$(MKDIR) $*.dir
+	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $*.dir/rtems
+	gzip -f9 $*.dir/rtems
 	$(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@ \
 		 $(PROJECT_RELEASE)/lib/bootloader.o \
 		--just-symbols=$< \
-		-b binary rtems.gz \
+		-b binary $*.dir/rtems.gz \
                 --no-warn-mismatch \
 		-T $(PROJECT_RELEASE)/lib/ppcboot.lds \
-		-Map $<.map
-	rm -f rtems.gz
+		-Map $@.map
 endef
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS

--- a/configure/os/CONFIG.Common.RTEMS-mvme2100
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2100
@@ -18,22 +18,19 @@ MUNCH_SUFFIX = .boot
 # PPCBUG leaves it.  This bootloader includes our executable in
 # compressed form.
 #
-# Note that the file name "rtems.gz" is hard-coded in ppcboot.lds
-# so we create it in a sub-directory to avoid problems w/ parallel
-# make.
-#
 # Our process after creation of $< (eg. "iocfoo.elf")
-# 1. Extract executable code as "iocfoo.dir/rtems"
-# 2. Compress as "iocfoo.dir/rtems.gz"
-# 3. Link w/ bootloader to produce "iocfoo.boot" (which is an ELF executable)
+# 1. Extract executable code as "iocfoo.app.bin"
+# 2. Compress as "iocfoo.app.bin.gz"
+# 3. Assemble iocfoo.boot.o with the verbatim contents of iocfoo.app.bin.gz
+# 4. Link w/ bootloader to produce "iocfoo.boot" (which is an ELF executable)
 define MUNCH_CMD
-	@$(MKDIR) $*.dir
-	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $*.dir/rtems
-	gzip -f9 $*.dir/rtems
+	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $*.app.bin
+	gzip -f9 $*.app.bin
+	$(COMPILE.c) -IRTEMS_GZ=$*.app.bin.gz -c ppc_bug.S -o $*.boot.o
 	$(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@ \
 		 $(PROJECT_RELEASE)/lib/bootloader.o \
 		--just-symbols=$< \
-		-b binary $*.dir/rtems.gz \
+		-b binary $*.boot.o \
                 --no-warn-mismatch \
 		-T $(PROJECT_RELEASE)/lib/ppcboot.lds \
 		-Map $@.map

--- a/configure/os/CONFIG.Common.RTEMS-mvme2100
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2100
@@ -26,7 +26,7 @@ MUNCH_SUFFIX = .boot
 define MUNCH_CMD
 	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $*.app.bin
 	gzip -f9 $*.app.bin
-	$(COMPILE.c) -IRTEMS_GZ=$*.app.bin.gz -c ppc_bug.S -o $*.boot.o
+	$(COMPILE.c) -DRTEMS_GZ=$*.app.bin.gz -c ppc_bug.S -o $*.boot.o
 	$(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@ \
 		 $(PROJECT_RELEASE)/lib/bootloader.o \
 		--just-symbols=$< \

--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -13,18 +13,19 @@ MUNCH_SUFFIX = .boot
 # cf. description in CONFIG.Common.RTEMS-mvme2100
 #
 # Our process after creation of $< (eg. "iocfoo.elf")
-# 1. Extract executable code as "iocfoo.dir/rtems"
-# 2. Compress as "iocfoo.dir/rtems.gz"
-# 3. Link w/ bootloader to produce "iocfoo.boot.elf"
-# 4. Extract as "iocfoo.boot"
+# 1. Extract executable code as "iocfoo.app.bin"
+# 2. Compress as "iocfoo.app.bin.gz"
+# 3. Assemble iocfoo.boot.o with the verbatim contents of iocfoo.app.bin.gz
+# 4. Link w/ bootloader to produce "iocfoo.boot.elf"
+# 5. Extract as "iocfoo.boot"
 define MUNCH_CMD
-	@$(MKDIR) $*.dir
-	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $*.dir/rtems
-	gzip -f9 $*.dir/rtems
+	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $*.app.bin
+	gzip -f9 $*.app.bin
+	$(COMPILE.c) -IRTEMS_GZ=$*.app.bin.gz -c ppc_bug.S -o $*.boot.o
 	$(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@.elf \
 		 $(PROJECT_RELEASE)/lib/bootloader.o \
 		--just-symbols=$< \
-		-b binary $*.dir/rtems.gz \
+		-b binary $*.boot.o \
                 --no-warn-mismatch \
 		-T $(PROJECT_RELEASE)/lib/ppcboot.lds \
 		-Map $@.map

--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -21,7 +21,7 @@ MUNCH_SUFFIX = .boot
 define MUNCH_CMD
 	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $*.app.bin
 	gzip -f9 $*.app.bin
-	$(COMPILE.c) -IRTEMS_GZ=$*.app.bin.gz -c ppc_bug.S -o $*.boot.o
+	$(COMPILE.c) -DRTEMS_GZ=$*.app.bin.gz -c ppc_bug.S -o $*.boot.o
 	$(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@.elf \
 		 $(PROJECT_RELEASE)/lib/bootloader.o \
 		--just-symbols=$< \

--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -1,6 +1,7 @@
 #
 # Author: Matt Rippa
 #
+EXE = .elf
 RTEMS_BSP = mvme2307
 RTEMS_TARGET_CPU = powerpc
 ARCH_DEP_CFLAGS += -DMY_DO_BOOTP=NULL
@@ -8,17 +9,26 @@ ARCH_DEP_CFLAGS += -DHAVE_PPCBUG
 ARCH_DEP_CFLAGS += -DNVRAM_INDIRECT
 
 MUNCH_SUFFIX = .boot
+
+# cf. description in CONFIG.Common.RTEMS-mvme2100
+#
+# Our process after creation of $< (eg. "iocfoo.elf")
+# 1. Extract executable code as "iocfoo.dir/rtems"
+# 2. Compress as "iocfoo.dir/rtems.gz"
+# 3. Link w/ bootloader to produce "iocfoo.boot.elf"
+# 4. Extract as "iocfoo.boot"
 define MUNCH_CMD
-	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< rtems
-	gzip -f9 rtems
-	$(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@ \
+	@$(MKDIR) $*.dir
+	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $*.dir/rtems
+	gzip -f9 $*.dir/rtems
+	$(RTEMS_TOOLS)/bin/$(LD_FOR_TARGET) -o $@.elf \
 		 $(PROJECT_RELEASE)/lib/bootloader.o \
 		--just-symbols=$< \
-		-b binary rtems.gz \
+		-b binary $*.dir/rtems.gz \
                 --no-warn-mismatch \
 		-T $(PROJECT_RELEASE)/lib/ppcboot.lds \
-		-Map $<.map
-	rm -f rtems.gz
+		-Map $@.map
+	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary  -S $@.elf $@
 endef
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS

--- a/modules/libcom/RTEMS/Makefile
+++ b/modules/libcom/RTEMS/Makefile
@@ -11,6 +11,8 @@ TOP = ../../..
 include $(TOP)/configure/CONFIG
 include $(TOP)/configure/CONFIG_LIBCOM_VERSION
 
+vpath %.S $(USR_VPATH) $(ALL_SRC_DIRS)
+
 # check check
 SRC_DIRS += ../$(OS_API)
 
@@ -19,6 +21,9 @@ PERL_SCRIPTS += epicsMakeMemFs.pl
 INC += epicsRtemsInitHooks.h
 INC += epicsMemFs.h
 INC += epicsNtp.h
+
+# really only needed by BSPs in the motorola_powerpc family
+INC_RTEMS += ppc_bug.S
 
 ifeq ($(RTEMS_QEMU_FIXUPS),YES)
 rtems_init_CPPFLAGS += -DQEMU_FIXUPS

--- a/modules/libcom/RTEMS/os/RTEMS/ppc_bug.S
+++ b/modules/libcom/RTEMS/os/RTEMS/ppc_bug.S
@@ -14,7 +14,7 @@
 #define STRINGIFY1(x) #x
 #define STRINGIFY(x)     STRINGIFY1(x)
 
-.section ".data"
+.section ".rodata"
 
 .global _binary_rtems_gz_start
 .global _binary_rtems_gz_end

--- a/modules/libcom/RTEMS/os/RTEMS/ppc_bug.S
+++ b/modules/libcom/RTEMS/os/RTEMS/ppc_bug.S
@@ -1,0 +1,24 @@
+/* cf. bsps/powerpc/motorola_powerpc/bootloader/head.S
+ * and bsps/powerpc/motorola_powerpc/bootloader/ppcboot.lds
+ * in the RTEMS source tree.
+ *
+ * This file provides the symbols _binary_rtems_gz_start
+ * and _binary_rtems_gz_end normally/originally intended
+ * to be created implicitly by inclusion of rtems.gz
+ * by ppcboot.lds.
+ *
+ * Depending on the hard-coded "rtems.gz" name allows
+ * problems with make -j
+ */
+
+#define STRINGIFY1(x) #x
+#define STRINGIFY(x)     STRINGIFY1(x)
+
+.section ".data"
+
+.global _binary_rtems_gz_start
+.global _binary_rtems_gz_end
+
+_binary_rtems_gz_start:
+.incbin STRINGIFY(RTEMS_GZ)
+_binary_rtems_gz_end:


### PR DESCRIPTION
Alternative to #217

For RTEMS-mvme2700, extract the bootloader+rtems.gz as "binary".  Also fix both mvme2100 and 2700 to avoid parallel linking issue w/ "rtems.gz" filename (hard-coded in bootloader linker script).