### PR TITLE
Improve compress record

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -15,7 +15,11 @@ should also be read to understand what has changed since earlier releases.
 
 ## Changes made on the 7.0 branch since 7.0.7
 
-<!-- Insert new items immediately below here ... -->
+### `compress` record enhancement
+
+The compress record now supports the use of partially-filled buffers when using
+any of the N-to-one algorithms. This is achieved by setting the new field `PBUF`
+to `YES`.
 
 ## EPICS Release 7.0.7
 

--- a/modules/database/src/std/rec/compressRecord.c
+++ b/modules/database/src/std/rec/compressRecord.c
@@ -294,19 +294,13 @@ static int compress_scalar(struct compressRecord *prec,double *psource)
     /* for scalars, Median not implemented => use average */
     case (compressALG_N_to_1_Average):
     case (compressALG_N_to_1_Median):
-        if (inx == 0)
-            *pdest = value;
-        else {
-            *pdest += value;
-            if (inx + 1 >= prec->n)
-                *pdest = *pdest / (inx + 1);
-        }
+        *pdest = (inx * (*pdest) + value) / (inx + 1);
         break;
     }
     inx++;
-    if (inx >= prec->n || prec->pbuf == menuYesNoYES) {
+    if ((inx >= prec->n) || (prec->pbuf == menuYesNoYES)) {
         put_value(prec,pdest,1);
-        prec->inx = 0;
+        prec->inx = (inx >= prec->n) ? 0 : inx;
         return 0;
     } else {
         prec->inx = inx;

--- a/modules/database/src/std/rec/compressRecord.c
+++ b/modules/database/src/std/rec/compressRecord.c
@@ -29,7 +29,6 @@
 #include "dbFldTypes.h"
 #include "errMdef.h"
 #include "menuYesNo.h"
-#include "menuAlarmStat.h"
 #include "special.h"
 #include "recSup.h"
 #include "recGbl.h"

--- a/modules/database/src/std/rec/compressRecord.c
+++ b/modules/database/src/std/rec/compressRecord.c
@@ -28,6 +28,8 @@
 #include "dbEvent.h"
 #include "dbFldTypes.h"
 #include "errMdef.h"
+#include "menuYesNo.h"
+#include "menuAlarmStat.h"
 #include "special.h"
 #include "recSup.h"
 #include "recGbl.h"
@@ -166,9 +168,9 @@ static int compress_array(compressRecord *prec,
     }
     if (prec->n <= 0)
         prec->n = 1;
-    n = prec->n;
-    if (no_elements < n)
+    if (no_elements < prec->n && prec->pbuf != menuYesNoYES)
         return 1; /*dont do anything*/
+    n = no_elements;
 
     /* determine number of samples to take */
     if (no_elements < nsam * n)
@@ -272,7 +274,7 @@ static int array_average(compressRecord *prec,
     prec->inx = 0;
     return 0;
 }
-
+
 static int compress_scalar(struct compressRecord *prec,double *psource)
 {
     double value = *psource;
@@ -302,7 +304,7 @@ static int compress_scalar(struct compressRecord *prec,double *psource)
         break;
     }
     inx++;
-    if (inx >= prec->n) {
+    if (inx >= prec->n || prec->pbuf == menuYesNoYES) {
         put_value(prec,pdest,1);
         prec->inx = 0;
         return 0;

--- a/modules/database/src/std/rec/compressRecord.dbd.pod
+++ b/modules/database/src/std/rec/compressRecord.dbd.pod
@@ -393,7 +393,15 @@ Scan forward link if necessary, set PACT FALSE, and return.
 		interest(1)
 		menu(compressALG)
 	}
- 	field(BALG,DBF_MENU) {
+	field(PBUF,DBF_MENU) {
+		prompt("Use Partial buffers")
+		promptgroup("30 - Action")
+		special(SPC_RESET)
+		interest(1)
+		menu(menuYesNo)
+		initial("NO")
+	}
+	field(BALG,DBF_MENU) {
 		prompt("Buffering Algorithm")
 		promptgroup("30 - Action")
 		special(SPC_RESET)

--- a/modules/database/src/std/rec/compressRecord.dbd.pod
+++ b/modules/database/src/std/rec/compressRecord.dbd.pod
@@ -175,6 +175,11 @@ of all four records will be calculated and placed into the VAL field.
 If PBUF is set to YES, then after each process the average of the first several
 elements will be calculated.
 
+Note that PBUF has no impact on the C<<< Average >>> method. If one wishes to have a
+rolling average computed, then the best way to achieve that is with two compress
+records: a C<<< Circular buffer >>> which is linked to an C<<< N to 1 Average >>>
+record with PBUF set to YES.
+
 The compression record keeps NSAM data samples.
 
 The field N determines the number of elements to compress into each result.

--- a/modules/database/src/std/rec/compressRecord.dbd.pod
+++ b/modules/database/src/std/rec/compressRecord.dbd.pod
@@ -40,7 +40,7 @@ the beginning or the end of the VAL array.
 
 =head2 Parameter Fields
 
-The record-specific fields are described below.
+The record-specific fields are described below, grouped by functionality.
 
 =recordtype compress
 
@@ -59,10 +59,6 @@ menu(bufferingALG) {
 	choice(bufferingALG_LIFO, "LIFO Buffer")
 }
 recordtype(compress) {
-
-=head2 Parameter Fields
-
-The record-specific fields are described below, grouped by functionality.
 
 =head3 Scanning Parameters
 
@@ -85,7 +81,7 @@ algorithms which can be specified as follows:
 
 The following fields determine what channel to read and how to compress the data:
 
-=fields ALG, INP, NSAM, N, ILIL, IHIL, OFF, RES
+=fields ALG, INP, NSAM, N, ILIL, IHIL, OFF, RES, PBUF
 
 As stated above, the ALG field specifies which algorithm to be performed on the data.
 
@@ -166,6 +162,18 @@ Compress N to 1 samples, taking the average value.
 Compress N to 1 samples, taking the median value.
 
 =back
+
+The behaviour of the record for partially filled buffers depends on the field PBUF.
+If PBUF is set to NO, then the record will wait until the buffer is completely full
+before processing. If PBUF is set to YES, then it will start processing immediately.
+
+For example, if ALG is set to C<<< N to 1 Average >>> with NSAM equal to 4, N equal
+to 1, and PBUF set to NO, then the first three times that the compress record is
+processed it will remain in an undefined state. On the fourth process, the average
+of all four records will be calculated and placed into the VAL field.
+
+If PBUF is set to YES, then after each process the average of the first several
+elements will be calculated.
 
 The compression record keeps NSAM data samples.
 

--- a/modules/database/test/std/rec/compressTest.c
+++ b/modules/database/test/std/rec/compressTest.c
@@ -437,7 +437,7 @@ testNto1AveragePartial(void) {
     long nReq = 1;
     DBADDR wfaddr, caddr;
 
-    testDiag("Test Average");
+    testDiag("Test Average, Partial");
 
     testdbPrepare();
     testdbReadDatabase("recTestIoc.dbd", NULL, NULL);
@@ -480,7 +480,7 @@ testNto1AveragePartial(void) {
 
 MAIN(compressTest)
 {
-    testPlan(123);
+    testPlan(127);
     testFIFOCirc();
     testLIFOCirc();
     testNto1Average();

--- a/modules/database/test/std/rec/compressTest.c
+++ b/modules/database/test/std/rec/compressTest.c
@@ -5,6 +5,9 @@
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 
+#include <stdlib.h>
+
+#include "cantProceed.h"
 #include "dbUnitTest.h"
 #include "testMain.h"
 #include "dbLock.h"
@@ -91,7 +94,7 @@ void
 writeToWaveform(DBADDR *addr, long count, ...) {
     va_list args;
     long i;
-    double values[count];
+    double *values = (double *)callocMustSucceed(count, sizeof(double), "writeToWaveform");
 
     va_start(args, count);
     for (i=0; i< count; i++) {
@@ -102,6 +105,7 @@ writeToWaveform(DBADDR *addr, long count, ...) {
     dbScanLock(addr->precord);
     dbPut(addr, DBR_DOUBLE, values, count);
     dbScanUnlock(addr->precord);
+    free(values);
 }
 
 static

--- a/modules/database/test/std/rec/compressTest.c
+++ b/modules/database/test/std/rec/compressTest.c
@@ -413,6 +413,20 @@ testNto1Average(void) {
     testDEq(buf, 2.5, 0.01);
     dbScanUnlock(caddr.precord);
 
+    testDiag("Test single input data");
+
+    writeToWaveform(&wfaddr, 1, 5.);
+
+    dbScanLock(caddr.precord);
+    dbProcess(caddr.precord);
+    nReq = 1;
+    if (dbGet(&caddr, DBR_DOUBLE, &buf, NULL, &nReq, NULL))
+        testAbort("dbGet failed on compress record");
+
+    // Assert that nothing has changed from before
+    testDEq(buf, 2.5, 0.01);
+    dbScanUnlock(caddr.precord);
+
     testIocShutdownOk();
     testdbCleanup();
 }
@@ -428,7 +442,7 @@ testNto1AveragePartial(void) {
     testdbPrepare();
     testdbReadDatabase("recTestIoc.dbd", NULL, NULL);
     recTestIoc_registerRecordDeviceDriver(pdbbase);
-    testdbReadDatabase("compressTest.db", NULL, "INP=wf,ALG=N to 1 Average,BALG=FIFO Buffer,NSAM=1,N=4,PBUF=YES");
+    testdbReadDatabase("compressTest.db", NULL, "INP=wf,ALG=N to 1 Average,BALG=FIFO Buffer,NSAM=1,N=4,PARTIAL=YES");
 
     eltc(0);
     testIocInitOk();
@@ -447,6 +461,17 @@ testNto1AveragePartial(void) {
         testAbort("dbGet failed on compress record");
 
     testDEq(buf, 2.0, 0.01);
+    dbScanUnlock(caddr.precord);
+
+
+    writeToWaveform(&wfaddr, 1, 6.);
+
+    dbScanLock(caddr.precord);
+    dbProcess(caddr.precord);
+    if (dbGet(&caddr, DBR_DOUBLE, &buf, NULL, &nReq, NULL))
+        testAbort("dbGet failed on compress record");
+
+    testDEq(buf, 6.0, 0.01);
     dbScanUnlock(caddr.precord);
 
     testIocShutdownOk();

--- a/modules/database/test/std/rec/compressTest.c
+++ b/modules/database/test/std/rec/compressTest.c
@@ -590,8 +590,12 @@ testNto1LowValue(void) {
 void
 testAIAveragePartial(void) {
     double buf = 0.;
-    double data[4] = {1., 2., 3., 4.};
-    double expected[4] = {1., 1.5, 2., 2.5};
+    double data[5] = {1., 2., 3., 4., 5.};
+    /* 
+     * Note that the fifth dbPut essentially resets the circular buffer, so the
+     * average is once again the average of the _first_ entry alone.
+     */
+    double expected[5] = {1., 1.5, 2., 2.5, 5.};
     long nReq = 1;
     int i;
     DBADDR aiaddr, caddr;
@@ -610,7 +614,7 @@ testAIAveragePartial(void) {
     fetchRecordOrDie("ai", aiaddr);
     fetchRecordOrDie("comp", caddr);
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < 5; i++) {
         dbScanLock(aiaddr.precord);
         dbPut(&aiaddr, DBR_DOUBLE, &data[i], 1);
         dbScanUnlock(aiaddr.precord);
@@ -630,7 +634,7 @@ testAIAveragePartial(void) {
 
 MAIN(compressTest)
 {
-    testPlan(131);
+    testPlan(132);
     testFIFOCirc();
     testLIFOCirc();
     testArrayAverage();

--- a/modules/database/test/std/rec/compressTest.db
+++ b/modules/database/test/std/rec/compressTest.db
@@ -6,7 +6,7 @@ record(waveform, "wf") {
 record(compress, "comp") {
   field(INP, "$(INP) NPP")
   field(ALG, "$(ALG)")
-  field(PBUF,"$(PARTIAL=NO)")
+  field(PBUF,"$(PBUF=NO)")
   field(BALG,"$(BALG)")
   field(NSAM,"$(NSAM)")
   field(N,   "$(N=1)")

--- a/modules/database/test/std/rec/compressTest.db
+++ b/modules/database/test/std/rec/compressTest.db
@@ -1,11 +1,12 @@
 record(ai, "ai") {}
 record(waveform, "wf") {
   field(FTVL, "DOUBLE")
-  field(NELM, "4")
+  field(NELM, "$(N=1)")
 }
 record(compress, "comp") {
   field(INP, "$(INP) NPP")
   field(ALG, "$(ALG)")
+  field(PBUF,"$(PARTIAL=NO)")
   field(BALG,"$(BALG)")
   field(NSAM,"$(NSAM)")
   field(N,   "$(N=1)")

--- a/modules/database/test/std/rec/compressTest.db
+++ b/modules/database/test/std/rec/compressTest.db
@@ -1,7 +1,12 @@
-record(ai, "val") {}
+record(ai, "ai") {}
+record(waveform, "wf") {
+  field(FTVL, "DOUBLE")
+  field(NELM, "4")
+}
 record(compress, "comp") {
-  field(INP, "val NPP")
+  field(INP, "$(INP) NPP")
   field(ALG, "$(ALG)")
   field(BALG,"$(BALG)")
   field(NSAM,"$(NSAM)")
+  field(N,   "$(N=1)")
 }

--- a/modules/database/test/std/rec/compressTest.db
+++ b/modules/database/test/std/rec/compressTest.db
@@ -1,7 +1,7 @@
 record(ai, "ai") {}
 record(waveform, "wf") {
   field(FTVL, "DOUBLE")
-  field(NELM, "$(N=1)")
+  field(NELM, "4")
 }
 record(compress, "comp") {
   field(INP, "$(INP) NPP")


### PR DESCRIPTION
This pull request accomplishes two main points:

1. Add testing to the compress record. This record had only very limited testing of two of the algorithms that are used. This pull request adds in more testing for the existing algorithms.
2. This also adds a new field (PBUF) which allows a user to select if partially filled buffers should be nevertheless calculated. For example, if you have a periodically scanned ai record that is being averaged, at the moment it waits until the entire buffer is full before it produces an average. With this change and with PBUF set to YES, then the average will be calculated based on the running tally.

See https://epics.anl.gov/tech-talk/2021/msg00239.php for some context.

Note that there are some other potential improvements to this record: for example, if you have a waveform record as input to a compress record, and you fill up the compress record and process it, then an update to the waveform record that does not fill it completely followed by another process of the compress record will yield no obvious clue that the compress record was not processed.

We could set the compress record in such a case to UDF or some other alarm state. That said, that feels out of scope for the suggested change.