### PR TITLE
Set `RSRV_SERVER_PORT`

### DIFF
--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -572,6 +572,7 @@ void rsrv_init (void)
 
     {
         unsigned short sport = ca_server_port;
+        char buf[6]; /* space for 0 - 65535 */
         socks = rsrv_grab_tcp(&sport);
 
         if ( sport != ca_server_port ) {
@@ -583,6 +584,10 @@ void rsrv_init (void)
             errlogPrintf ( "cas " ERL_WARNING ": Depending on your IP kernel this server may not be\n" );
             errlogPrintf ( "cas " ERL_WARNING ": reachable with UDP unicast (a host's IP in EPICS_CA_ADDR_LIST)\n" );
         }
+
+        epicsSnprintf(buf, sizeof(buf)-1u, "%u", ca_server_port);
+        buf[sizeof(buf)-1u] = '\0';
+        epicsEnvSet("RSRV_SERVER_PORT", buf);
     }
 
     /* start servers (TCP and UDP(s) for each interface.


### PR DESCRIPTION
Publish the actual TCP port used as `$RSRV_SERVER_PORT`.

Note that RSRV is, and was, only capable of making use of a single TCP port number.  With multiple interfaces this same port must be bound on all.

https://github.com/epics-base/epics-base/blob/3fadf4a26cfe33dcb9eb9e4620634e1d3a7b9763/modules/database/src/ioc/rsrv/caservertask.c#L143-L150

@shroffk fyi.