### PR TITLE
make epicsNAN and epicsINF constants really constant

### DIFF
--- a/modules/libcom/src/osi/epicsMath.cpp
+++ b/modules/libcom/src/osi/epicsMath.cpp
@@ -33,8 +33,8 @@ static float makeINF ( void )
 #endif
 
 extern "C" {
-float epicsNAN = NAN;
-float epicsINF = INFINITY;
+const float epicsNAN = NAN;
+const float epicsINF = INFINITY;
 }
 
 #ifdef _MSC_VER

--- a/modules/libcom/src/osi/os/Darwin/epicsMath.h
+++ b/modules/libcom/src/osi/os/Darwin/epicsMath.h
@@ -20,8 +20,8 @@
 extern "C" {
 #endif
 
-LIBCOM_API extern float epicsNAN;
-LIBCOM_API extern float epicsINF;
+LIBCOM_API extern const float epicsNAN;
+LIBCOM_API extern const float epicsINF;
 
 #ifdef __cplusplus
 }

--- a/modules/libcom/src/osi/os/RTEMS-score/epicsMath.h
+++ b/modules/libcom/src/osi/os/RTEMS-score/epicsMath.h
@@ -19,8 +19,8 @@
 extern "C" {
 #endif
 
-LIBCOM_API extern float epicsNAN;
-LIBCOM_API extern float epicsINF;
+LIBCOM_API extern const float epicsNAN;
+LIBCOM_API extern const float epicsINF;
 
 #ifdef __cplusplus
 }

--- a/modules/libcom/src/osi/os/WIN32/epicsMath.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsMath.h
@@ -31,8 +31,8 @@
 extern "C" {
 #endif
 
-LIBCOM_API extern float epicsNAN;
-LIBCOM_API extern float epicsINF;
+LIBCOM_API extern const float epicsNAN;
+LIBCOM_API extern const float epicsINF;
 
 #ifdef __cplusplus
 }

--- a/modules/libcom/src/osi/os/iOS/epicsMath.h
+++ b/modules/libcom/src/osi/os/iOS/epicsMath.h
@@ -18,8 +18,8 @@
 extern "C" {
 #endif
 
-LIBCOM_API extern float epicsNAN;
-LIBCOM_API extern float epicsINF;
+LIBCOM_API extern const float epicsNAN;
+LIBCOM_API extern const float epicsINF;
 
 #ifdef __cplusplus
 }

--- a/modules/libcom/src/osi/os/posix/epicsMath.h
+++ b/modules/libcom/src/osi/os/posix/epicsMath.h
@@ -35,8 +35,8 @@ extern "C" {
 #  define finite(x) isfinite((double)(x))
 #endif
 
-LIBCOM_API extern float epicsNAN;
-LIBCOM_API extern float epicsINF;
+LIBCOM_API extern const float epicsNAN;
+LIBCOM_API extern const float epicsINF;
 
 #ifdef __cplusplus
 }

--- a/modules/libcom/src/osi/os/solaris/epicsMath.h
+++ b/modules/libcom/src/osi/os/solaris/epicsMath.h
@@ -26,8 +26,8 @@
 extern "C" {
 #endif
 
-LIBCOM_API extern float epicsNAN;
-LIBCOM_API extern float epicsINF;
+LIBCOM_API extern const float epicsNAN;
+LIBCOM_API extern const float epicsINF;
 
 #ifdef __cplusplus
 }

--- a/modules/libcom/src/osi/os/vxWorks/epicsMath.h
+++ b/modules/libcom/src/osi/os/vxWorks/epicsMath.h
@@ -30,8 +30,8 @@
 extern "C" {
 #endif
 
-LIBCOM_API extern float epicsNAN;
-LIBCOM_API extern float epicsINF;
+LIBCOM_API extern const float epicsNAN;
+LIBCOM_API extern const float epicsINF;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This seems like a simple change.  But I also wonder why there constants weren't actually `const`.  Am I missing something?