### PR TITLE
EXT link modifier

### DIFF
--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -24,6 +24,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#define EPICS_PRIVATE_API
+
 #include "alarm.h"
 #include "cantProceed.h"
 #include "cvtFast.h"

--- a/modules/database/src/ioc/db/dbLink.c
+++ b/modules/database/src/ioc/db/dbLink.c
@@ -67,6 +67,27 @@ const char * dbLinkFieldName(const struct link *plink)
     return "????";
 }
 
+const char *dbLinkSrcName(const struct link* plink)
+{
+    const char *ret = "";
+
+    if(plink->type == DB_LINK || plink->type == CA_LINK || plink->type == PV_LINK) {
+        unsigned srcMask = plink->value.pv_link.pvlMask & pvlOptSrcMask;
+
+        if(srcMask == pvlOptSrcUnDef)
+            srcMask = plink->flags & pvlOptSrcMask;
+
+        ret = " INVALID"; /* should not be possible */
+        switch(srcMask) {
+        case pvlOptSrcUnDef:ret = " UNDEF"; break; /* should also not be possible */
+        case pvlOptSrcAuto: ret = ""; break;
+        case pvlOptSrcInt:  ret = " INT"; break;
+        case pvlOptSrcExt:  ret = " EXT"; break;
+        }
+    }
+    return ret;
+}
+
 /* Special TSEL handler for PV links */
 /* FIXME: Generalize for new link types... */
 static void TSEL_modified(struct link *plink)

--- a/modules/database/src/ioc/db/dbLink.c
+++ b/modules/database/src/ioc/db/dbLink.c
@@ -89,28 +89,28 @@ static void TSEL_modified(struct link *plink)
 
 /***************************** Generic Link API *****************************/
 
-void dbInitLink(struct link *plink, short dbfType)
+long dbInitLink(struct link *plink, short dbfType)
 {
     struct dbCommon *precord = plink->precord;
 
     /* Only initialize link once */
     if (plink->flags & DBLINK_FLAG_INITIALIZED)
-        return;
+        return 0;
     else
         plink->flags |= DBLINK_FLAG_INITIALIZED;
 
     if (plink->type == CONSTANT) {
         dbConstInitLink(plink);
-        return;
+        return 0;
     }
 
     if (plink->type == JSON_LINK) {
         dbJLinkInit(plink);
-        return;
+        return 0;
     }
 
     if (plink->type != PV_LINK)
-        return;
+        return 0;
 
     if (plink == &precord->tsel)
         TSEL_modified(plink);
@@ -118,7 +118,7 @@ void dbInitLink(struct link *plink, short dbfType)
     if (!(plink->value.pv_link.pvlMask & (pvlOptCA | pvlOptCP | pvlOptCPP))) {
         /* Make it a DB link if possible */
         if (!dbDbInitLink(plink, dbfType))
-            return;
+            return 0;
     }
 
     /* Make it a CA link */
@@ -142,6 +142,8 @@ void dbInitLink(struct link *plink, short dbfType)
                 plink->value.pv_link.pvname);
         }
     }
+
+    return 0;
 }
 
 void dbAddLink(struct dbLocker *locker, struct link *plink, short dbfType,

--- a/modules/database/src/ioc/db/dbLink.c
+++ b/modules/database/src/ioc/db/dbLink.c
@@ -41,8 +41,9 @@
 #include "dbLink.h"
 #include "dbLock.h"
 #include "dbScan.h"
-#include "dbStaticLib.h"
+#include "dbStaticPvt.h"
 #include "devSup.h"
+#include "epicsString.h"
 #include "link.h"
 #include "recGbl.h"
 #include "recSup.h"
@@ -86,18 +87,67 @@ static void TSEL_modified(struct link *plink)
     }
 }
 
