### PR TITLE
In-memory filesystem

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -182,7 +182,7 @@ jobs:
     - name: "apt-get install"
       run: |
         sudo apt-get update
-        sudo apt-get -y install qemu-system-x86 g++-mingw-w64-x86-64 gdb
+        sudo apt-get -y install qemu-system-x86 g++-mingw-w64-x86-64 gdb libz-dev
       if: runner.os == 'Linux'
     - name: Prepare and compile dependencies
       run: python .ci/cue.py prepare
@@ -253,7 +253,7 @@ jobs:
             dnf -y "$@" || yum -y "$@"
             return $?
         }
-        dnfyum install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple
+        dnfyum install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple zlib-devel
         git --version || dnfyum install git
         # rather than just bite the bullet and link python3 -> python,
         # people would rather just break all existing scripts...

--- a/configure/toolchain.c
+++ b/configure/toolchain.c
@@ -7,6 +7,9 @@
  * into what is really a Makefile snippet
  *
  * cf. https://sourceforge.net/p/predef/wiki/Home/
+ *
+ * clang, GCC, and newer MSVC have __has_include()
+ * which becomes standard with c++17
  */
 /* GCC preprocessor drops C comments from output.
  * MSVC preprocessor emits C comments in output
@@ -43,6 +46,12 @@ COMMANDLINE_LIBRARY ?= LIBTECLA
 COMMANDLINE_LIBRARY ?= READLINE
 #  else
 COMMANDLINE_LIBRARY ?= EPICS
+#  endif
+#  if __has_include(<zlib.h>)
+HAVE_ZLIB = YES
+PROD_SYS_LIBS += z
+LIB_SYS_LIBS += z
+EMEM_FLAGS += -z
 #  endif
 #else
 COMMANDLINE_LIBRARY ?= $(strip $(if $(wildcard $(if $(GNU_DIR),$(GNU_DIR)/include/readline/readline.h)), READLINE, EPICS))

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -11,6 +11,8 @@
 /* Author:  Marty Kraimer Date:    13JUL95*/
 
 /*The routines in this module are serially reusable NOT reentrant*/
+#define epicsStdioStdPrintfEtc
+#define epicsStdioStdStreams
 
 #include <ctype.h>
 #include <epicsStdlib.h>
@@ -21,6 +23,7 @@
 #include "dbDefs.h"
 #include "dbmf.h"
 #include "ellLib.h"
+#include "epicsStdio.h"
 #include "epicsPrint.h"
 #include "epicsString.h"
 #include "errMdef.h"
@@ -170,7 +173,7 @@ const char *dbOpenFile(DBBASE *pdbbase,const char *filename,FILE **fp)
     if (!filename) return 0;
     if (!ppathList || ellCount(ppathList) == 0 ||
         strchr(filename, '/') || strchr(filename, '\\')) {
-        *fp = fopen(filename, "r");
+        *fp = epicsFOpen(filename, "r");
         if (*fp && makeDbdDepends)
             fprintf(stdout, "%s:%s \n", makeDbdDepends, filename);
         return 0;
@@ -182,7 +185,7 @@ const char *dbOpenFile(DBBASE *pdbbase,const char *filename,FILE **fp)
         strcpy(fullfilename, pdbPathNode->directory);
         strcat(fullfilename, "/");
         strcat(fullfilename, filename);
-        *fp = fopen(fullfilename, "r");
+        *fp = epicsFOpen(fullfilename, "r");
         if (*fp && makeDbdDepends)
             fprintf(stdout, "%s:%s \n", makeDbdDepends, fullfilename);
         free((void *)fullfilename);

--- a/modules/database/src/ioc/dbtemplate/dbLoadTemplate.y
+++ b/modules/database/src/ioc/dbtemplate/dbLoadTemplate.y
@@ -13,6 +13,10 @@
 #include <stddef.h>
 #include <string.h>
 
+#define epicsStdioStdPrintfEtc
+#define epicsStdioStdStreams
+
+#include "epicsStdio.h"
 #include "osiUnistd.h"
 #include "macLib.h"
 #include "dbmf.h"
@@ -342,7 +346,7 @@ int dbLoadTemplate(const char *sub_file, const char *cmd_collect)
         return -1;
     }
 
