### PR TITLE
Fix undef ts on first camonitor update of NORD

### DIFF
--- a/modules/database/src/std/rec/waveformRecord.c
+++ b/modules/database/src/std/rec/waveformRecord.c
@@ -124,6 +124,7 @@ static long process(struct dbCommon *pcommon)
     struct waveformRecord *prec = (struct waveformRecord *)pcommon;
     wfdset *pdset = (wfdset *)(prec->dset);
     unsigned char pact=prec->pact;
+	epicsUInt32 nord = prec->nord;
     long status;
 
     if ((pdset==NULL) || (pdset->read_wf==NULL)) {
@@ -143,6 +144,8 @@ static long process(struct dbCommon *pcommon)
     prec->udf = FALSE;
     recGblGetTimeStampSimm(prec, prec->simm, &prec->siol);
 
+	if (nord != prec->nord)
+		db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
     monitor(prec);
 
     /* process the forward scan link record */
@@ -206,7 +209,10 @@ static long put_array_info(DBADDR *paddr, long nNew)
         prec->nord = prec->nelm;
 
     if (nord != prec->nord)
+	{
+		printf( "put_array_info: db_post_events(DBE_VALUE\|DBE_LOG)\n" );
         db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
+	}
     return 0;
 }
 
@@ -334,11 +340,7 @@ static long readValue(waveformRecord *prec)
 
     switch (prec->simm) {
     case menuYesNoNO: {
-        epicsUInt32 nord = prec->nord;
-
         status = pdset->read_wf(prec);
-        if (nord != prec->nord)
-            db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
         break;
     }
 
@@ -353,7 +355,6 @@ static long readValue(waveformRecord *prec)
 
             if (nRequest != prec->nord) {
                 prec->nord = nRequest;
-                db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
             }
             prec->pact = FALSE;
         }

--- a/modules/database/src/std/rec/waveformRecord.c
+++ b/modules/database/src/std/rec/waveformRecord.c
@@ -124,7 +124,7 @@ static long process(struct dbCommon *pcommon)
     struct waveformRecord *prec = (struct waveformRecord *)pcommon;
     wfdset *pdset = (wfdset *)(prec->dset);
     unsigned char pact=prec->pact;
-	epicsUInt32 nord = prec->nord;
+    epicsUInt32 nord = prec->nord;
     long status;
 
     if ((pdset==NULL) || (pdset->read_wf==NULL)) {
@@ -144,8 +144,8 @@ static long process(struct dbCommon *pcommon)
     prec->udf = FALSE;
     recGblGetTimeStampSimm(prec, prec->simm, &prec->siol);
 
-	if (nord != prec->nord)
-		db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
+    if (nord != prec->nord)
+        db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
     monitor(prec);
 
     /* process the forward scan link record */
@@ -209,10 +209,9 @@ static long put_array_info(DBADDR *paddr, long nNew)
         prec->nord = prec->nelm;
 
     if (nord != prec->nord)
-	{
-		printf( "put_array_info: db_post_events(DBE_VALUE\|DBE_LOG)\n" );
+    {
         db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
-	}
+    }
     return 0;
 }
 


### PR DESCRIPTION
Moves db_post_events() calls for NORD to process() function
after it updates the timestamp.

DRAFT
Needs a test case to show bug in 7.0 branch and verify the fix.