### PR TITLE
calc: add FMOD

### DIFF
--- a/modules/database/src/std/rec/calcRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcRecord.dbd.pod
@@ -158,6 +158,9 @@ CEIL: Ceiling (unary)
 FLOOR: Floor (unary)
 
 =item *
+FMOD: Floating point modulo (binary)  Added in UNRELEASED
+
+=item *
 LOG: Log base 10 (unary)
 
 =item *

--- a/modules/database/src/std/rec/calcoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcoutRecord.dbd.pod
@@ -184,6 +184,9 @@ CEIL: Ceiling (unary)
 FLOOR: Floor (unary)
 
 =item *
+FMOD: Floating point modulo (binary)  Added in UNRELEASED
+
+=item *
 LOG: Log base 10 (unary)
 
 =item *

--- a/modules/libcom/src/calc/calcPerform.c
+++ b/modules/libcom/src/calc/calcPerform.c
@@ -240,6 +240,11 @@ LIBCOM_API long
             *ptop = floor(*ptop);
             break;
 
+        case FMOD:
+            top = *ptop--;
+            *ptop = fmod(*ptop, top);
+            break;
+
         case FINITE:
             nargs = *pinst++;
             top = finite(*ptop);

--- a/modules/libcom/src/calc/postfix.c
+++ b/modules/libcom/src/calc/postfix.c
@@ -104,6 +104,7 @@ static const ELEMENT operands[] = {
 {"F",           0, 0,   1,      OPERAND,        FETCH_F},
 {"FINITE",      7, 8,   0,      VARARG_OPERATOR,FINITE},
 {"FLOOR",       7, 8,   0,      UNARY_OPERATOR, FLOOR},
+{"FMOD",        7, 8,   -1,     UNARY_OPERATOR, FMOD},
 {"G",           0, 0,   1,      OPERAND,        FETCH_G},
 {"H",           0, 0,   1,      OPERAND,        FETCH_H},
 {"I",           0, 0,   1,      OPERAND,        FETCH_I},

--- a/modules/libcom/src/calc/postfixPvt.h
+++ b/modules/libcom/src/calc/postfixPvt.h
@@ -71,6 +71,7 @@ typedef enum {
     /* Numeric */
     CEIL,
     FLOOR,
+    FMOD,
     FINITE,
     ISINF,
     ISNAN,

--- a/modules/libcom/test/epicsCalcTest.cpp
+++ b/modules/libcom/test/epicsCalcTest.cpp
@@ -298,7 +298,7 @@ MAIN(epicsCalcTest)
     const double a=1.0, b=2.0, c=3.0, d=4.0, e=5.0, f=6.0,
                  g=7.0, h=8.0, i=9.0, j=10.0, k=11.0, l=12.0;
 
-    testPlan(630);
+    testPlan(635);
 
     /* LITERAL_OPERAND elements */
     testExpr(0);
@@ -370,6 +370,11 @@ MAIN(epicsCalcTest)
     testExpr(cosh(0.5));
     testExpr(exp(1.));
     testExpr(floor(1.5));
+    testExpr(fmod(1.5, 1.0));
+    testExpr(fmod(-1.5, 1.0));
+    testExpr(fmod(1.5, -1.0));
+    testExpr(fmod(-1.5, -1.0));
+    testExpr(fmod(1.5, 0.0));
 
     testExpr(finite(0.));
     testExpr(finite(Inf));


### PR DESCRIPTION
I sometimes find myself doing RF-y calculations with calc records, where I would like to have floating point modulo.  I can mostly get by with a ternary, but have been known to get this wrong on the first try.  So here is my attempt to add `FMOD(x, y)` to the calc/postfix engine.