### PR TITLE
automatic COMMANDLINE_LIBRARY w/ newer compilers

### DIFF
--- a/configure/CONFIG_COMMON
+++ b/configure/CONFIG_COMMON
@@ -288,7 +288,6 @@ TARGET_LIB_LDFLAGS = $(if $(findstring $*, $(LOADABLE_LIBRARY)), \
 
 #--------------------------------------------------
 # Command-line input support default
-COMMANDLINE_LIBRARY = EPICS
 OP_SYS_LDLIBS += $(LDLIBS_$(COMMANDLINE_LIBRARY))
 OP_SYS_LDFLAGS += $(LDFLAGS_$(COMMANDLINE_LIBRARY))
 RUNTIME_LDFLAGS += $(RUNTIME_LDFLAGS_$(COMMANDLINE_LIBRARY))

--- a/configure/os/CONFIG.Common.win32-x86-mingw
+++ b/configure/os/CONFIG.Common.win32-x86-mingw
@@ -12,7 +12,7 @@ ARCH_CLASS = x86
 POSIX = NO
 
 #  Definitions used when COMMANDLINE_LIBRARY is READLINE
-LDLIBS_READLINE = -lreadline -lcurses
+LDLIBS_READLINE = -lreadline -ltermcap
 
 ARCH_DEP_CFLAGS += -m32
 ARCH_DEP_LDFLAGS += -m32

--- a/configure/os/CONFIG.linux-x86.win32-x86-mingw
+++ b/configure/os/CONFIG.linux-x86.win32-x86-mingw
@@ -21,4 +21,4 @@ LOADABLE_SHRLIB_LDFLAGS = -shared \
 GNU_LDLIBS_YES =
 
 # Link with system libraries
-OP_SYS_LDLIBS = -lpsapi -lws2_32 -ladvapi32 -luser32 -lkernel32 -lwinmm -ldbghelp
+OP_SYS_LDLIBS += -lpsapi -lws2_32 -ladvapi32 -luser32 -lkernel32 -lwinmm -ldbghelp

--- a/configure/os/CONFIG.win32-x86-mingw.win32-x86-mingw
+++ b/configure/os/CONFIG.win32-x86-mingw.win32-x86-mingw
@@ -32,4 +32,4 @@ LOADABLE_SHRLIB_LDFLAGS = -shared \
 GNU_LDLIBS_YES =
 
 # Link with system libraries
-OP_SYS_LDLIBS = -lpsapi -lws2_32 -ladvapi32 -luser32 -lkernel32 -lwinmm -ldbghelp
+OP_SYS_LDLIBS += -lpsapi -lws2_32 -ladvapi32 -luser32 -lkernel32 -lwinmm -ldbghelp

--- a/configure/os/CONFIG_SITE.Common.linux-arm
+++ b/configure/os/CONFIG_SITE.Common.linux-arm
@@ -15,11 +15,6 @@
 #    to inform the system of the shared library location.
 
 
-# Use GNU Readline if the header file is installed
-COMMANDLINE_LIBRARY = $(strip $(if $(wildcard \
-    $(firstword $(READLINE_DIR) $(GNU_DIR))/include/readline/readline.h), \
-  READLINE, EPICS))
-
 # If libreadline needs additional libraries to be linked with it, try
 # uncommenting each of the lines below in turn, starting with the top
 # one and working downwards, until the build succeeds. Do a 'make rebuild'

--- a/configure/os/CONFIG_SITE.Common.linux-microblaze
+++ b/configure/os/CONFIG_SITE.Common.linux-microblaze
@@ -12,10 +12,6 @@
 GNU_DIR = /usr/local/vw/microblaze-2.0/microblazeel-unknown-linux-gnu
 
 
-# Use GNU Readline if the header file is installed
-COMMANDLINE_LIBRARY = $(strip $(if $(wildcard \
-    $(GNU_DIR)/include/readline/readline.h), READLINE, EPICS))
-
 # If libreadline needs additional libraries to be linked with it, try
 # uncommenting each of the lines below in turn, starting with the top
 # one and working downwards, until the build succeeds. Do a 'make rebuild'

--- a/configure/os/CONFIG_SITE.Common.linux-x86
+++ b/configure/os/CONFIG_SITE.Common.linux-x86
@@ -15,10 +15,6 @@
 #    to inform the system of the shared library location.
 
 
-# Use GNU Readline if the header file is installed
-COMMANDLINE_LIBRARY = $(strip $(if $(wildcard \
-    $(GNU_DIR)/include/readline/readline.h), READLINE, EPICS))
-
 # If libreadline needs additional libraries to be linked with it, try
 # uncommenting each of the lines below in turn, starting with the top
 # one and working downwards, until the build succeeds. Do a 'make rebuild'

--- a/configure/os/CONFIG_SITE.Common.linux-x86_64
+++ b/configure/os/CONFIG_SITE.Common.linux-x86_64
@@ -15,10 +15,6 @@
 #    to inform the system of the shared library location.
 
 
-# Use GNU Readline if the header file is installed
-COMMANDLINE_LIBRARY = $(strip $(if $(wildcard \
-    $(GNU_DIR)/include/readline/readline.h), READLINE, EPICS))
-
 # If libreadline needs additional libraries to be linked with it, try
 # uncommenting each of the lines below in turn, starting with the top
 # one and working downwards, until the build succeeds. Do a 'make rebuild'

--- a/configure/os/CONFIG_SITE.Common.linux-xscale_be
+++ b/configure/os/CONFIG_SITE.Common.linux-xscale_be
@@ -3,11 +3,6 @@
 # Site-specific settings for the linux-xscale_be target
 
 
-# Use GNU Readline if the header file is installed
-COMMANDLINE_LIBRARY = $(strip $(if $(wildcard \
-    $(firstword $(READLINE_DIR) $(GNU_DIR))/include/readline/readline.h), \
-  READLINE, EPICS))
-
 # If libreadline needs additional libraries to be linked with it, try
 # uncommenting each of the lines below in turn, starting with the top
 # one and working downwards, until the build succeeds. Do a 'make rebuild'

--- a/configure/toolchain.c
+++ b/configure/toolchain.c
@@ -35,3 +35,15 @@ OS_API = posix
 OS_API = score
 #  endif
 #endif
+
+#ifdef __has_include
+#  if defined(__rtems__) && __RTEMS_MAJOR__<5 && __has_include(<libtecla.h>)
+COMMANDLINE_LIBRARY ?= LIBTECLA
+#  elif __has_include(<readline/readline.h>)
+COMMANDLINE_LIBRARY ?= READLINE
+#  else
+COMMANDLINE_LIBRARY ?= EPICS
+#  endif
+#else
+COMMANDLINE_LIBRARY ?= EPICS
+#endif


### PR DESCRIPTION
clang, recent GCC, and even more recent MSVC support [`__has_include()`](https://en.cppreference.com/w/cpp/preprocessor/include) which allows the preprocessor to test for the existence of a header file in the configured search path (including `-I`).  This becomes standard w/ c++17.