+typedef struct {
+    jlink j;
+} dummyLink;
+
+static
+void dummyJlifFree(jlink *ptr) {}
+
+static
+jlif dummyJlif = {
+    "dummy",
+    NULL,
+    &dummyJlifFree,
+};
+
+static
+void dummyLsetRemove(struct dbLocker *locker, struct link *plink) {}
+
+static
+int dummyLsetConnected(const struct link *plink)
+{
+    return 0;
+}
+
+static
+lset dummyLset = {
+    0,
+    1,
+    NULL,
+    &dummyLsetRemove,
+    NULL,
+    NULL,
+    NULL,
+    &dummyLsetConnected,
+};
+
+static
+dummyLink dummyL = {
+    {
+        &dummyJlif,
+        NULL,
+        0,
+        0,
+    }
+};
 
 /***************************** Generic Link API *****************************/
 
 long dbInitLink(struct link *plink, short dbfType)
 {
     struct dbCommon *precord = plink->precord;
+    unsigned srcMask;
 
     /* Only initialize link once */
-    if (plink->flags & DBLINK_FLAG_INITIALIZED)
+    if (plink->flags & DBLINK_FLAG_INITIALIZED) {
         return 0;
-    else
+    } else {
         plink->flags |= DBLINK_FLAG_INITIALIZED;
+        if((plink->flags & pvlOptSrcMask)==pvlOptSrcUnDef) {
+            plink->flags |= pvlOptSrcAuto; /* link field never set from any .db file */
+        }
+    }
 
     if (plink->type == CONSTANT) {
         dbConstInitLink(plink);
@@ -111,6 +161,60 @@ long dbInitLink(struct link *plink, short dbfType)
 
     if (plink->type != PV_LINK)
         return 0;
+    /* From this point, must change link type to something else on success or error */
+
+    srcMask = plink->value.pv_link.pvlMask & pvlOptSrcMask;
+
+    if(srcMask == pvlOptSrcUnDef) {
+        /* apply default from set("link:scope", ...) */
+        srcMask = plink->flags & pvlOptSrcMask;
+        assert(srcMask != pvlOptSrcUnDef); /* file scope is always defined */
+    }
+
+    int isLocal = dbChannelTest(plink->value.pv_link.pvname)==0;
+    if(srcMask != pvlOptSrcAuto) {
+        int allow = 1;
+
+        if(srcMask == pvlOptSrcInt && !isLocal) {
+            /* local link to non-local target */
+            DBENTRY closest;
+            const char *fldname = dbLinkFieldName(plink);
+            fprintf(stderr, "%s.%s " ERL_ERROR ": Unable to create INT link to \"" ANSI_BOLD("%s") "\".\n",
+                    precord->name, fldname, plink->value.pv_link.pvname);
+
+            dbInitEntry(pdbbase, &closest);
+            if(!dbFindRecordSimilar(&closest, plink->value.pv_link.pvname, NULL)) {
+                unsigned indent = strlen(precord->name) + strlen(fldname) + 23;
+                epicsPrintf("%*s  Did you mean \"" ANSI_BOLD("%s.%s") "\" ?\n",
+                            indent, "",
+                            closest.precnode->recordname,
+                            closest.pflddes->name);
+            }
+            dbFinishEntry(&closest);
+
+            allow = 0;
+
+        } else if(srcMask == pvlOptSrcExt && isLocal) {
+            /* external link to local target */
+            const char *fldname = dbLinkFieldName(plink);
+
+            fprintf(stderr, "%s.%s " ERL_ERROR ": Unable to create EXT link to \"" ANSI_BOLD("%s") "\".\n",
+                    precord->name, fldname, plink->value.pv_link.pvname);
+
+            allow = 0;
+        }
+
+        if(!allow) {
+            /* We must replace PV_LINK with something else to allow for correct shutdown.
+             */
+            plink->type = JSON_LINK;
+            plink->lset = &dummyLset;
+            plink->value.json.jlink = &dummyL.j;
+            plink->value.json.string = "{}";
+
+            return S_dbLib_badLink;
+        }
+    }
 
     if (plink == &precord->tsel)
         TSEL_modified(plink);
@@ -124,8 +228,6 @@ long dbInitLink(struct link *plink, short dbfType)
     /* Make it a CA link */
     if (dbfType == DBF_INLINK)
         plink->value.pv_link.pvlMask |= pvlOptInpNative;
-
-    int isLocal = dbChannelTest(plink->value.pv_link.pvname)==0;
 
     dbCaAddLinkCallbackOpt(NULL, plink, NULL, NULL, NULL, isLocal ? DBCA_CALLBACK_INIT_WAIT : 0);
     if (dbfType == DBF_FWDLINK) {

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -397,9 +397,11 @@ typedef struct lset {
  */
 DBCORE_API const char * dbLinkFieldName(const struct link *plink);
 
-DBCORE_API void dbInitLink(struct link *plink, short dbfType);
-DBCORE_API void dbAddLink(struct dbLocker *locker, struct link *plink,
-        short dbfType, dbChannel *ptarget);
+#ifdef EPICS_PRIVATE_API
+void dbInitLink(struct link *plink, short dbfType);
+void dbAddLink(struct dbLocker *locker, struct link *plink,
+               short dbfType, dbChannel *ptarget);
+#endif /* EPICS_PRIVATE_API */
 
 DBCORE_API void dbLinkOpen(struct link *plink);
 DBCORE_API void dbRemoveLink(struct dbLocker *locker, struct link *plink);

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -398,7 +398,7 @@ typedef struct lset {
 DBCORE_API const char * dbLinkFieldName(const struct link *plink);
 
 #ifdef EPICS_PRIVATE_API
-void dbInitLink(struct link *plink, short dbfType);
+long dbInitLink(struct link *plink, short dbfType);
 void dbAddLink(struct dbLocker *locker, struct link *plink,
                short dbfType, dbChannel *ptarget);
 #endif /* EPICS_PRIVATE_API */

--- a/modules/database/src/ioc/db/dbLock.c
+++ b/modules/database/src/ioc/db/dbLock.c
@@ -32,7 +32,7 @@
 #include "dbCommon.h"
 #include "dbFldTypes.h"
 #include "dbLockPvt.h"
-#include "dbStaticLib.h"
+#include "dbStaticPvt.h"
 #include "link.h"
 
 typedef struct dbScanLockNode dbScanLockNode;
@@ -927,9 +927,10 @@ long dblsr(char *recordname,int level)
                 } else if(pdbFldDes->field_type==DBF_FWDLINK) {
                     printf("\tFWDLINK");
                 }
-                printf(" %s %s",
+                printf(" %s %s%s",
                     ((plink->value.pv_link.pvlMask&pvlOptPP)?" PP":"NPP"),
-                    msstring[plink->value.pv_link.pvlMask&pvlOptMsMode]);
+                    msstring[plink->value.pv_link.pvlMask&pvlOptMsMode],
+                    dbLinkSrcName(plink));
                 printf(" %s\n",pdbAddr->precord->name);
             }
         }

--- a/modules/database/src/ioc/dbStatic/dbLex.l
+++ b/modules/database/src/ioc/dbStatic/dbLex.l
@@ -79,6 +79,7 @@ static int yyreset(void)
 "registrar"     return(tokenREGISTRAR);
 "function"      return(tokenFUNCTION);
 "variable"      return(tokenVARIABLE);
+"set"           return(tokenSET);
 
 {bareword}+ { /* unquoted string or number */
     yylval.Str = dbmfStrdup((char *) yytext);

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1519,6 +1519,29 @@ static void dbAlias(char *name, char *alias)
     dbFinishEntry(pdbEntry);
 }
 
+static void warnSetUnknown(const char *name)
+{
+    fprintf(stderr, ERL_WARNING " Unknown name in set(\"%s\", ...)\n", name);
+    dbIncludePrint();
+}
+
+static void dbSet(const char *name)
+{
+    warnSetUnknown(name);
+
+    /* clean up unused arguments */
+    while(ellCount(&tempList))
+        dbmfFree(popFirstTemp());
+}
+
+unsigned dbLinkScopeDefault(void)
+{
+    int ret = pvlOptSrcAuto;
+    if(pinputFileNow)
+        ret = pinputFileNow->linkDefLoc;
+    return ret;
+}
+
 static void dbRecordBody(void)
 {
     DBENTRY *pdbentry;

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -61,6 +61,9 @@ epicsExportAddress(int,dbQuietMacroWarnings);
 int dbRecordsAbcSorted=0;
 epicsExportAddress(int,dbRecordsAbcSorted);
 
+int dbLinkDefaultINT=0;
+epicsExportAddress(int,dbLinkDefaultINT);
+
 /*private routines */
 static void yyerrorAbort(char *str);
 static void allocTemp(void *pvoid);
@@ -110,6 +113,7 @@ typedef struct inputFile{
     const char  *filename;
     FILE        *fp;
     int         line_num;
+    unsigned linkDefLoc;
 }inputFile;
 static ELLLIST inputFileList = ELLLIST_INIT;
 
@@ -293,6 +297,7 @@ static long dbReadCOM(DBBASE **ppdbbase,const char *filename, FILE *fp,
         pinputFile->fp = fp;
         fp = NULL;
     }
+    pinputFile->linkDefLoc = dbLinkDefaultINT ? pvlOptSrcInt : pvlOptSrcAuto;
     pinputFile->line_num = 0;
     pinputFileNow = pinputFile;
     my_buffer[0] = '\0';
@@ -1527,7 +1532,26 @@ static void warnSetUnknown(const char *name)
 
 static void dbSet(const char *name)
 {
-    warnSetUnknown(name);
+    if(strcmp(name, "link:scope")==0) {
+        char* val = popFirstTemp();
+
+        if(!val || strcmp(val, "AUTO")==0) {
+            pinputFileNow->linkDefLoc = pvlOptSrcAuto;
+
+        } else if(strcmp(val, "EXT")==0) {
+            pinputFileNow->linkDefLoc = pvlOptSrcExt;
+
+        } else if(strcmp(val, "INT")==0) {
+            pinputFileNow->linkDefLoc = pvlOptSrcInt;
+
+        } else {
+            fprintf(stderr, ERL_WARNING " Invalid value in set(\"%s\", \"%s\")\n", name, val);
+        }
+        dbmfFree(val);
+
+    } else {
+        warnSetUnknown(name);
+    }
 
     /* clean up unused arguments */
     while(ellCount(&tempList))
@@ -1536,7 +1560,7 @@ static void dbSet(const char *name)
 
 unsigned dbLinkScopeDefault(void)
 {
-    int ret = pvlOptSrcAuto;
+    int ret = dbLinkDefaultINT ? pvlOptSrcInt : pvlOptSrcAuto;
     if(pinputFileNow)
         ret = pinputFileNow->linkDefLoc;
     return ret;

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -2503,6 +2503,10 @@ long dbParseLink(const char *str, short ftype, dbLinkInfo *pinfo, const char *re
         else if (strstr(pstr, "MSS")) pinfo->modifiers |= pvlOptMSS;
         else if (strstr(pstr, "MS")) pinfo->modifiers |= pvlOptMS;
 
+        if (strstr(pstr, "AUTO")) pinfo->modifiers |= pvlOptSrcAuto;
+        else if (strstr(pstr, "INT")) pinfo->modifiers |= pvlOptSrcInt;
+        else if (strstr(pstr, "EXT")) pinfo->modifiers |= pvlOptSrcExt;
+
         /* filter modifiers based on link type */
         switch(ftype) {
         case DBF_INLINK: /* accept all */ break;

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -2758,6 +2758,9 @@ long dbPutString(DBENTRY *pdbentry,const char *pstring)
                 free(plink->text);
                 plink->text = epicsStrDup(pstring);
                 dbFreeLinkInfo(&link_info);
+                /* capture default link scope */
+                plink->flags &= ~pvlOptSrcMask;
+                plink->flags |= dbLinkScopeDefault();
             } else {
                 /* assignment after init (eg. autosave restore) */
                 struct dbCommon *prec = pdbentry->precnode->precord;

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -2070,11 +2070,12 @@ char * dbGetString(DBENTRY *pdbentry)
             else if(pvlMask&pvlOptCP) ppind=3;
             else if(pvlMask&pvlOptCPP) ppind=4;
             else ppind=0;
-            dbMsgPrint(pdbentry, "%s%s%s%s",
+            dbMsgPrint(pdbentry, "%s%s%s%s%s",
                    plink->value.pv_link.pvname ? plink->value.pv_link.pvname : "",
                    (plink->flags & DBLINK_FLAG_TSELisTIME) ? ".TIME" : "",
                    ppstring[ppind],
-                   msstring[plink->value.pv_link.pvlMask&pvlOptMsMode]);
+                   msstring[plink->value.pv_link.pvlMask&pvlOptMsMode],
+                   dbLinkSrcName(plink));
             break;
         }
         case VME_IO:

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -1545,6 +1545,132 @@ long dbFreeRecords(DBBASE *pdbbase)
     return(0);
 }
 
+long dbFindRecordSimilar(DBENTRY *pdbentry, const char * const pname, double *psimilarity)
+{
+    DBENTRY result;
+    size_t      recLen;
+    const char *pfld;
+    size_t fldLen;
+    PVDENTRY    *ppvdNode;
+    double score = 0.0;
+
+    dbInitEntry(pdbentry->pdbbase, &result);
+    result.pdbbase = pdbentry->pdbbase;
+
+    /* split out record name */
+
+    pfld = strchr(pname, '.');
+    if (!pfld) { /* no field name implies .VAL */
+        recLen = strlen(pname);
+        pfld = "VAL";
+        fldLen = 3u;
+
+    } else {
+        char ch;
+
+        recLen = (size_t) (pfld - pname);
+        pfld++; /* skip past '.' */
+        fldLen = 0;
+
+        fldLen = 0;
+        if ((ch = *pfld) &&
+            (ch == '_' || isalpha(ch))) {
+            while ((ch = pfld[++fldLen]))
+                if (!(ch == '_' || isalnum(ch))) break;
+        }
+    }
+
+    /* not validating remaining pname, aka. filter expr */
+
+    ppvdNode = dbPvdFind(pdbentry->pdbbase, pname, recLen);
+    if (ppvdNode) { /* exact match on record name */
+        /* duplicate effects of dbFindRecordPart() */
+        result.precnode = ppvdNode->precnode;
+        result.precordType = ppvdNode->precordType;
+        score = 1.0;
+
+    } else { /* no match, find best fit record name */
+        DBENTRY temp;
+        double bestScore = -1.0;
+        long status;
+
+        dbCopyEntryContents(&result, &temp);
+
+        for(status = dbFirstRecordType(&temp); !status; status = dbNextRecordType(&temp)) {
+            for(status = dbFirstRecord(&temp); !status; status = dbNextRecord(&temp)) {
+                double score = epicsStrNSimilarity(pname, recLen,
+                                                   temp.precnode->recordname,
+                                                   strlen(temp.precnode->recordname));
+                if(score > bestScore) {
+                    dbFinishEntry(&result);
+                    dbCopyEntryContents(&temp, &result);
+                    bestScore = score;
+                }
+            }
+        }
+
+        dbFinishEntry(&temp);
+        score = bestScore;
+    }
+
+    if(result.precnode) { /* have record, search for field */
+
+        long status = dbFindFieldPart(&result, &pfld);
+        if(!status) { /* exact match on field */
+            /* result now updated. */
+            score = (score + 1.0)/2.0;
+
+        } else if(status==S_dbLib_fieldNotFound) { /* search for field */
+            DBENTRY temp;
+            double bestScore = -1.0;
+            long status;
+
+            dbCopyEntryContents(&result, &temp);
+
+            for(status = dbFirstField(&temp, 0); !status; status = dbNextField(&temp, 0)) {
+                double score = epicsStrNSimilarity(pfld, fldLen,
+                                                   temp.pflddes->name,
+                                                   strlen(temp.pflddes->name));
+                if(score > bestScore) {
+                    dbFinishEntry(&result);
+                    dbCopyEntryContents(&temp, &result);
+                    bestScore = score;
+                }
+            }
+
+            dbFinishEntry(&temp);
+            score = (score + bestScore)/2.0;
+
+            if(result.pflddes) {
+                pfld = result.pflddes->name;
+                /* re-search with dbFindFieldPart() to fully update result */
+                if(dbFindFieldPart(&result, &pfld))
+                    result.pflddes = NULL; /* should never happen, spoil result if it does */
+            }
+
+        } else { /* some other error? */
+            score /= 2.0;
+        }
+    }
+
+    if(psimilarity)
+        *psimilarity = score;
+
+    if(result.precnode && result.pflddes) {
+        dbFinishEntry(pdbentry);
+        memcpy(pdbentry, &result, sizeof(result));
+        return 0;
+    }
+
+    dbFinishEntry(&result);
+
+    if(!result.precnode) {
+        return S_dbLib_recNotFound;
+    } else {
+        return S_dbLib_fieldNotFound;
+    }
+}
+
 long dbFindRecordPart(DBENTRY *pdbentry, const char **ppname)
 {
     dbBase      *pdbbase = pdbentry->pdbbase;

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -125,6 +125,8 @@ void dbPvdFreeMem(DBBASE *pdbbase);
 DBCORE_API
 char** dbCompleteRecord(const char *word);
 
+unsigned dbLinkScopeDefault(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -63,7 +63,7 @@ typedef struct dbLinkInfo {
      */
     char *target;
 
-    /* for PV_LINK */
+    /* pvlOpt* modifiers for PV_LINK */
     short modifiers;
 
     /* for HW links */

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -45,6 +45,11 @@ void dbMsgPrint(
 
 void dbPutStringSuggest(DBENTRY *pdbentry, const char *pstring);
 
+/* Find closest match for PV name.  output similarity in range [0, 1]
+ */
+DBCORE_API
+long dbFindRecordSimilar(DBENTRY *pdbentry, const char *pname, double *psimilarity);
+
 DBCORE_API
 const char *dbOpenFile(DBBASE *pdbbase,const char *filename,FILE **fp);
 

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -126,6 +126,7 @@ DBCORE_API
 char** dbCompleteRecord(const char *word);
 
 unsigned dbLinkScopeDefault(void);
+const char *dbLinkSrcName(const struct link* plink);
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/dbStatic/dbYacc.y
+++ b/modules/database/src/ioc/dbStatic/dbYacc.y
@@ -28,6 +28,7 @@ static int yyAbort = 0;
 %token tokenFIELD tokenINFO tokenREGISTRAR
 %token tokenDEVICE tokenDRIVER tokenLINK tokenBREAKTABLE
 %token tokenRECORD tokenGRECORD tokenVARIABLE tokenFUNCTION
+%token tokenSET
 %token <Str> tokenSTRING tokenCDEFS
 
 %token jsonNULL jsonTRUE jsonFALSE
@@ -60,6 +61,7 @@ database_item:  include
     |   tokenRECORD record_head record_body
     |   tokenGRECORD grecord_head record_body
     |   alias
+    |   set
     ;
 
 include:    tokenINCLUDE tokenSTRING
@@ -277,6 +279,25 @@ alias: tokenALIAS '(' tokenSTRING ',' tokenSTRING ')'
     if(dbStaticDebug>2) printf("alias %s %s\n",$3,$5);
     dbAlias($3,$5); dbmfFree($3); dbmfFree($5);
 };
+
+set: tokenSET '(' tokenSTRING set_args ')'
+{
+    if(dbStaticDebug>2) printf("set(%s\n",$3);
+    dbSet($3); dbmfFree($3);
+    /* dbSet() empties tempList */
+};
+
+set_args:
+{
+    if (ellCount(&tempList))
+        yyerrorAbort("dbSet: tempList not empty");
+}
+    | set_args ',' tokenSTRING
+{
+    if(dbStaticDebug>2) printf("  %s,\n",$3);
+    allocTemp($3); /* takes ownership of $3 */
+}
+    ;
 
 json_object: '{' '}'
 {

--- a/modules/database/src/ioc/dbStatic/link.h
+++ b/modules/database/src/ioc/dbStatic/link.h
@@ -68,6 +68,23 @@ DBCORE_API extern const maplinkType pamaplinkType[LINK_NTYPES];
 #define pvlOptInpString  0x100  /*Input as string*/
 #define pvlOptOutNative  0x200  /*Output native*/
 #define pvlOptOutString  0x400  /*Output as string*/
+/* DB/CA link target mask.
+ * If unset, then the implied default (file scope) is used.
+ * - INT:  link must target local record
+ * - EXT:  link must not target local record
+ * - AUTO: link may target any PV
+ *
+ * Used in two places:
+ * - dbLink::flags
+ *   Reflects default if no modifier explicitly provided.  Will never be UnDef.
+ * - dbLink::value::pv_link::pvlMask
+ *   Flags parsed from link string.  May be UnDef.
+ */
+#define pvlOptSrcMask   0x3000
+#define pvlOptSrcUnDef  0x0000
+#define pvlOptSrcInt    0x1000
+#define pvlOptSrcExt    0x2000
+#define pvlOptSrcAuto   0x3000
 
 /* DBLINK Flag bits */
 #define DBLINK_FLAG_INITIALIZED    1 /* dbInitLink() called */

--- a/modules/database/src/ioc/dbStatic/link.h
+++ b/modules/database/src/ioc/dbStatic/link.h
@@ -73,6 +73,7 @@ DBCORE_API extern const maplinkType pamaplinkType[LINK_NTYPES];
 #define DBLINK_FLAG_INITIALIZED    1 /* dbInitLink() called */
 #define DBLINK_FLAG_TSELisTIME     2 /* Use TSEL to get timeStamp */
 #define DBLINK_FLAG_VISITED        4 /* Used in loop detection */
+/* pvlOptSrc* bits also used to indicate default from file parsing. */
 
 struct macro_link {
     char *macroStr;

--- a/modules/database/src/ioc/misc/dbCore.dbd
+++ b/modules/database/src/ioc/misc/dbCore.dbd
@@ -21,6 +21,7 @@ variable(dbRecordsAbcSorted,int)
 variable(dbBptNotMonotonic,int)
 variable(dbQuietMacroWarnings,int)
 variable(dbConvertStrict,int)
+variable(dbLinkDefaultINT,int)
 
 # PUTF/RPRO tracing; set TPRO on records to trace
 variable(dbAccessDebugPUTF,int)

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -23,6 +23,8 @@
 #include <errno.h>
 #include <limits.h>
 
+#define EPICS_PRIVATE_API
+
 #include "dbDefs.h"
 #include "ellLib.h"
 #include "envDefs.h"

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -551,11 +551,13 @@ static long doResolveLinks(dbRecordType *pdbRecordType, dbCommon *precord,
     dbFldDes **papFldDes = pdbRecordType->papFldDes;
     short *link_ind = pdbRecordType->link_ind;
     int j;
+    long ret = 0;
 
     /* For all the links in the record type... */
     for (j = 0; j < pdbRecordType->no_links; j++) {
         dbFldDes *pdbFldDes = papFldDes[link_ind[j]];
         DBLINK *plink = (DBLINK*)((char*)precord + pdbFldDes->offset);
+        long status;
 
         if (ellCount(&precord->rdes->devList) > 0 && pdbFldDes->isDevLink) {
             devSup *pdevSup = dbDTYPtoDevSup(pdbRecordType, precord->dtyp);
@@ -568,9 +570,11 @@ static long doResolveLinks(dbRecordType *pdbRecordType, dbCommon *precord,
             }
         }
 
-        dbInitLink(plink, pdbFldDes->field_type);
+        status = dbInitLink(plink, pdbFldDes->field_type);
+        if(!ret)
+            ret = status; /* latch first error */
     }
-    return 0;
+    return ret;
 }
 
 static long doInitRecord1(dbRecordType *pdbRecordType, dbCommon *precord, void *user)

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -85,7 +85,7 @@ static void initDrvSup(void);
 static void initRecSup(void);
 static void initDevSup(void);
 static void finishDevSup(void);
-static void initDatabase(void);
+static long initDatabase(void);
 static void initialProcess(void);
 static void exitDatabase(void *dummy);
 
@@ -93,9 +93,9 @@ static void exitDatabase(void *dummy);
  * Iterate through all record instances (but not aliases),
  * calling a function for each one.
  */
-typedef void (*recIterFunc)(dbRecordType *rtyp, dbCommon *prec, void *user);
+typedef long (*recIterFunc)(dbRecordType *rtyp, dbCommon *prec, void *user);
 
-static void iterateRecords(recIterFunc func, void *user);
+static long iterateRecords(recIterFunc func, void *user);
 
 int dbThreadRealtimeLock = 1;
 epicsExportAddress(int, dbThreadRealtimeLock);
@@ -155,13 +155,14 @@ static int iocBuild_1(void)
     return 0;
 }
 
-static void prepareLinks(dbRecordType *rtyp, dbCommon *prec, void *junk)
+static long prepareLinks(dbRecordType *rtyp, dbCommon *prec, void *junk)
 {
-    dbInitRecordLinks(rtyp, prec);
+    return dbInitRecordLinks(rtyp, prec);
 }
 
 static int iocBuild_2(void)
 {
+    long ret;
     initHookAnnounce(initHookAfterCaLinkInit);
 
     initDrvSup();
@@ -176,7 +177,10 @@ static int iocBuild_2(void)
     iterateRecords(prepareLinks, NULL);
 
     dbLockInitRecords(pdbbase);
-    initDatabase();
+    if((ret = initDatabase())!=0) {
+        fprintf(stderr, ERL_ERROR " iocBuild: initDatabase Failed.\n");
+        return ret;
+    }
     dbBkptInit();
     initHookAnnounce(initHookAfterInitDatabase); /* used by autosave pass 1 */
 
@@ -184,9 +188,9 @@ static int iocBuild_2(void)
     initHookAnnounce(initHookAfterFinishDevSup);
 
     scanInit();
-    if (asInit()) {
-        errlogPrintf(ERL_ERROR " iocBuild: asInit Failed.\n");
-        return -1;
+    if ((ret = asInit())!=0) {
+        fprintf(stderr, ERL_ERROR " iocBuild: asInit Failed.\n");
+        return ret;
     }
     dbProcessNotifyInit();
     epicsThreadSleep(.5);
@@ -480,9 +484,10 @@ static void finishDevSup(void)
     }
 }
 
-static void iterateRecords(recIterFunc func, void *user)
+static long iterateRecords(recIterFunc func, void *user)
 {
     dbRecordType *pdbRecordType;
+    long ret = 0;
 
     for (pdbRecordType = (dbRecordType *)ellFirst(&pdbbase->recordTypeList);
          pdbRecordType;
@@ -493,24 +498,30 @@ static void iterateRecords(recIterFunc func, void *user)
              pdbRecordNode;
              pdbRecordNode = (dbRecordNode *)ellNext(&pdbRecordNode->node)) {
             dbCommon *precord = pdbRecordNode->precord;
+            long status;
 
             if (!precord->name[0] ||
                 pdbRecordNode->flags & DBRN_FLAGS_ISALIAS)
                 continue;
 
-            func(pdbRecordType, precord, user);
+            status = func(pdbRecordType, precord, user);
+            if (!ret)
+                ret = status; /* latch first error */
         }
     }
-    return;
+    return ret;
 }
 
-static void doInitRecord0(dbRecordType *pdbRecordType, dbCommon *precord,
+static long doInitRecord0(dbRecordType *pdbRecordType, dbCommon *precord,
     void *user)
 {
     rset *prset = pdbRecordType->prset;
     devSup *pdevSup;
 
-    if (!prset) return;         /* unlikely */
+    if (!prset) {
+        fprintf(stderr, ERL_ERROR " %sRecord missing rset\n", pdbRecordType->name);
+        return S_dbLib_noRecSup;
+    }
 
     precord->rset = prset;
     precord->mlok = epicsMutexMustCreate();
@@ -529,9 +540,10 @@ static void doInitRecord0(dbRecordType *pdbRecordType, dbCommon *precord,
 
     if (prset->init_record)
         prset->init_record(precord, 0);
+    return 0;
 }
 
-static void doResolveLinks(dbRecordType *pdbRecordType, dbCommon *precord,
+static long doResolveLinks(dbRecordType *pdbRecordType, dbCommon *precord,
     void *user)
 {
     dbFldDes **papFldDes = pdbRecordType->papFldDes;
@@ -556,28 +568,37 @@ static void doResolveLinks(dbRecordType *pdbRecordType, dbCommon *precord,
 
         dbInitLink(plink, pdbFldDes->field_type);
     }
+    return 0;
 }
 
-static void doInitRecord1(dbRecordType *pdbRecordType, dbCommon *precord,
-    void *user)
+static long doInitRecord1(dbRecordType *pdbRecordType, dbCommon *precord, void *user)
 {
     rset *prset = pdbRecordType->prset;
 
-    if (!prset) return;         /* unlikely */
+    if (!prset) return S_dbLib_noRecSup; /* already printed by doInitRecord0() */
 
     if (prset->init_record)
         prset->init_record(precord, 1);
+    return 0;
 }
 
-static void initDatabase(void)
+static long initDatabase(void)
 {
+    long status, ret = 0;
     dbChannelInit();
-    iterateRecords(doInitRecord0, NULL);
-    iterateRecords(doResolveLinks, NULL);
-    iterateRecords(doInitRecord1, NULL);
-
-    epicsAtExit(exitDatabase, NULL);
-    return;
+    status = iterateRecords(doInitRecord0, NULL);
+    if (!ret)
+        ret = status; /* latch first error */
+    status = iterateRecords(doResolveLinks, NULL);
+    if (!ret)
+        ret = status;
+    status = iterateRecords(doInitRecord1, NULL);
+    if (!ret)
+        ret = status;
+    status = epicsAtExit(exitDatabase, NULL);
+    if (!ret)
+        ret = status;
+    return ret;
 }
 
 /*
@@ -590,12 +611,12 @@ typedef struct {
     epicsEnum16 pini;
 } phaseData_t;
 
-static void doRecordPini(dbRecordType *rtype, dbCommon *precord, void *user)
+static long doRecordPini(dbRecordType *rtype, dbCommon *precord, void *user)
 {
     phaseData_t *pphase = (phaseData_t *)user;
     int phas;
 
-    if (precord->pini != pphase->pini) return;
+    if (precord->pini != pphase->pini) return 0;
 
     phas = precord->phas;
     if (phas == pphase->this) {
@@ -604,6 +625,7 @@ static void doRecordPini(dbRecordType *rtype, dbCommon *precord, void *user)
         dbScanUnlock(precord);
     } else if (phas > pphase->this && phas < pphase->next)
         pphase->next = phas;
+    return 0;
 }
 
 static void piniProcess(int pini)
@@ -661,7 +683,7 @@ static void initialProcess(void)
  * set DB_LINK and CA_LINK to PV_LINK
  * Delete record scans
  */
-static void doCloseLinks(dbRecordType *pdbRecordType, dbCommon *precord,
+static long doCloseLinks(dbRecordType *pdbRecordType, dbCommon *precord,
     void *user)
 {
     devSup *pdevSup;
@@ -700,9 +722,10 @@ static void doCloseLinks(dbRecordType *pdbRecordType, dbCommon *precord,
         precord->pact = TRUE;
         dbScanUnlock(precord);
     }
+    return 0;
 }
 
-static void doFreeRecord(dbRecordType *pdbRecordType, dbCommon *precord,
+static long doFreeRecord(dbRecordType *pdbRecordType, dbCommon *precord,
     void *user)
 {
     int j;
@@ -717,6 +740,7 @@ static void doFreeRecord(dbRecordType *pdbRecordType, dbCommon *precord,
 
     epicsMutexDestroy(precord->mlok);
     free(precord->ppnr); /* may be allocated in dbNotify.c */
+    return 0;
 }
 
 int iocShutdown(void)

--- a/modules/database/test/ioc/db/Makefile
+++ b/modules/database/test/ioc/db/Makefile
@@ -54,6 +54,7 @@ dbShutdownTest_SRCS += dbShutdownTest.c
 dbShutdownTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbShutdownTest.c
 TESTS += dbShutdownTest
+TESTFILES += ../dbInitLinkTest.db
 
 TESTPROD_HOST += dbPutLinkTest
 dbPutLinkTest_SRCS += dbPutLinkTest.c

--- a/modules/database/test/ioc/db/dbInitLinkTest.db
+++ b/modules/database/test/ioc/db/dbInitLinkTest.db
@@ -1,0 +1,32 @@
+# implied default default is AUTO
+
+record(x, "il$(N)src0") {
+    # implied default is AUTO
+    field(INP, "no:such:pv")
+}
+
+# change implied default to INT
+set("link:scope", "INT")
+
+record(x, "il$(N)tgt") {}
+record(x, "il$(N)src1") {
+    field(INP, "il$(N)tgt INT")
+}
+record(x, "il$(N)src2") {
+    # implied default is INT
+    field(INP, "il$(N)tgt")
+}
+record(x, "il$(N)src3") {
+    field(INP, "il$(N)tgt AUTO")
+}
+record(x, "il$(N)src4") {
+    field(INP, "no:such:pv EXT")
+}
+
+set("link:scope", "AUTO")
+set("link:scope") # equivalent
+# implied default back to AUTO
+
+record(x, "il$(N)src5") {
+    field(INP, "no:such:pv")
+}

--- a/modules/database/test/ioc/db/dbPutLinkTest.c
+++ b/modules/database/test/ioc/db/dbPutLinkTest.c
@@ -258,6 +258,62 @@ static void testCADBSet(void)
     testdbCleanup();
 }
 
+static
+void testInitLocalLink(const char *name, unsigned fileScope, unsigned linkScope)
+{
+    dbCommon *prec = testdbRecordPtr(name);
+    DBLINK *plink = dbGetDevLink(prec);
+    if(plink->type != DB_LINK && plink->type != CA_LINK) {
+        testFail("%s not a PV link (%d)", name, plink->type);
+    } else {
+        unsigned fileActual = plink->flags & pvlOptSrcMask;
+        unsigned linkActual = plink->value.pv_link.pvlMask & pvlOptSrcMask;
+        testOk(fileScope==fileActual && linkScope==linkActual,
+               "%s link scopes file %u == %u, link %u == %u",
+               name, fileActual, fileScope, linkActual, linkScope);
+    }
+}
+
+static
+void testInitLocal()
+{
+    testDiag("testInitLocal()");
+
+    testdbReadDatabase("dbTestIoc.dbd", NULL, NULL);
+
+    dbTestIoc_registerRecordDeviceDriver(pdbbase);
+
+    testdbReadDatabase("dbInitLinkTest.db", NULL, "N=1");
+
+    eltc(0);
+    testIocInitOk();
+    eltc(1);
+
+    testdbGetFieldEqual("il1src0.INP", DBF_STRING, "no:such:pv NPP NMS");
+    testdbGetFieldEqual("il1src1.INP", DBF_STRING, "il1tgt NPP NMS INT");
+    testdbGetFieldEqual("il1src2.INP", DBF_STRING, "il1tgt NPP NMS INT");
+    testdbGetFieldEqual("il1src3.INP", DBF_STRING, "il1tgt NPP NMS");
+    testdbGetFieldEqual("il1src4.INP", DBF_STRING, "no:such:pv NPP NMS EXT");
+    testdbGetFieldEqual("il1src5.INP", DBF_STRING, "no:such:pv NPP NMS");
+
+    testInitLocalLink("il1src0", pvlOptSrcAuto, pvlOptSrcUnDef);
+    testInitLocalLink("il1src1", pvlOptSrcInt, pvlOptSrcInt );
+    testInitLocalLink("il1src2", pvlOptSrcInt, pvlOptSrcUnDef);
+    testInitLocalLink("il1src3", pvlOptSrcInt, pvlOptSrcAuto);
+    testInitLocalLink("il1src4", pvlOptSrcInt, pvlOptSrcExt);
+    testInitLocalLink("il1src5", pvlOptSrcAuto, pvlOptSrcUnDef);
+
+    /* INT not enforced for runtime changes */
+    testdbPutFieldOk("il1src1.INP", DBF_STRING, "not:a:pv");
+    testdbPutFieldOk("il1src1.INP", DBF_STRING, "not:a:pv EXT");
+    testdbPutFieldOk("il1src1.INP", DBF_STRING, "il1tgt EXT");
+    testdbPutFieldOk("il1src1.INP", DBF_STRING, "il1tgt");
+
+    testIocShutdownOk();
+
+    testdbCleanup();
+}
+
 typedef struct {
     const char * const recname;
     short ltype;
@@ -715,10 +771,11 @@ void testTSEL(void)
 
 MAIN(dbPutLinkTest)
 {
-    testPlan(354);
+    testPlan(370);
     testLinkParse();
     testLinkFailParse();
     testCADBSet();
+    testInitLocal();
     testHWInitSet();
     testHWMod();
     testLinkInitFail();

--- a/modules/database/test/ioc/db/dbStaticTest.c
+++ b/modules/database/test/ioc/db/dbStaticTest.c
@@ -12,6 +12,7 @@
 #include <dbStaticLib.h>
 #include <dbStaticPvt.h>
 #include <dbUnitTest.h>
+#include <epicsMath.h>
 #include <testMain.h>
 #include <epicsString.h>
 #include <iocsh.h>
@@ -337,6 +338,42 @@ static void testReadDatabase(const char *filename, int expectToFail)
             expectToFail ? " is expected to fail" : "");
 }
 
+static void testSimilarName(const char *input,
+                            const char *expectRec,
+                            const char *expectFld,
+                            double expectScore)
+{
+    DBENTRY ent;
+    long status;
+    double score = -2.0;
+
+    dbInitEntry(pdbbase, &ent);
+    status = dbFindRecordSimilar(&ent, input, &score);
+
+    if(status) {
+        if(!expectRec) {
+            testPass("Expected no match for '%s'", input);
+        } else {
+            testFail("No match for '%s', expected '%s.%s' with %f",
+                     input, expectRec, expectFld, expectScore);
+        }
+    } else {
+        if(!expectRec) {
+            testFail("Unexpected match '%s', found '%s.%s' with %f",
+                     input, ent.precnode->recordname,
+                     ent.pflddes->name, score);
+        } else {
+            testOk(strcmp(expectRec, ent.precnode->recordname)==0
+                   && strcmp(expectFld, ent.pflddes->name)==0
+                   && fabs(score-expectScore) < 0.001,
+                   "Mis-match '%s', found '%s.%s' with %f, expected '%s.%s' with %f",
+                   input,
+                   ent.precnode->recordname, ent.pflddes->name, score,
+                   expectRec, expectFld, expectScore);
+        }
+    }
+}
+
 void dbTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 MAIN(dbStaticTest)
@@ -345,7 +382,7 @@ MAIN(dbStaticTest)
     char *ldirDup;
     FILE *fp = NULL;
 
-    testPlan(350);
+    testPlan(358);
     testdbPrepare();
 
     testdbReadDatabase("dbTestIoc.dbd", NULL, NULL);
@@ -451,6 +488,16 @@ MAIN(dbStaticTest)
     testEntryRemoved("testdelrec11");
 
     testDbVerify("testrec");
+
+    testDiag("testSimilarName");
+    testSimilarName("testrec", "testrec", "VAL", 1.0);
+    testSimilarName("testrec.VAL", "testrec", "VAL", 1.0);
+    testSimilarName("testrec.VAL$", "testrec", "VAL", 1.0);
+    testSimilarName("testrec.CAL", "testrec", "VAL", 0.833);
+    testSimilarName("testrex.VAL", "testrec", "VAL", 0.929);
+    testSimilarName("testrex$", "testrec", "VAL", 0.875);
+    testSimilarName("testrex.", "testrec", "VAL", 0.929);
+    testSimilarName("testrex.$", "testrec", "VAL", 0.929);
 
     testIocShutdownOk();
 

--- a/modules/libcom/src/misc/epicsString.c
+++ b/modules/libcom/src/misc/epicsString.c
@@ -395,15 +395,13 @@ unsigned int epicsMemHash(const char *str, size_t length, unsigned int seed)
  * All normal integer weights are multiplied by two, with case
  * insensitive added in as one.
  */
-double epicsStrSimilarity(const char *A, const char *B)
+double epicsStrNSimilarity(const char *A, size_t lA,
+                           const char *B, size_t lB)
 {
     double ret = 0;
-    size_t lA, lB, a, b;
+    size_t a, b;
     size_t norm;
     size_t *dist0, *dist1, *stemp;
-
-    lA = strlen(A);
-    lB = strlen(B);
 
     /* max number of edits to change A into B is max(lA, lB) */
     norm = lA > lB ? lA : lB;
@@ -453,4 +451,9 @@ done:
     free(dist0);
     free(dist1);
     return ret;
+}
+
+double epicsStrSimilarity(const char *A, const char *B)
+{
+    return epicsStrNSimilarity(A, strlen(A), B, strlen(B));
 }

--- a/modules/libcom/src/misc/epicsString.h
+++ b/modules/libcom/src/misc/epicsString.h
@@ -197,6 +197,13 @@ LIBCOM_API unsigned int epicsMemHash(const char *str, size_t length,
  */
 LIBCOM_API double epicsStrSimilarity(const char *A, const char *B);
 
+/** Equivalent to epicsStrSimilarity() without nil terminated inputs.
+ *
+ *  @since EPICS UNRELEASED
+ */
+LIBCOM_API double epicsStrNSimilarity(const char *A, size_t lenA,
+                                      const char *B, size_t lenB);
+
 /** \brief DEPRECATED
  * \deprecated dbTranslateEscape is deprecated, use epicsStrnRawFromEscaped() instead
  */


### PR DESCRIPTION
A re-design of #111 which ~flips the logic.  This maps better to the use case I had in mind.  I try to remember to check to `dbcar()` frequently when editing a .db file, but often slip up.  Typos become broken links.

Adds three new link modifiers: `INT`, `AUTO`, and `EXT`.

- `AUTO` make the current default explicit.  DB and CA links may target any PV, local or remote.
- `INT` requires that a DB or CA link target a local record.
- `EXT` requires that a DB or CA link must not target a local record.  Effectively prevents DB links.

In addition to appearing explicitly as link modifiers, the implied default may be set a new .db file `set()` statement.

For example:

```
# default default is AUTO
set("link:scope","INT")

record(longin, "my:dev:sigA") {
    field(INP, "my:def:sigB CPP")
    field(TPRO, "1")
}

record(longin, "my:dev:sigB") {
    field(INP, "some:other EXT")
    field(TPRO, "1")
}

# optional, restore default for any subsequent records
set("link:scope","AUTO")
set("link:scope") # equivalent
```

![image](https://user-images.githubusercontent.com/4429215/152043270-1f0466f6-770d-44dd-b178-26c99b012da0.png)


