### PR TITLE
fall back to EPICS_BASE/dbd/softIoc.dbd

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -159,12 +159,13 @@ static void *getLastTemp(void)
     return(ptempListNode->item);
 }
 
-const char *dbOpenFile(DBBASE *pdbbase,const char *filename,FILE **fp)
+const char *dbOpenFile(DBBASE **ppdbbase,const char *filename,FILE **fp)
 {
-    ELLLIST     *ppathList = (ELLLIST *)pdbbase->pathPvt;
+    ELLLIST     *ppathList;
     dbPathNode  *pdbPathNode;
     char        *fullfilename;
-
+    if (*ppdbbase == 0) *ppdbbase = dbAllocBase();
+    ppathList = (ELLLIST *)(*ppdbbase)->pathPvt;
     *fp = 0;
     if (!filename) return 0;
     if (!ppathList || ellCount(ppathList) == 0 ||
@@ -271,7 +272,7 @@ static long dbReadCOM(DBBASE **ppdbbase,const char *filename, FILE *fp,
         FILE *fp1 = 0;
 
         if (pinputFile->filename)
-            pinputFile->path = dbOpenFile(pdbbase, pinputFile->filename, &fp1);
+            pinputFile->path = dbOpenFile(&pdbbase, pinputFile->filename, &fp1);
         if (!pinputFile->filename || !fp1) {
             errPrintf(0, __FILE__, __LINE__,
                 "dbRead opening file %s\n",pinputFile->filename);
@@ -431,7 +432,7 @@ static void dbIncludeNew(char *filename)
 
     pinputFile = dbCalloc(1,sizeof(inputFile));
     pinputFile->filename = macEnvExpand(filename);
-    pinputFile->path = dbOpenFile(pdbbase, pinputFile->filename, &fp);
+    pinputFile->path = dbOpenFile(&pdbbase, pinputFile->filename, &fp);
     if (!fp) {
         epicsPrintf("Can't open include file \"%s\"\n", filename);
         yyerror(NULL);

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -44,7 +44,7 @@ void dbMsgPrint(DBENTRY *pdbentry, const char *fmt, ...) EPICS_PRINTF_STYLE(2,3)
 void dbPutStringSuggest(DBENTRY *pdbentry, const char *pstring);
 
 DBCORE_API
-const char *dbOpenFile(DBBASE *pdbbase,const char *filename,FILE **fp);
+const char *dbOpenFile(DBBASE **ppdbbase,const char *filename,FILE **fp);
 
 struct jlink;
 

--- a/modules/database/test/ioc/db/dbStaticTest.c
+++ b/modules/database/test/ioc/db/dbStaticTest.c
@@ -304,7 +304,7 @@ MAIN(dbStaticTest)
     testdbReadDatabase("dbTestIoc.dbd", NULL, NULL);
     dbTestIoc_registerRecordDeviceDriver(pdbbase);
     dbPath(pdbbase,"." OSI_PATH_LIST_SEPARATOR "..");
-    if(!(ldir = dbOpenFile(pdbbase, "dbStaticTest.db", &fp))) {
+    if(!(ldir = dbOpenFile(&pdbbase, "dbStaticTest.db", &fp))) {
         testAbort("Unable to read dbStaticTest.db");
     }
     if(dbReadDatabaseFP(&pdbbase, fp, NULL, NULL)) {


### PR DESCRIPTION
As discussed in #228 with @mdavidsaver, allow softIoc to fall back on EPICS_BASE/softIoc.dbd if relative path resolution fails, instead of adding yet another build flag. 