### PR TITLE
ioc template avoid passing "0"

### DIFF
--- a/modules/database/src/template/top/iocBoot/ioc/st.cmd@Cross
+++ b/modules/database/src/template/top/iocBoot/ioc/st.cmd@Cross
@@ -6,7 +6,7 @@
 #< envPaths
 
 ## Register all support components
-dbLoadDatabase("../../dbd/_APPNAME_.dbd",0,0)
+dbLoadDatabase "../../dbd/_APPNAME_.dbd"
 _CSAFEAPPNAME__registerRecordDeviceDriver(pdbbase) 
 
 ## Load record instances


### PR DESCRIPTION
A small and seemingly simple change, but high visibility...

At present `st.cmd@Cross` contains:

> dbLoadDatabase("../../dbd/_APPNAME_.dbd",0,0)

which iocsh interprets like:

> dbLoadDatabase "../../dbd/_APPNAME_.dbd" "0" "0"

The logic in `dbOpenFile(pdbbase, "my.dbd", fp)` which skips `open()`ing plain `"my.dbd"` if it doesn't contain `/` or `\` results in an extra confusing situation where only `"0/my.dbd"` is tried.  cf.

https://github.com/epics-base/epics-base/blob/e329fa3296bf587a1c2159a48da9d826f1310afc/modules/database/src/ioc/dbStatic/dbLexRoutines.c#L170-L176

(Was there ever a reason for this condition?)