### PR TITLE
fix failing STATIC_BUILD on linux-arm

### DIFF
--- a/configure/os/CONFIG.linux-arm.linux-arm
+++ b/configure/os/CONFIG.linux-arm.linux-arm
@@ -6,3 +6,8 @@
 
 # Include common gnu compiler definitions
 include $(CONFIG)/CONFIG.gnuCommon
+
+STATIC_LDFLAGS_YES= -Wl,-Bstatic
+STATIC_LDFLAGS_NO=
+STATIC_LDLIBS_YES= -Wl,-Bdynamic
+STATIC_LDLIBS_NO=


### PR DESCRIPTION
On linux-arm STATIC_BUILD used the `-static` flag which leads for some reason to the executables being linked against `/lib/ld.so.1` which does not exists.

Setting `STATIC_LDFLAGS_YES= -Wl,-Bstatic` in CONFIG.linux-arm.linux-arm fixed this issue for me.