### PR TITLE
Define Clang version variables for use in Makefiles

### DIFF
--- a/configure/toolchain.c
+++ b/configure/toolchain.c
@@ -23,6 +23,34 @@ CLANG_MAJOR = __clang_major__
 CLANG_MINOR = __clang_minor__
 CLANG_PATCH = __clang_patchlevel__
 
+#ifdef _COMMENT_
+/* CLANG version detection, similar scheme as used for BASE_3_15 etc.
+ * Needed to disable warnings added in later Clang versions.
+ * In a Makefile
+ *   ifdef CLANG_12
+ *     means the compiler is Clang 12.x or later,
+ *   ifeq ($(CLANG_12),1)
+ *     means the compiler is Clang 12.x.
+ * Add other versions as needed.
+ */
+#endif
+
+#if __clang_major__ >= 12
+  #if __clang_major__ == 12
+    CLANG_12 = 1
+  #else
+    CLANG_12 = 0
+    #if __clang_major__ == 13
+      CLANG_13 = 1
+    #else
+      CLANG_13 = 0
+      #if __clang_major__ == 14
+        CLANG_14 = 1
+      #endif
+    #endif
+  #endif
+#endif
+
 #elif defined(_MSC_VER)
 MSVC_VER = _MSC_VER
 #endif

--- a/modules/ca/src/perl/Makefile
+++ b/modules/ca/src/perl/Makefile
@@ -20,6 +20,11 @@ ifdef T_A
   PERLBIN := $(shell $(PERL) ../perlConfig.pl binexp)
   XSUBPP := $(firstword $(wildcard $(PERLBIN)/xsubpp $(EXTUTILS)/xsubpp))
 
+ifdef CLANG_12
+  # Turn off noisy warnings from Clang 12 or later
+  CODE_CFLAGS = -Wno-compound-token-split-by-macro
+endif
+
 # Special settings for Darwin:
 ifeq ($(OS_CLASS),Darwin)
   # Use hdepends command (not GNU compiler flags)


### PR DESCRIPTION
Disable specific warning triggered frequently by Perl's XS API.

Question: I included variables for `CLANG_13` and `CLANG_14` but I only actually need `CLANG_12`, should I leave the others out until they are actually needed? I already decided to not define the earlier version var's at all.