### PR TITLE
Use GNU Readline if the header file is installed for linux-aarch64

### DIFF
--- a/configure/os/CONFIG_SITE.Common.linux-aarch64
+++ b/configure/os/CONFIG_SITE.Common.linux-aarch64
@@ -21,6 +21,11 @@
 # build doesn't fail to link the readline library.  If none of them work,
 # comment them all out to build without readline support.
 
+# Use GNU Readline if the header file is installed
+COMMANDLINE_LIBRARY = $(strip $(if $(wildcard \
+    $(firstword $(READLINE_DIR) $(GNU_DIR))/include/readline/readline.h), \
+  READLINE, EPICS))
+
 # No other libraries needed (recent Fedora, Ubuntu etc.):
 #COMMANDLINE_LIBRARY = READLINE
 


### PR DESCRIPTION
For the targets linux-arm, -microblaze, -x86, x86_64 and xscale_be the corresponding CONFIG_SITE.Common.$(T_A) files contain the following lines:
```
# Use GNU Readline if the header file is installed
COMMANDLINE_LIBRARY = $(strip $(if $(wildcard \
    $(firstword $(READLINE_DIR) $(GNU_DIR))/include/readline/readline.h), \
  READLINE, EPICS))
```
to automatically include libreadline if the header files are installed on the system.
But these lines are missing for linux-aarch64.