-    fp = fopen(sub_file, "r");
+    fp = epicsFOpen(sub_file, "r");
     if (!fp) {
         fprintf(stderr, "dbLoadTemplate: error opening sub file %s\n", sub_file);
         return -1;

--- a/modules/database/src/ioc/dbtemplate/msi.cpp
+++ b/modules/database/src/ioc/dbtemplate/msi.cpp
@@ -20,6 +20,10 @@
 #include <ctype.h>
 #include <errno.h>
 
+#define epicsStdioStdPrintfEtc
+#define epicsStdioStdStreams
+
+#include <epicsStdio.h>
 #include <dbDefs.h>
 #include <macLib.h>
 #include <errlog.h>
@@ -507,14 +511,14 @@ static void inputOpenFile(inputData *pinputData, const char * const filename)
     }
     else if (pathList.empty() || strchr(filename, '/')){
         STEPS("Opening ", filename);
-        fp = fopen(filename, "r");
+        fp = epicsFOpen(filename, "r");
     }
     else {
         pathIt = pathList.begin();
         while(pathIt != pathList.end()) {
             fullname = *pathIt + "/" + filename;
             STEPS("Trying", filename);
-            fp = fopen(fullname.c_str(), "r");
+            fp = epicsFOpen(fullname.c_str(), "r");
             if (fp)
                 break;
             ++pathIt;
@@ -670,7 +674,7 @@ static void substituteOpen(subInfo **ppvt, const std::string& substitutionName)
     psubFile = new subFile;
     psubInfo->psubFile = psubFile;
 
-    fp = fopen(substitutionName.c_str(), "r");
+    fp = epicsFOpen(substitutionName.c_str(), "r");
     if (!fp) {
         fprintf(stderr, "msi: Can't open file '%s'\n", substitutionName.c_str());
         abortExit(1);

--- a/modules/database/src/std/softIoc/Makefile
+++ b/modules/database/src/std/softIoc/Makefile
@@ -22,7 +22,11 @@ softIoc_DBD += system.dbd
 
 softIoc_SRCS += softIoc_registerRecordDeviceDriver.cpp
 softIoc_SRCS_DEFAULT += softMain.cpp
+softIoc_SRCS_DEFAULT += softIoc_emem.c
 softIoc_SRCS_vxWorks = -nil-
+
+softIoc_emem_FILES += $(COMMON_DIR)/softIoc.dbd
+softIoc_emem_FILES += ../softIoc/softIocExit.db
 
 softIoc_LIBS = $(EPICS_BASE_IOC_LIBS)
 

--- a/modules/database/src/std/softIoc/RULES
+++ b/modules/database/src/std/softIoc/RULES
@@ -21,3 +21,5 @@ epicsInstallDir.h: $(TOP)/configure/CONFIG_SITE*
 	$(ECHO) "FINAL_LOCATION=$(FINAL_LOCATION)"
 	$(PERL) $(STDDIR)/softIoc/makeInstallDir.pl "$(FINAL_LOCATION)" > $@
 
+softIoc_emem.c: $(softIoc_emem_FILES) $(TOOLS)/epicsMakeMemFs.pl
+	$(PERL) $(TOOLS)/epicsMakeMemFs.pl -f imf $(EMEM_FLAGS) -T ../softIoc $@ softIoc $(softIoc_emem_FILES)

--- a/modules/libcom/RTEMS/epicsMakeMemFs.pl
+++ b/modules/libcom/RTEMS/epicsMakeMemFs.pl
@@ -2,18 +2,85 @@
 #
 
 use File::Basename;
+use File::Spec;
 use Text::Wrap;
 
 use strict;
+use warnings;
 
-my $outfile = shift;
-my $varname = shift;
+use Getopt::Std;
+$Getopt::Std::STANDARD_HELP_VERSION = 1;
 
+use Pod::Usage;
+
+=head1 NAME
+
+epicsMakeMemFs.pl - Generate C code file containing in-memory filesystem
+
+=head1 SYNOPSIS
+
+B<epicsMakeMemFs.pl> [B<-h>] [B<-z>] [B<-T> dir] [B<-P> dir] [B<-f> I<memfs> | I<imf>] output.c varname file1 file2 ...
+
+=head1 OPTIONS
+
+B<epicsMakeMemFs.pl> understands the following options:
+
+=over 4
+
+=item B<-h>
+
+Help, display this document as text.
+
+=item B<-z>
+
+Enable use of zlib compression.
+
+=item B<-T> dir
+
+Store paths relative to this directory.  (eg. "$(TOP)")
+
+=item B<-f> I<memfs> | I<imf>
+
+Selects output format.  I<memfs> is the default.
+
+=item B<-P> dir
+
+With I<imf> format, prepend directory to all files.
+
+=back
+
+=cut
+
+our ($opt_z, $opt_T, $opt_P, $opt_f, $opt_h);
+
+$opt_T = File::Spec->curdir();
+$opt_f = "memfs";
+
+sub HELP_MESSAGE {
+    pod2usage(-exitval => 2, -verbose => $opt_h ? 2 : 0);
+}
+
+HELP_MESSAGE() if !getopts('hzT:P:f:') || $opt_h || @ARGV <= 2;
+
+if($opt_z && !eval "require Compress::Zlib; 1") {
+    $opt_z = 0;
+}
+
+my $outfile = shift @ARGV;
+my $varname = shift @ARGV;
+
+# TODO: output to .tmp, then rename
 open(my $DST, '>', $outfile)
   or die "Failed to open $outfile";
 
-my $inputs = join "\n *    ", @ARGV;
-print $DST <<EOF;
+$Text::Wrap::break = ',';
+$Text::Wrap::columns = 78;
+$Text::Wrap::separator = ",\n";
+
+if($opt_f eq "memfs") { # ================ Format 1
+
+    my $inputs = join "\n *    ", @ARGV;
+    print $DST <<EOF;
 /* $outfile containing
  *    $inputs
  */
@@ -22,41 +89,37 @@ print $DST <<EOF;
 
 EOF
 
-my $N = 0;
+    my $N = 0;
 
-$Text::Wrap::break = ',';
-$Text::Wrap::columns = 78;
-$Text::Wrap::separator = ",\n";
+    for my $fname (@ARGV) {
+        my $realfname = $fname;
 
-for my $fname (@ARGV) {
-  my $realfname = $fname;
+        # strip leading "../" "./" or "/"
+        $fname =~ s(^\.{0,2}/)()g;
 
-  # strip leading "../" "./" or "/"
-  $fname =~ s(^\.{0,2}/)()g;
+        my $file = basename($fname);
+        my @dirs  = split('/', dirname($fname));
 
-  my $file = basename($fname);
-  my @dirs  = split('/', dirname($fname));
+        print $DST "/* $realfname */\n",
+            "static const char * const file_${N}_dir[] = {",
+            map("\"$_\", ", @dirs), "NULL};\n",
+            "static const char file_${N}_data[] = {\n",
+            "  ";
 
-  print $DST "/* $realfname */\n",
-    "static const char * const file_${N}_dir[] = {",
-    map("\"$_\", ", @dirs), "NULL};\n",
-    "static const char file_${N}_data[] = {\n",
-    "  ";
+        open(my $SRC, '<', $realfname)
+            or die "Failed to open $realfname";
+        binmode $SRC;
 
-  open(my $SRC, '<', $realfname)
-    or die "Failed to open $realfname";
-  binmode $SRC;
+        my ($buf, @bufs);
+        while (read($SRC, $buf, 4096)) {
+            @bufs[-1] .= ',' if @bufs;  # Need ',' between buffers
+            push @bufs, join(",", map(ord, split(//, $buf)));
+        }
+        print $DST wrap('', '  ', @bufs);
 
-  my ($buf, @bufs);
-  while (read($SRC, $buf, 4096)) {
-    @bufs[-1] .= ',' if @bufs;  # Need ',' between buffers
-    push @bufs, join(",", map(ord, split(//, $buf)));
-  }
-  print $DST wrap('', '  ', @bufs);
+        close $SRC;
 
-  close $SRC;
-
-  print $DST <<EOF;
+        print $DST <<EOF;
 
 };
 static const epicsMemFile file_${N} = {
@@ -67,19 +130,124 @@ static const epicsMemFile file_${N} = {
 };
 
 EOF
-  $N++;
-}
+        $N++;
+    }
 
-my $files = join ', ', map "&file_${_}", (0 .. $N-1);
+    my $files = join ', ', map "&file_${_}", (0 .. $N-1);
 
-print $DST <<EOF;
+    print $DST <<EOF;
 static const epicsMemFile* files[] = {
-  $files, NULL
+$files, NULL
 };
 
 static
 const epicsMemFS ${varname}_image = {&files[0]};
 const epicsMemFS * $varname = &${varname}_image;
 EOF
+
+
+} elsif($opt_f eq "imf") { # ================ Format 2
+
+    my $inputs = join "\n *    ", @ARGV;
+    print $DST <<EOF;
+/* $outfile containing
+ *    $inputs
+ */
+
+#include <epicsStdio.h>
+EOF
+    my $N = 0;
+    my (@fencode, @alens, @clens);
+
+    for my $fname (@ARGV) {
+        my $realfname = $fname;
+
+        $fname = File::Spec->canonpath($fname);
+        $fname = File::Spec->rel2abs($fname);
+        $fname = File::Spec->abs2rel($fname, $opt_T);
+
+        # attempt Windows to unix path convert
+        $fname =~ s(\\)(/)g;
+
+        # strip leading "../" "./" or "/"
+        $fname =~ s[^(\.{0,2}/)+][];
+
+        # strip leading O.Common/
+        $fname =~ s(^O\.Common/)();
+
+        if($opt_P) {
+            $fname = "${opt_P}${fname}";
+        }
+
+        open(my $SRC, '<', $realfname)
+            or die "Failed to open $realfname";
+        binmode $SRC;
+
+        read $SRC, my $actual, -s $SRC;
+
+        close $SRC;
+
+        my $actualLen = length($actual);
+
+        my $actualz;
+        if($opt_z) {
+            $actualz = Compress::Zlib::compress($actual, 9);
+        }
+
+        our ($encode, $content);
+
+        if(defined($actualz) && (length($actualz) < $actualLen)) {
+            $encode = "epicsIMFZ";
+            $content = $actualz;
+
+        } else {
+            $encode = "epicsIMFRaw";
+            $content = $actual;
+        }
+
+        my $contentLen = length($content);
+
+        $content = wrap('', '        ', join(",", map(ord, split(//, $content))));
+
+        push @fencode, $encode;
+        push @alens, $actualLen;
+        push @clens, $contentLen;
+
+        print $DST <<EOF;
+static const char file_${N}_name[] = "/$fname";
+static const char file_${N}_content[] = {
+        $content
+};
+EOF
+        $N++;
+    }
+    print $DST <<EOF;
+const epicsIMF ${varname}_imf[] = {
+EOF
+
+    $N = 0;
+    for my $fname (@ARGV) {
+
+        print $DST <<EOF;
+    {
+        file_${N}_name,
+        file_${N}_content,
+        $clens[$N],
+        $alens[$N],
+        $fencode[$N],
+        1,
+    },
+EOF
+        $N++;
+    }
+
+    print $DST <<EOF;
+    {NULL, NULL, 0, 0, epicsIMFRaw, 0}
+};
+EOF
+
+} else { # ================ Format Unsupported
+  die "Unsupported output format $opt_f";
+}
 
 close $DST;

--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -174,7 +174,7 @@ long epicsStdCall asInitFile(const char *filename,const char *substitutions)
     FILE *fp;
     long status;
 
-    fp = fopen(filename,"r");
+    fp = epicsFOpen(filename,"r");
     if(!fp) {
         errlogPrintf("asInitFile: Can't open file '%s'\n", filename);
         return(S_asLib_badConfig);

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -1000,7 +1000,7 @@ iocshBody (const char *pathname, const char *commandLine, const char *macros)
             scope.interactive = true;
         }
         else {
-            fp = fopen (pathname, "r");
+            fp = epicsFOpen (pathname, "r");
             if (fp == NULL) {
                 fprintf(epicsGetStderr(), "Can't open %s: %s\n", pathname,
                     strerror (errno));

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -10,6 +10,7 @@
 \*************************************************************************/
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "iocsh.h"
 #include "asLib.h"
@@ -124,6 +125,73 @@ static void pwdCallFunc (const iocshArgBuf *args)
         buf[sizeof(buf)-1u] = '\0';
         printf ( "%s\n", pwd );
     }
+}
+
+static const iocshArg cpArg0 = { "src",iocshArgString};
+static const iocshArg cpArg1 = { "dest",iocshArgString};
+static const iocshArg * const cpArgs[] = {&cpArg0,&cpArg1};
+static const iocshFuncDef cpFuncDef = {
+    "cp", 2, cpArgs,
+    "Copy the contents of one file.  Source may be OS, or in-memory file (\"app:///...\").\n"
+    "If provided, destination must be OS file.  If not provided, prints to stdout.\n"
+};
+
+/* provide "cat" as an alias for "cp" where destination is always (redirect) stdout. */
+static const iocshFuncDef catFuncDef = {
+    "cat", 1, cpArgs,
+    "Print the contents of one file.  May be OS, or in-memory file (\"app:///...\").\n"
+};
+
+static void cpCallFunc (const iocshArgBuf *args)
+{
+    const size_t buflen = 1024u;
+    FILE *src = NULL, *dst = NULL, *dstalloc = NULL;
+    char *buf = NULL;
+
+    if(!args[0].sval || !args[0].sval[0]) {
+        fprintf(stderr, "Usage: cp <src> [dst]\n");
+        iocshSetError(1);
+        return;
+    }
+
+    if(!args[1].sval || !args[1].sval[0]) {
+        dst = epicsGetStdout();
+    }
+
+    if(!(src = epicsFOpen(args[0].sval, "rb"))) {
+        int err = iocshSetError(errno);
+        fprintf(stderr, "%s(%d) unable to open input \"%s\"\n",
+                strerror(err), err, args[0].sval);
+
+    } else if(!dst && !(dst = dstalloc = fopen(args[1].sval, "wb"))) {
+        int err = iocshSetError(errno);
+        fprintf(stderr, "%s(%d) unable to open output \"%s\"\n",
+                strerror(err), err, args[1].sval);
+
+    } else if(!(buf = malloc(buflen))) {
+        iocshSetError(ENOMEM);
+
+    } else {
+        int ret;
+
+        do {
+            ret = fread(buf, 1, buflen, src);
+            if(ret > 0)
+                ret = fwrite(buf, 1, (size_t)ret, dst);
+
+        } while(ret > 0);
+
+        if(ret < 0) {
+            int err = iocshSetError(errno);
+            fprintf(stderr, "%s(%d) unable to copy\n", strerror(err), err);
+        }
+    }
+
+    if(src)
+        (void)fclose(src);
+    if(dstalloc)
+        (void)fclose(dstalloc);
+    free(buf);
 }
 
 /* epicsEnvSet */
@@ -480,6 +548,8 @@ void epicsStdCall libComRegister(void)
     iocshRegister(&echoFuncDef, echoCallFunc);
     iocshRegister(&chdirFuncDef, chdirCallFunc);
     iocshRegister(&pwdFuncDef, pwdCallFunc);
+    iocshRegister(&cpFuncDef, &cpCallFunc);
+    iocshRegister(&catFuncDef, &cpCallFunc); /* "cat" is an alias for "cp" */
 
     updatePWD();
 

--- a/modules/libcom/src/osi/Makefile
+++ b/modules/libcom/src/osi/Makefile
@@ -111,6 +111,12 @@ Com_SRCS += epicsReadline.c
 Com_SRCS += epicsTempFile.c
 Com_SRCS += epicsStdio.c
 Com_SRCS += osdStdio.c
+Com_SRCS += epicsMemFile.c
+Com_SRCS += osdMemFile.c
+
+ifeq (YES,$(HAVE_ZLIB))
+epicsMemFile_CFLAGS += -DIMF_HAS_ZLIB
+endif
 
 #POSIX thread priority scheduling flag
 THREAD_CPPFLAGS_NO += -DDONT_USE_POSIX_THREAD_PRIORITY_SCHEDULING

--- a/modules/libcom/src/osi/epicsMemFile.c
+++ b/modules/libcom/src/osi/epicsMemFile.c
@@ -1,0 +1,382 @@
+/*************************************************************************\
+* Copyright (c) 2022 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+#define EPICS_PRIVATE_API
+
+#include <dbDefs.h>
+#include <epicsString.h>
+#include <epicsMutex.h>
+#include <epicsThread.h>
+#include <cantProceed.h>
+#include <errlog.h>
+#include <gpHash.h>
+#include <iocsh.h>
+
+#include "epicsStdio.h"
+#include "epicsMemFilePvt.h"
+
+#ifdef IMF_HAS_ZLIB
+#  include <zlib.h>
+#endif
+
+#define IMFPREFIX "app://"
+
+typedef struct epicsIMFPvt {
+    ELLNODE node;
+    size_t nref;
+    epicsIMF imf;
+} epicsIMFPvt;
+
+typedef struct {
+    struct gphPvt* table;
+
+    epicsMutexId lock;
+    ELLLIST list;
+    unsigned iterate:1;
+} eimfs_t;
+
+static eimfs_t *eimfs;
+
+static epicsThreadOnceId eimfsOnce = EPICS_THREAD_ONCE_INIT;
+
+static
+void epicsMemInit(void* unused);
+
+void epicsIMFInc(const epicsIMF *mf)
+{
+    epicsIMFPvt *pvt = CONTAINER((epicsIMF*)mf, epicsIMFPvt, imf);
+
+    epicsMutexMustLock(eimfs->lock);
+
+    assert(pvt->nref>0u);
+    pvt->nref++;
+
+    epicsMutexUnlock(eimfs->lock);
+}
+
+void epicsIMFDec(const epicsIMF *mf)
+{
+    if(mf) {
+        size_t nref;
+        epicsIMFPvt *pvt = CONTAINER((epicsIMF*)mf, epicsIMFPvt, imf);
+
+        epicsMutexMustLock(eimfs->lock);
+
+        assert(pvt->nref > 0u);
+        nref = --pvt->nref;
+
+        epicsMutexUnlock(eimfs->lock);
+
+        if(!nref) {
+            free(pvt);
+        }
+    }
+}
+
+FILE* epicsMemOpen(const char *pathname, const char *mode)
+{
+    FILE *ret = NULL;
+    GPHENTRY *ent;
+    char c;
+    int binary = 0;
+
+    for(c=*mode++; c; c=*mode++) {
+        switch(c) {
+        case ' ':
+        case 'r':
+            break;
+        case 'b':
+            binary = 1;
+            break;
+        default:
+            errno = EINVAL;
+            return NULL;
+        }
+    }
+
+    epicsThreadOnce(&eimfsOnce, &epicsMemInit, NULL);
+
+    ent = gphFind(eimfs->table, pathname, eimfs);
+    if(ent) {
+        epicsIMFPvt *pvt = (epicsIMFPvt*)ent->userPvt;
+        ret = osdMemOpen(&pvt->imf, binary);
+
+    } else {
+        errno = ENOENT;
+    }
+    return ret;
+}
+
+/* eimfs->lock is held */
+static
+int mountFile(const epicsIMF *f, unsigned verb)
+{
+    int ret;
+    const size_t pathlen = strlen(f->path);
+    epicsIMFPvt *pvt = NULL;
+    size_t nalloc = sizeof(*pvt) + pathlen + 1u;
+    char *pbuf;
+    GPHENTRY *ent;
+
+    /* validation */
+
+    if(f->path[0]!='/' || f->path[pathlen-1u]=='/') {
+        if(verb)
+            fprintf(stderr, ERL_WARNING " path must begin, but not end, with '/' \"%s\"\n",
+                    f->path);
+        ret = EINVAL;
+        goto done;
+    }
+
+    switch(f->encoding) {
+    case epicsIMFRaw:
+    case epicsIMFZ:
+#ifndef IMF_HAS_ZLIB
+        if(verb)
+            fprintf(stderr, ERL_WARNING " zlib not available.  unusable file : \"%s\"\n",
+                    f->path);
+#endif
+        break;
+    default:
+        if(verb)
+            fprintf(stderr, ERL_WARNING " EMF unknown compression %u for \"%s\"\n",
+                    f->encoding, f->path);
+
+        /* continue, file will be unreadable */
+    }
+
+    /* allocate and populate epicsIMFPvt */
+
+    if(!f->nocopy)
+        nalloc += f->contentLen;
+
+    pvt = malloc(nalloc);
+    if(!pvt) {
+        fprintf(stderr, "Unable to allocate space for '%s'\n", f->path);
+        ret = ENOMEM;
+        goto done;
+    }
+    pvt->nref = 1u;
+
+    memcpy(&pvt->imf, f, sizeof(pvt->imf));
+
+    pbuf = (char*)pvt;
+    pbuf += sizeof(*pvt);
+    pvt->imf.path = pbuf;
+    memcpy(pbuf, f->path, pathlen+1u);
+
+    if(!f->nocopy) {
+        pbuf += pathlen+1u;
+        memcpy(pbuf, f->content, f->contentLen);
+        pvt->imf.content = pbuf;
+    }
+
+    /* silently replace existing */
+    (void)epicsMemUnmount(pvt->imf.path, 0);
+
+    if(!!(ent = gphAdd(eimfs->table, pvt->imf.path, eimfs))) {
+
+        ent->userPvt = pvt;
+        ellAdd(&eimfs->list, &pvt->node);
+        pvt->nref++;
+
+        ret = 0;
+
+    } else {
+        if(verb)
+            fprintf(stderr, ERL_WARNING " EMF not enough memory for \"%s\"\n",
+                    pvt->imf.path);
+
+        ret = ENOMEM;
+    }
+
+done:
+    epicsIMFDec(&pvt->imf);
+    return ret;
+}
+
+int epicsMemMount(const epicsIMF* files,
+                  epicsUInt64 flags)
+{
+    int ret = 0;
+    const unsigned verb = !!(flags&EPICS_MEM_MOUNT_VERBOSE);
+    size_t n;
+
+    if(flags&0xfe00)
+        return ENOTSUP;
+
+    epicsThreadOnce(&eimfsOnce, &epicsMemInit, NULL);
+
+    epicsMutexMustLock(eimfs->lock);
+
+    if(eimfs->iterate) {
+        ret = EPERM;
+
+    } else {
+        for(n=0u; files[n].path && !ret; n++) {
+            ret = mountFile(&files[n], verb);
+        }
+    }
+
+    epicsMutexUnlock(eimfs->lock);
+
+    return ret;
+}
+
+int epicsMemUnmount(const char *path, epicsUInt64 flags)
+{
+    int ret;
+    GPHENTRY *ent = NULL;
+
+    if(flags&0xffff)
+        return ENOTSUP;
+
+    epicsThreadOnce(&eimfsOnce, &epicsMemInit, NULL);
+
+    epicsMutexMustLock(eimfs->lock);
+
+    if(eimfs->iterate) {
+        ret = EPERM;
+
+    } else {
+        ent = gphFind(eimfs->table, path, eimfs);
+    }
+
+    if(ent) {
+        epicsIMFPvt *prev = ent->userPvt;
+        ent->userPvt = NULL;
+
+        gphDelete(eimfs->table, prev->imf.path, eimfs);
+        ellDelete(&eimfs->list, &prev->node);
+        epicsIMFDec(&prev->imf);
+        ret = 0;
+
+    } else {
+        ret = ENOENT;
+    }
+
+    epicsMutexUnlock(eimfs->lock);
+
+    return ret;
+}
+
+
+void epicsMemFileForEach(void (*func)(void *arg, const epicsIMF* mf),
+                         void *arg)
+{
+    ELLNODE *cur;
+    epicsThreadOnce(&eimfsOnce, &epicsMemInit, NULL);
+
+    epicsMutexMustLock(eimfs->lock);
+
+    eimfs->iterate = 1;
+
+    for(cur = ellFirst(&eimfs->list); cur; cur = ellNext(cur)) {
+        epicsIMFPvt* pvt = CONTAINER(cur, epicsIMFPvt, node);
+
+        (*func)(arg, &pvt->imf);
+    }
+
+    eimfs->iterate = 0;
+
+    epicsMutexUnlock(eimfs->lock);
+}
+
+FILE* epicsFOpen(const char *pathname, const char *mode)
+{
+    if(strncmp(IMFPREFIX, pathname, sizeof(IMFPREFIX)-1)==0) {
+        pathname += sizeof(IMFPREFIX)-1u;
+        return epicsMemOpen(pathname, mode);
+
+    } else {
+        return fopen(pathname, mode);
+    }
+}
+
+/* cf. https://www.zlib.net/manual.html
+ */
+int osiUncompressZ(const char* inbuf, size_t inlen, char *outbuf, size_t outlen)
+{
+#ifdef IMF_HAS_ZLIB
+    uLongf dst = outlen;
+    int err = uncompress((Bytef*)outbuf, &dst, (const Bytef*)inbuf, inlen);
+    if(err!=Z_OK) {
+        switch(err) {
+        case Z_MEM_ERROR: err = ENOMEM; break; /* alloc error */
+        case Z_BUF_ERROR: err = ENOMEM; break; /* outlen was wrong */
+        case Z_DATA_ERROR: err = EIO; break; /* corrupt */
+        case Z_ERRNO: break;
+        default: err = EIO;
+        }
+        free(outbuf);
+        outbuf = NULL;
+    }
+
+    return err;
+#else
+    return EIO;
+#endif /* IMF_HAS_ZLIB */
+}
+
+static
+void showMemFile(void *unused, const epicsIMF* mf)
+{
+    const epicsIMFPvt *pvt = CONTAINER(mf, epicsIMFPvt, imf);
+    char mode[4];
+
+    mode[0] = 'R';
+    mode[3] = '\0';
+
+    switch(mf->encoding) {
+    case epicsIMFRaw: mode[1] = 'R'; break;
+#ifdef IMF_HAS_ZLIB
+    case epicsIMFZ: mode[1] = 'Z'; break;
+#else
+    case epicsIMFZ: mode[1] = 'z'; break;
+#endif
+    default: mode[1] = '?';
+    }
+
+    mode[2] = mf->nocopy ? ' ' : 'A';
+
+    epicsStdoutPrintf("%s %u %lu " IMFPREFIX "%s\n", mode,
+                      (unsigned)pvt->nref, (unsigned long)mf->actualLen,
+                      mf->path);
+}
+
+void epicsMemFileShow(void)
+{
+#ifndef IMF_HAS_ZLIB
+    printf("# Compression not supported\n");
+#endif
+    epicsMemFileForEach(&showMemFile, NULL);
+}
+
+static const iocshFuncDef epicsMemFileShowFuncDef = {
+    "epicsMemFileShow", 0, 0,
+    "List currently mounted in-memory files\n"
+};
+
+static void epicsMemFileShowCallFunc (const iocshArgBuf *args)
+{
+    epicsMemFileShow();
+}
+
+static
+void epicsMemInit(void* unused)
+{
+    (void)unused;
+    eimfs = callocMustSucceed(1, sizeof(*eimfs), "eimfs");
+    eimfs->lock = epicsMutexMustCreate();
+    gphInitPvt(&eimfs->table, 32u);
+    ellInit(&eimfs->list);
+    iocshRegister(&epicsMemFileShowFuncDef, &epicsMemFileShowCallFunc);
+}

--- a/modules/libcom/src/osi/epicsMemFilePvt.h
+++ b/modules/libcom/src/osi/epicsMemFilePvt.h
@@ -1,0 +1,40 @@
+/*************************************************************************\
+* Copyright (c) 2022 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+#ifndef EPICSMEMFILEPVT_H
+#define EPICSMEMFILEPVT_H
+
+#include <ellLib.h>
+
+#include "epicsStdio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* For use by osdMemOpen() implementations to ensure that epicsIMF* remains
+ * valid if epicsMemUnmount() called before fclose()
+ */
+void epicsIMFInc(const epicsIMF *mf);
+void epicsIMFDec(const epicsIMF *mf);
+
+/* Called by epicsMemOpen(), should set errno when returning NULL.
+ * "!binary" is text mode.
+ */
+FILE* osdMemOpen(const epicsIMF* file, int binary);
+
+/* Uncompress into pre-allocated buffer.
+ * Caller must already know uncompressed size.
+ * Return zero on success
+ */
+int osiUncompressZ(const char* inbuf, size_t inlen,
+                   char* outbuf, size_t outlen);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // EPICSMEMFILEPVT_H

--- a/modules/libcom/src/osi/os/WIN32/osdMemFile.c
+++ b/modules/libcom/src/osi/os/WIN32/osdMemFile.c
@@ -1,0 +1,121 @@
+/*************************************************************************\
+* Copyright (c) 2022 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#define VC_EXTRALEAN
+#include <windows.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <io.h>
+
+#include "epicsStdio.h"
+#include "epicsString.h"
+#include "epicsMemFilePvt.h"
+
+#ifndef _WIN32
+// help qtcreator
+typedef unsigned long DWORD;
+typedef unsigned UINT;
+#define MAX_PATH (128u)
+#define O_TEMPORARY (0u)
+
+DWORD GetLastError(void);
+DWORD GetTempPath(DWORD, char*);
+UINT GetTempFileName(const char*, const char*, UINT, char*);
+#endif
+
+FILE* osdMemOpen(const epicsIMF* file, int binary)
+{
+    FILE* ret = NULL;
+    DWORD tmpdirlen = GetTempPath(0, NULL);
+    size_t tmpalloc;
+    char* tmp = NULL;
+    char* actualalloc = NULL;
+
+    if(!tmpdirlen) {
+        errno = EINVAL;
+        goto done;
+    }
+
+    /* eg. "C:\Temp\" "emf" + "XXXXXXXX" + ".tmp" + '\0'
+     */
+    tmpalloc = tmpdirlen + 3 + 8 + 4 + 1;
+    tmp = malloc(tmpalloc);
+    if(!tmp) {
+        errno = ENOMEM;
+        goto done;
+    }
+
+    tmpdirlen = GetTempPath(tmpdirlen, tmp);
+    if(!tmpdirlen) {
+        errno = GetLastError();
+        goto done;
+    }
+
+    while(1) {
+        int r = rand();
+        int fd;
+        int n = -1;
+        const char* actual = NULL;
+
+        epicsSnprintf(tmp+tmpdirlen,
+                      tmpalloc-tmpdirlen-1u,
+                      "emf%08x.tmp",
+                      r);
+
+        fd = open(tmp,
+                  O_CREAT | O_EXCL | O_TEMPORARY | O_RDWR | (binary ? O_BINARY : O_TEXT),
+                  _S_IREAD | _S_IWRITE);
+        if(fd==-1) {
+            if(errno==EEXIST)
+                continue; /* re-try with a different name */
+            else
+                break;
+        }
+
+        switch(file->encoding) {
+        case epicsIMFRaw:
+            actual = file->content;
+            break;
+        case epicsIMFZ:
+            actual = actualalloc = malloc(file->actualLen);
+            if(actualalloc) {
+                if(!!(errno = osiUncompressZ(file->content,
+                                             file->contentLen,
+                                             actualalloc,
+                                             file->actualLen))) {
+                    free(actualalloc);
+                    actual = actualalloc = NULL;
+                }
+            }
+
+        default:
+            errno = EIO;
+        }
+
+        if(actual) {
+            n = write(fd, actual, file->actualLen);
+        }
+
+        if(n!=file->actualLen
+           || lseek(fd, 0, SEEK_SET)
+           || !(ret = fdopen(fd, binary ? "rb" : "r"))) {
+            close(fd);
+        }
+        break;
+    }
+
+done:
+    free(tmp);
+    free((char*)actualalloc);
+    return ret;
+}

--- a/modules/libcom/src/osi/os/default/osdMemFile.c
+++ b/modules/libcom/src/osi/os/default/osdMemFile.c
@@ -1,0 +1,19 @@
+/*************************************************************************\
+* Copyright (c) 2022 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include <errno.h>
+
+#include "epicsStdio.h"
+#include "epicsMemFilePvt.h"
+
+FILE* osdMemOpen(const epicsIMF* file, int binary)
+{
+    (void)file;
+    (void)binary;
+    errno = ENOTSUP;
+    return NULL;
+}

--- a/modules/libcom/src/osi/os/posix/osdMemFile.c
+++ b/modules/libcom/src/osi/os/posix/osdMemFile.c
@@ -1,0 +1,140 @@
+/*************************************************************************\
+* Copyright (c) 2022 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#if defined(__linux__)
+#  ifndef _GNU_SOURCE
+#    define _GNU_SOURCE
+#  endif
+#  define USE_FOPENCOOKIE
+
+#else
+/* freebsd, OSX, RTEMS */
+#  define USE_FUNOPEN
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "epicsStdio.h"
+#include "epicsMemFilePvt.h"
+
+#if defined(USE_FOPENCOOKIE)
+typedef size_t loc_t;
+typedef ssize_t sloc_t;
+typedef cookie_io_functions_t io_functions_t;
+
+#define xfopen(COOKIE, FUNCS) fopencookie(COOKIE, "r", FUNCS)
+
+#elif defined(USE_FUNOPEN)
+typedef fpos_t seek_off_t;
+typedef int loc_t;
+typedef int sloc_t;
+
+typedef struct {
+    int (*close)(void *raw);
+    int (*read)(void *raw, char* buf, loc_t cnt);
+} io_functions_t;
+
+#define xfopen(COOKIE, FUNCS) funopen(COOKIE, (FUNCS).read, NULL, NULL, (FUNCS).close)
+#endif
+
+typedef struct {
+    const epicsIMF* mf;
+    size_t pos;
+    const char* actual;
+} mfCookie;
+
+static
+int mfClose(void *raw)
+{
+    mfCookie *c = (mfCookie*)raw;
+
+    epicsIMFDec(c->mf);
+    free(c);
+
+    return 0;
+}
+
+static
+sloc_t mfRead(void *raw, char* buf, loc_t cnt)
+{
+    mfCookie *c = (mfCookie*)raw;
+    size_t remaining = c->mf->actualLen - c->pos;
+
+    if(cnt > remaining)
+        cnt = remaining;
+
+    memcpy(buf, c->actual + c->pos, cnt);
+    c->pos += cnt;
+
+    return cnt;
+}
+
+static
+const io_functions_t mf = {
+    .close = mfClose,
+    .read = mfRead,
+};
+
+FILE* osdMemOpen(const epicsIMF* file, int binary)
+{
+    FILE* ret = NULL;
+    mfCookie *c;
+    size_t asize = sizeof(*c);
+
+    (void)binary; /* no relevant on *NIX */
+
+    if(file->encoding == epicsIMFZ)
+        asize += file->actualLen;
+
+    c = calloc(1, asize);
+
+    if(!c) {
+        errno = ENOMEM;
+
+    } else {
+        const io_functions_t *pio = NULL;
+        char *buf;
+
+        c->mf = file;
+
+        switch (file->encoding) {
+        case epicsIMFRaw:
+            pio = &mf;
+            c->actual = c->mf->content;
+            break;
+        case epicsIMFZ:
+            buf = (char*)&c[1];
+            if(!osiUncompressZ(c->mf->content,
+                              c->mf->contentLen,
+                              buf,
+                              c->mf->actualLen))
+            {
+                c->actual = buf;
+                pio = &mf;
+
+            } else {
+                errno = EIO;
+            }
+            break;
+        default:
+            errno = EIO;
+        }
+
+        if(pio)
+            ret = xfopen(c, *pio);
+    }
+
+    if(ret) {
+        epicsIMFInc(file);
+
+    } else {
+        free(c);
+    }
+    return ret;
+}

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -251,6 +251,14 @@ osiSockTest_SRCS += osiSockTest.c
 testHarness_SRCS += osiSockTest.c
 TESTS += osiSockTest
 
+TESTPROD_HOST += epicsMemFileTest
+epicsMemFileTest_SRCS += epicsMemFileTest.cpp
+ifeq (YES,$(HAVE_ZLIB))
+epicsMemFileTest_CXXFLAGS += -DIMF_HAS_ZLIB
+endif
+testHarness_SRCS += epicsMemFileTest.cpp
+TESTS += epicsMemFileTest
+
 TESTPROD_HOST += testexecname
 testexecname_SRCS += testexecname.c
 # no point in including in testHarness.  Not implemented for RTEMS/vxWorks.

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -275,8 +275,9 @@ endif
 
 TESTPROD_HOST += iocshTest
 iocshTest_SRCS += iocshTest.cpp
+iocshTest_SRCS += iocshTest_emem.c
+iocshTest_FILES = $(wildcard ../iocshTest*.cmd)
 TESTS += iocshTest
-TESTFILES += $(wildcard ../iocshTest*.cmd)
 
 TESTPROD_HOST += epicsLoadTest
 epicsLoadTest_SRCS += epicsLoadTest.cpp
@@ -348,8 +349,8 @@ endif
 
 include $(TOP)/configure/RULES
 
-rtemsTestData.c : $(TESTFILES) $(TOOLS)/epicsMakeMemFs.pl
-	$(PERL) $(TOOLS)/epicsMakeMemFs.pl $@ epicsRtemsFSImage $(TESTFILES)
+iocshTest_emem.c: $(iocshTest_FILES) $(TOOLS)/epicsMakeMemFs.pl
+	$(PERL) $(TOOLS)/epicsMakeMemFs.pl -f imf $(EMEM_FLAGS) $@ iocshTest $(iocshTest_FILES)
 
 epicsLoadTest$(DEP): epicsInstallDir.h
 

--- a/modules/libcom/test/epicsMemFileTest.cpp
+++ b/modules/libcom/test/epicsMemFileTest.cpp
@@ -1,0 +1,178 @@
+/*************************************************************************\
+* Copyright (c) 2022 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include <vector>
+#include <string>
+
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+
+#define EPICS_PRIVATE_API
+
+#include <testMain.h>
+#include <epicsUnitTest.h>
+
+#include <dbDefs.h>
+#include <epicsStdio.h>
+#include <epicsString.h>
+
+namespace {
+
+std::string escape(const char* buf, size_t len)
+{
+    size_t elen = epicsStrnEscapedFromRawSize(buf, len);
+
+    std::vector<char> ebuf(elen+1u);
+
+    epicsStrnEscapedFromRaw(&ebuf[0], ebuf.size(),
+                            buf, len);
+
+    return std::string(ebuf.begin(), ebuf.end());
+}
+
+#define STR(S) S, sizeof(S)-1
+#define STR2(S) S, sizeof(S)-1, sizeof(S)-1
+#define CSTR(A, C) C, sizeof(C)-1, sizeof(A)-1
+
+const epicsIMF testFiles[] = {
+    {
+        "/db/blah.txt",
+        STR2("this is a test\n"),
+        epicsIMFRaw,
+        1,
+    },
+    {
+        "/some.bin",
+        STR2("\xde\xad\0\xbe\xef"),
+        epicsIMFRaw,
+        1,
+    },
+    {
+        "/test.txt.z",
+        CSTR("this is a test!",
+             "x\xda+\xc9\xc8,V\x00\xa2" "D\x85\x92\xd4\xe2\x12" "E\x00+j\x05" "7"),
+        /* an example of why compression is not always a benefit... */
+        epicsIMFZ,
+        1,
+    },
+    {NULL, NULL, 0, 0, epicsIMFRaw, 0}
+};
+
+void testMount()
+{
+    testDiag("testMount()");
+
+    int ret = epicsMemMount(testFiles,
+                            EPICS_MEM_MOUNT_VERBOSE);
+
+    testOk(!ret, "testMount %d", ret);
+}
+
+void testDynMount()
+{
+    epicsIMF hello[] = {
+        {
+        "/hello.txt",
+        NULL, 0, 0,
+        epicsIMFRaw,
+        0,
+        },
+        {NULL, NULL, 0, 0, epicsIMFRaw, 0}
+    };
+    char* str = epicsStrDup("hello world");
+
+    hello[0].content = str;
+    hello[0].contentLen = hello[0].actualLen = strlen(str);
+
+    testDiag("testDynMount()");
+
+    int ret = epicsMemMount(hello,
+                            EPICS_MEM_MOUNT_VERBOSE);
+
+    testOk(!ret, "testDynMount %d", ret);
+
+    str[0] = 'X'; /* spoil */
+
+    free(str);
+}
+
+void showFile(void*, const epicsIMF *mf)
+{
+    testDiag("F: '%s'", mf->path);
+}
+
+void testRead(const char* path, const char* mode,
+              const char* content, size_t contentLen)
+{
+    testDiag("testRead(\"%s\", \"%s\")", path, mode);
+
+    std::string econtent(escape(content, contentLen));
+
+    FILE *fp = epicsFOpen(path, mode);
+    if(!fp) {
+        testFail("Failed to open \"%s\" -> %d", path, errno);
+
+    } else {
+        int err;
+        std::vector<char> buf(2*contentLen);
+
+        int n = fread(&buf[0], 1u, buf.size()-1u, fp);
+        err = errno;
+        fclose(fp);
+        if(n<0) {
+            testFail("IO Error \"%s\" : %d", path, err);
+
+        } else {
+            buf.resize(n);
+            std::string ebuf(escape(&buf[0], buf.size()));
+
+            testOk(ebuf==econtent, "\"%s\" == \"%s\"", econtent.c_str(), ebuf.c_str());
+        }
+    }
+}
+
+void testCantOpen(int err, const char* path, const char* mode, const char* msg)
+{
+    FILE *fp = epicsFOpen(path, mode);
+    int actual = errno;
+    testOk(!fp && actual==err,
+                   "Expect failure epicsFOpen(\"%s\", \"%s\") -> %d == %d : %s",
+                  path, mode, err, actual, msg);
+    if(fp)
+        fclose(fp);
+}
+
+void testCompressZ()
+{
+#ifdef IMF_HAS_ZLIB
+    testRead("app:///test.txt.z", "r", STR("this is a test!"));
+#else
+    testCantOpen(EIO, "app:///test.txt.z", "r", "no zlib");
+#endif
+}
+
+} // namespace
+
+MAIN(epicsMemFileTest)
+{
+    testPlan(12);
+    testMount();
+    testDynMount();
+    epicsMemFileForEach(&showFile, NULL);
+    testRead("app:///hello.txt", "r", STR("hello world"));
+    testRead("app:///db/blah.txt", "r", STR("this is a test\n"));
+    testRead("app:///some.bin", "rb", STR("\xde\xad\0\xbe\xef"));
+    testOk(!epicsMemUnmount("/some.bin", 0), "Unmount /some.bin");
+    testCantOpen(ENOENT, "app:///some.bin", "r", "no such file");
+    testCantOpen(ENOENT, "app:///blah.txt", "r", "no such file");
+    testCantOpen(ENOENT, "app://blah.txt", "r", "missing '/' prefix");
+    testCantOpen(ENOENT, "app:///blah.txt/", "r", "missing filename");
+    testCantOpen(EINVAL, "app:///blah.txt", "rx", "bad mode");
+    testCompressZ();
+    return testDone();
+}

--- a/modules/libcom/test/epicsRunLibComTests.c
+++ b/modules/libcom/test/epicsRunLibComTests.c
@@ -28,6 +28,7 @@ int epicsErrlogTest(void);
 int epicsEventTest(void);
 int epicsExitTest(void);
 int epicsMathTest(void);
+int epicsMemFileTest(void);
 int epicsMessageQueueTest(void);
 int epicsMMIOTest(void);
 int epicsMutexTest(void);
@@ -87,6 +88,7 @@ void epicsRunLibComTests(void)
     runTest(epicsEventTest);
     runTest(epicsInlineTest);
     runTest(epicsMathTest);
+    runTest(epicsMemFileTest);
     runTest(epicsMessageQueueTest);
     runTest(epicsMMIOTest);
     runTest(epicsMutexTest);

--- a/modules/libcom/test/iocshTest.cpp
+++ b/modules/libcom/test/iocshTest.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <set>
 
+#include <epicsStdio.h>
 #include <osiUnistd.h>
 #include <osiFileName.h>
 #include <dbDefs.h>
@@ -20,30 +21,6 @@
 #include <testMain.h>
 
 namespace {
-void findTestData()
-{
-    const char *locations[] = {
-        ".",
-        "..",
-        ".." OSI_PATH_LIST_SEPARATOR "O.Common",
-        "O.Common",
-    };
-
-    for(size_t i=0; i<NELEMENTS(locations); i++) {
-        std::string path(locations[i]);
-        path += OSI_PATH_SEPARATOR "iocshTestSuccess.cmd";
-
-        std::ifstream strm(path.c_str());
-        if(strm.good()) {
-            testDiag("Found test data in %s", locations[i]);
-            if(chdir(locations[i])!=0)
-                testAbort("Unable to cd \"%s\"", locations[i]);
-            return;
-        }
-    }
-
-    testAbort("Failed to find test data");
-}
 
 void testFile(const char *fname, bool expect=true)
 {
@@ -85,20 +62,23 @@ void assertCallFunc(const iocshArgBuf *args)
 
 } // namespace
 
+extern "C"
+const epicsIMF iocshTest_imf[];
+
 MAIN(iocshTest)
 {
     testPlan(19);
+    epicsMemMount(iocshTest_imf, 0);
     libComRegister();
     iocshRegister(&positionFuncDef, &positionCallFunc);
     iocshRegister(&assertFuncDef, &assertCallFunc);
-    findTestData();
 
-    testFile("iocshTestSuccess.cmd");
+    testFile("app:///iocshTestSuccess.cmd");
     testPosition("success");
     reached.clear();
     testPosition("success", false);
 
-    testCmd("<iocshTestSuccess.cmd");
+    testCmd("<app:///iocshTestSuccess.cmd");
     testPosition("success");
     reached.clear();
 
@@ -118,12 +98,12 @@ MAIN(iocshTest)
 
     testDiag("successful indirection");
 
-    testFile("iocshTestSuccessIndirect.cmd");
+    testFile("app:///iocshTestSuccessIndirect.cmd");
     testPosition("success");
     testPosition("after_success");
     reached.clear();
 
-    testFile("iocshTestBadArgIndirect.cmd", false);
+    testFile("app:///iocshTestBadArgIndirect.cmd", false);
     testPosition("before_error");
     testPosition("after_error", false);
     testPosition("after_error_1", false);

--- a/modules/libcom/test/iocshTestBadArgIndirect.cmd
+++ b/modules/libcom/test/iocshTestBadArgIndirect.cmd
@@ -1,3 +1,3 @@
 on error break
-<iocshTestBadArg.cmd
+<app:///iocshTestBadArg.cmd
 position after_error_1

--- a/modules/libcom/test/iocshTestSuccessIndirect.cmd
+++ b/modules/libcom/test/iocshTestSuccessIndirect.cmd
@@ -1,3 +1,3 @@
 on error break
-<iocshTestSuccess.cmd
+<app:///iocshTestSuccess.cmd
 position after_success

--- a/modules/libcom/test/rtemsTestData.c
+++ b/modules/libcom/test/rtemsTestData.c
@@ -1,0 +1,3 @@
+
+#include <epicsMemFs.h>
+const epicsMemFS* epicsRtemsFSImage;


### PR DESCRIPTION
Adds the ability for compiling some static file content into an executable.  Patterned on the [Qt resource system](https://doc.qt.io/qt-5/resources.html).  The main entry point is `epicsFopen()` which forwards to `fopen()` unless the provided path is prefixed by `app://`.  Also `epicsMemMount()`.

Current status:

- Reuses the `epicsMakeMemFs.pl` script, with added arguments.
- Supports compression w/ zlib on supported targets.  (automatically probed in `configure/toolchain.c`
- On POSIX targets, uses `fopencookie()` or `funopen()` to stay entirely in-memory.
- On Windows, writes a temporary file using the `O_TEMPORARY` flag for automatic cleanup.
- On other targets (vxWorks): not supported

Open Questions:

- Require absolute (unix) style path.  eg. `app:///dir/file`.
- API names
- Overlap with RTEMS specific `epicsMemFs.h`
- How to express a more general mapping for `epicsMakeMemFs.pl` between disk and IMF names?

TODO items:

- [X] vxWorks, `ioslib.h` isn't adaquate
- [ ] Options for zlib headers/library (eg. LIB vs. SYS_LIB)
- [X] Some IOCsh functions to manipulate files.  (`cp`, `cat`, etc.)