### PR TITLE
cleanup epicsThreadOSD for any thread, epicsThread or otherwise

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -24,12 +24,10 @@ or indirectly calls an `epicsThread*()` function, a specific tracking struct
 is allocated.
 
 Prior to this release, on POSIX and WIN32 targets, this
-struct would not be `free()`d, resulting in a memory leak.
+allocation would not be `free()`d, resulting in a memory leak.
 
-This release fixed the leak on POSIX targets.
-
-See the associated github [issue 241](https://github.com/epics-base/epics-base/issues/241)
-for WIN32 status.
+This release fixed the leak on POSIX and WIN32 targets (excluding
+MSVC before vs2012, and the WINE runtime).
 
 ### Fix `CHECK_RELEASE = WARN`
 

--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -17,6 +17,20 @@ should also be read to understand what has changed since earlier releases.
 <!-- Insert new items immediately below here ... -->
 
 
+### Fixed leak from a non-EPICS thread
+
+On some targets, if a thread not created by `epicsThreadCreate*()` directly
+or indirectly calls an `epicsThread*()` function, a specific tracking struct
+is allocated.
+
+Prior to this release, on POSIX and WIN32 targets, this
+struct would not be `free()`d, resulting in a memory leak.
+
+This release fixed the leak on POSIX targets.
+
+See the associated github [issue 241](https://github.com/epics-base/epics-base/issues/241)
+for WIN32 status.
+
 ### Fix `CHECK_RELEASE = WARN`
 
 This now works again, it was broken in 2019 (7.0.3.1) by an errant commit.

--- a/modules/libcom/src/osi/os/RTEMS-score/osdThread.c
+++ b/modules/libcom/src/osi/os/RTEMS-score/osdThread.c
@@ -219,8 +219,7 @@ threadWrapper (rtems_task_argument arg)
  */
 void epicsThreadExitMain (void)
 {
-    cantProceed("epicsThreadExitMain() has been deprecated for lack of usage."
-                "  Please report if you see this message.");
+    cantProceed("epicsThreadExitMain() must no longer be used.\n");
 }
 
 static rtems_status_code

--- a/modules/libcom/src/osi/os/WIN32/osdThread.c
+++ b/modules/libcom/src/osi/os/WIN32/osdThread.c
@@ -260,8 +260,7 @@ static void epicsParmCleanupWIN32 ( win32ThreadParam * pParm )
  */
 LIBCOM_API void epicsStdCall epicsThreadExitMain ( void )
 {
-    cantProceed("epicsThreadExitMain() has been deprecated for lack of usage."
-                "  Please report if you see this message.");
+    cantProceed("epicsThreadExitMain() must no longer be used.\n");
 }
 
 /*

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -217,8 +217,9 @@ static epicsThreadOSD * init_threadInfo(const char *name,
     return(pthreadInfo);
 }
 
-static void free_threadInfo(epicsThreadOSD *pthreadInfo)
+static void free_threadInfo(void* raw)
 {
+    epicsThreadOSD *pthreadInfo = raw;
     int status;
 
     if(epicsAtomicDecrIntT(&pthreadInfo->refcnt) > 0) return;
@@ -354,7 +355,8 @@ static void once(void)
     checkStatusOnce(status, "pthread_atfork");
 #endif
 
-    pthread_key_create(&getpthreadInfo,0);
+    checkStatusOnceQuit(pthread_key_create(&getpthreadInfo,&free_threadInfo),
+                        "pthread_key_create","epicsThreadInit");
     status = osdPosixMutexInit(&onceLock,PTHREAD_MUTEX_DEFAULT);
     checkStatusOnceQuit(status,"osdPosixMutexInit","epicsThreadInit");
     status = osdPosixMutexInit(&listLock,PTHREAD_MUTEX_DEFAULT);
@@ -439,7 +441,6 @@ static void * start_routine(void *arg)
     (*pthreadInfo->createFunc)(pthreadInfo->createArg);
 
     epicsExitCallAtThreadExits ();
-    free_threadInfo(pthreadInfo);
     return(0);
 }
 
@@ -733,7 +734,6 @@ LIBCOM_API void epicsStdCall epicsThreadExitMain(void)
         cantProceed("epicsThreadExitMain");
     }
     else {
-    free_threadInfo(pthreadInfo);
     pthread_exit(0);
     }
 }

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -723,8 +723,7 @@ LIBCOM_API void epicsStdCall epicsThreadExitMain(void)
 
     epicsThreadInit();
 
-    cantProceed("epicsThreadExitMain() has been deprecated for lack of usage."
-                "  Please report if you see this message.");
+    cantProceed("epicsThreadExitMain() must no longer be used.\n");
 
     pthreadInfo = (epicsThreadOSD *)pthread_getspecific(getpthreadInfo);
     if(pthreadInfo==NULL)

--- a/modules/libcom/src/osi/os/vxWorks/osdThread.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdThread.c
@@ -353,8 +353,7 @@ void epicsThreadResume(epicsThreadId id)
 
 void epicsThreadExitMain(void)
 {
-    cantProceed("epicsThreadExitMain() has been deprecated for lack of usage."
-                "  Please report if you see this message.");
+    cantProceed("epicsThreadExitMain() must no longer be used.\n");
 }
 
 unsigned int epicsThreadGetPriority(epicsThreadId id)


### PR DESCRIPTION
Ensure that cleanup happens for all threads, including implicitly created.