### PR TITLE
Add epicsBaseDebugLog

### DIFF
--- a/modules/libcom/src/Makefile
+++ b/modules/libcom/src/Makefile
@@ -32,6 +32,7 @@ include $(LIBCOM)/cvtFast/Makefile
 include $(LIBCOM)/cppStd/Makefile
 include $(LIBCOM)/cxxTemplates/Makefile
 include $(LIBCOM)/dbmf/Makefile
+include $(LIBCOM)/debuglog/Makefile
 include $(LIBCOM)/ellLib/Makefile
 include $(LIBCOM)/env/Makefile
 include $(LIBCOM)/error/Makefile

--- a/modules/libcom/src/debuglog/Makefile
+++ b/modules/libcom/src/debuglog/Makefile
@@ -1,0 +1,14 @@
+#*************************************************************************
+# Copyright (c) 2010 UChicago Argonne LLC, as Operator of Argonne
+#     National Laboratory.
+# EPICS BASE is distributed subject to a Software License Agreement found
+# in file LICENSE that is included with this distribution. 
+#*************************************************************************
+
+# This is a Makefile fragment, see src/libCom/Makefile.
+
+SRC_DIRS += $(LIBCOM)/debuglog
+
+INC += epicsBaseDebugLog.h
+
+Com_SRCS += epicsBaseDebugLog.c

--- a/modules/libcom/src/debuglog/epicsBaseDebugLog.c
+++ b/modules/libcom/src/debuglog/epicsBaseDebugLog.c
@@ -1,0 +1,32 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef epicsBaseDebugLogh
+#define epicsBaseDebugLogh
+
+#include  <string.h>
+#include  <epicsStdio.h>
+#include  <stdarg.h>
+#include  "epicsTime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void epicsBaseDoDebugLog(const char *format, ...)
+    {
+        va_list pVar;
+        va_start(pVar, format);
+        vfprintf(stdout, format, pVar);
+        va_end(pVar);
+        fflush(stdout);
+    }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/modules/libcom/src/debuglog/epicsBaseDebugLog.h
+++ b/modules/libcom/src/debuglog/epicsBaseDebugLog.h
@@ -1,0 +1,71 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef epicsBaseDebugLogh
+#define epicsBaseDebugLogh
+
+#include  <string.h>
+#include  <epicsStdio.h>
+#include  <stdarg.h>
+#include  "epicsTime.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void epicsBaseDoDebugLog(const char *, ...) EPICS_PRINTF_STYLE(1,2);
+    void epicsBaseDoDebugLog(const char *format, ...);
+
+    static inline const char *osiDebugStripPath(const char *file)
+    {
+        const char *ret = strrchr(file, '/');
+        if (ret) return ret + 1;
+#if (defined(CYGWIN32) || defined(_WIN32))
+        ret = strrchr(file, '\\');
+        if (ret) return ret + 1;
+#endif
+        return file;
+    }
+
+#define epicsBaseDebugLog(fmt, ...)                                  \
+    {                                                                \
+        epicsTimeStamp now;                                          \
+        char nowText[25];                                            \
+        size_t rtn;                                                  \
+        nowText[0] = 0;                                              \
+        rtn = epicsTimeGetCurrent(&now);                             \
+        if (!rtn) {                                                  \
+            epicsTimeToStrftime(nowText,sizeof(nowText),             \
+                                "%Y/%m/%d %H:%M:%S.%03f ",&now);     \
+        }                                                            \
+        epicsBaseDoDebugLog("%s %s:%-4d " fmt,                       \
+                        nowText,                                     \
+                        osiDebugStripPath(__FILE__), __LINE__,       \
+                        __VA_ARGS__);                                \
+    }
+
+#define epicsBaseDebugLogFL(fmt, fileName, lineNo, ...)              \
+    {                                                                \
+        epicsTimeStamp now;                                          \
+        char nowText[25];                                            \
+        size_t rtn;                                                  \
+        nowText[0] = 0;                                              \
+        rtn = epicsTimeGetCurrent(&now);                             \
+        if (!rtn) {                                                  \
+            epicsTimeToStrftime(nowText,sizeof(nowText),             \
+                                "%Y/%m/%d %H:%M:%S.%03f ",&now);     \
+        }                                                            \
+        epicsBaseDoDebugLog("%s " fmt,                               \
+                            nowText,                                 \
+                            osiDebugStripPath(fileName), lineNo,     \
+                            __VA_ARGS__);                            \
+    }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Add a debug print, inspired by asynPrint():
epicsBaseDebugLog("fmt", ...)

Example: A print in source code like this:
epicsBaseDebugLog ("idx=%u socket=%d revents=0x%x\n",
                    idx, (int)pPollFds[idx].fd, pPollFds[idx].revents);

will give a print like this:
2022/01/17 08:41:07.042  repeater.cpp:662 idx=1 socket=4 revents=0x1

As the printing is heavily needed in the changes in libcom for IPv6,
put the source into libcom.
But anybody linked against libcom can use it.

There are 2 versions:

  epicsBaseDebugLog(fmt, ...)
    Date, time __FILE__ and __LINE__ are inserted into the print.

   epicsBaseDebugLogFL(fmt, fileName, lineNo, ...)
    Date, and are inserted into the print.
    __FILE__ and __LINE__ are provided by the caller.