### PR TITLE
make Perl hash iteration reproducible

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -178,5 +178,10 @@ LINKER_USE_RPATH = YES
 # All root directories are considered to be the same.
 LINKER_ORIGIN_ROOT = $(INSTALL_LOCATION)
 
+# Make Perl hash iteration reproducible.
+#  Uncomment to enable reproducible builds.
+#  See: https://reproducible-builds.org/docs/stable-outputs/
+#export PERL_HASH_SEED = 0
+
 # Overrides for the settings above may appear in a CONFIG_SITE.local file
 -include $(CONFIG)/CONFIG_SITE.local


### PR DESCRIPTION
From my limited testing, with a deterministic version header, this makes epics-base's linux-x86_64 build 100% reproducible. This also should make downstream modules much more deterministic.

---

By default Perl doesn't iterate over hashes in a reproducible manner,
to avoid DDoS. Since we aren't providing untrusted inputs, it is fine to
disable this behaviour.

Among other things, this makes the .dbd and some .h generation reproducible.

More information here:

- https://reproducible-builds.org/docs/stable-outputs/
- https://perldoc.perl.org/perlrun#PERL_HASH_SEED