### PR TITLE
Embedded DBD file contents in `*_registerRecordDeviceDriver.cpp`

### DIFF
--- a/configure/RULES.Db
+++ b/configure/RULES.Db
@@ -527,15 +527,15 @@ $(foreach file, $(DB_INSTALLS), $(eval $(call DB_INSTALLS_template, $(file))))
 #---------------------------------------------------------------
 # register record,device,driver support
 
-%_registerRecordDeviceDriver.cpp: $(COMMON_DIR)/%.dbd
+%_registerRecordDeviceDriver.cpp: $(COMMON_DIR)/%.dbd $(EPICS_BASE_HOST_BIN)/registerRecordDeviceDriver.pl
 	@$(RM) $@
 	$(REGISTERRECORDDEVICEDRIVER) $(REGRDDFLAGS) -o $@ $< $(basename $@) $(IOCS_APPL_TOP)
 
-%_registerRecordDeviceDriver.cpp: %.dbd
+%_registerRecordDeviceDriver.cpp: %.dbd $(EPICS_BASE_HOST_BIN)/registerRecordDeviceDriver.pl
 	@$(RM) $@
 	$(REGISTERRECORDDEVICEDRIVER) $(REGRDDFLAGS) -o $@ $< $(basename $@) $(IOCS_APPL_TOP)
 
-%_registerRecordDeviceDriver.cpp: ../%.dbd
+%_registerRecordDeviceDriver.cpp: ../%.dbd $(EPICS_BASE_HOST_BIN)/registerRecordDeviceDriver.pl
 	@$(RM) $@
 	$(REGISTERRECORDDEVICEDRIVER) $(REGRDDFLAGS) -o $@ $< $(basename $@) $(IOCS_APPL_TOP)
 

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.h
@@ -79,6 +79,10 @@ DBCORE_API long dbReadDatabase(DBBASE **ppdbbase,
  */
 DBCORE_API long dbReadDatabaseFP(DBBASE **ppdbbase,
     FILE *fp, const char *path, const char *substitutions);
+#ifdef EPICS_PRIVATE_API
+DBCORE_API long dbReadDatabaseMem(DBBASE **ppdbbase,
+                                  const char* contents, epicsUInt32 flags);
+#endif
 DBCORE_API long dbPath(DBBASE *pdbbase, const char *path);
 DBCORE_API long dbAddPath(DBBASE *pdbbase, const char *path);
 DBCORE_API char * dbGetPromptGroupNameFromKey(DBBASE *pdbbase,

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -12,6 +12,8 @@
 /* Heavily modified by Eric Norum   Date: 03MAY2000 */
 /* Adapted to C++ by Eric Norum   Date: 18DEC2000 */
 
+#define EPICS_PRIVATE_API
+
 #include <exception>
 
 #include <stddef.h>
@@ -40,6 +42,8 @@ extern "C" {
  * Global link to pdbbase
  */
 struct dbBase **iocshPpdbbase;
+
+long (*iocshDefaultDatabaseHook)(struct dbBase **);
 
 /*
  * File-local information
@@ -334,6 +338,10 @@ cvtArg (const char *filename, int lineno, char *arg, iocshArgBuf *argBuf,
     case iocshArgPdbbase:
         /* Argument must be missing or 0 or pdbbase */
         if(!arg || !*arg || (*arg == '0') || (strcmp(arg, "pdbbase") == 0)) {
+            if((!iocshPpdbbase || !*iocshPpdbbase) && iocshDefaultDatabaseHook) {
+                if((*iocshDefaultDatabaseHook)(iocshPpdbbase))
+                    return 0;
+            }
             if(!iocshPpdbbase || !*iocshPpdbbase) {
                 showError(filename, lineno, "pdbbase not present");
                 return 0;

--- a/modules/libcom/src/iocsh/iocsh.h
+++ b/modules/libcom/src/iocsh/iocsh.h
@@ -116,6 +116,13 @@ LIBCOM_API void epicsStdCall iocshEnvClear(const char *name);
 /* 'weak' link to pdbbase */
 LIBCOM_API extern struct dbBase **iocshPpdbbase;
 
+#ifdef EPICS_PRIVATE_API
+/* Hook to allow for implicit creation of a DBD just before 'pdbbase'
+ * is passed for the first time.  (eg. to an rRDD function)
+ */
+LIBCOM_API extern long (*iocshDefaultDatabaseHook)(struct dbBase **);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I'm experimenting with including the content of the `.dbd` file in the generated `*_registerRecordDeviceDriver.cpp` in a way which allows this to be used if `*_registerRecordDeviceDriver(pdbbase)` is called without a preceeding `dbReadDatabase("*.dbd")`.

My motivation is having one less file to move around, and confuse, while trying to coordinate testing by someone not so familiar with linux.

As it stands, this is a minimal demonstration of an idea.  It will only work on POSIX targets where `fmemopen()` is available.  It also adds ~500kB in size to every IOC executable.  Having such a large string constant actually crashes MSVC sometimes!  (`fatal error C1060: compiler is out of heap space`)

Compression would be the obvious way to deal with this.  Even simple gzip compacts by an order of magnitude.  Of course, this raises the issue of adding compression library(ies) as dependencies to Base.  Also, rather than `fmemopen()` or similar, a better solution would be adapt the db parser as is already done for the acf parse (cf. `asInitMem()`).