### PR TITLE
caservertask: Remove new local variable conf shadows...

### DIFF
--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -61,12 +61,12 @@ epicsThreadPrivateId rsrvCurrentClient;
  */
 static void req_server (void *pParm)
 {
-    rsrv_iface_config *conf = pParm;
+    rsrv_iface_config *pConf = pParm;
     SOCKET IOC_sock;
 
     taskwdInsert ( epicsThreadGetIdSelf (), NULL, NULL );
 
-    IOC_sock = conf->tcp;
+    IOC_sock = pConf->tcp;
 
     epicsEventSignal(castcp_startStopEvent);
 


### PR DESCRIPTION
There is a global variable "conf" which is hidden by a local
variable "conf" in req_server().
Since the latter is a pointer, rename it into "pConf".

Noticed by the lgtm bot.