### PR TITLE
db: move db_field_log dtor out of union

### DIFF
--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -731,7 +731,7 @@ static db_field_log* db_create_field_log (struct dbChannel *chan, int use_val)
             /* don't make a copy yet, just reference the field value */
             pLog->u.r.field = dbChannelField(chan);
             /* indicate field value still owned by record */
-            pLog->u.r.dtor = NULL;
+            pLog->dtor = NULL;
             /* no private data yet, may be set by a filter */
             pLog->u.r.pvt = NULL;
         }
@@ -1201,7 +1201,7 @@ void db_delete_field_log (db_field_log *pfl)
 {
     if (pfl) {
         /* Free field if reference type field log and dtor is set */
-        if (pfl->type == dbfl_type_ref && pfl->u.r.dtor) pfl->u.r.dtor(pfl);
+        if (pfl->type == dbfl_type_ref && pfl->dtor) pfl->dtor(pfl);
         /* Free the field log chunk */
         freeListFree(dbevFieldLogFreeList, pfl);
     }

--- a/modules/database/src/ioc/db/db_field_log.h
+++ b/modules/database/src/ioc/db/db_field_log.h
@@ -97,7 +97,6 @@ struct dbfl_val {
  * data is still owned by a record. See the macro dbfl_has_copy below.
  */
 struct dbfl_ref {
-    dbfl_freeFunc     *dtor;  /* Callback to free filter-allocated resources */
     void              *pvt;   /* Private pointer */
     void              *field; /* Field value */
 };
@@ -120,6 +119,7 @@ typedef struct db_field_log {
     short        field_type;  /* DBF type of data */
     short        field_size;  /* Size of a single element */
     long        no_elements;  /* No of valid array elements */
+    dbfl_freeFunc     *dtor;  /* Callback to free filter-allocated resources */
     union {
         struct dbfl_val v;
         struct dbfl_ref r;
@@ -136,7 +136,7 @@ typedef struct db_field_log {
  * the db_field_log still owns the (empty) data.
  */
 #define dbfl_has_copy(p)\
- ((p) && ((p)->type==dbfl_type_val || (p)->u.r.dtor || (p)->no_elements==0))
+ ((p) && ((p)->type==dbfl_type_val || (p)->dtor || (p)->no_elements==0))
 
 #define dbfl_pfield(p)\
  ((p)->type==dbfl_type_val ? &p->u.v.field : p->u.r.field)

--- a/modules/database/src/std/filters/arr.c
+++ b/modules/database/src/std/filters/arr.c
@@ -109,7 +109,7 @@ static db_field_log* filter(void* pvt, dbChannel *chan, db_field_log *pfl)
         break;
 
     case dbfl_type_ref:
-        must_lock = !pfl->u.r.dtor;
+        must_lock = !pfl->dtor;
         if (must_lock) {
             dbScanLock(dbChannelRecord(chan));
             dbChannelGetArrayInfo(chan, &pSource, &nSource, &offset);
@@ -123,9 +123,9 @@ static db_field_log* filter(void* pvt, dbChannel *chan, db_field_log *pfl)
             offset = (offset + start) % pfl->no_elements;
             dbExtractArray(pSource, pTarget, pfl->field_size,
                 nTarget, pfl->no_elements, offset, my->incr);
-            if (pfl->u.r.dtor) pfl->u.r.dtor(pfl);
+            if (pfl->dtor) pfl->dtor(pfl);
             pfl->u.r.field = pTarget;
-            pfl->u.r.dtor = freeArray;
+            pfl->dtor = freeArray;
             pfl->u.r.pvt = my->arrayFreeList;
         }
         /* adjust no_elements (even if zero elements remain) */

--- a/modules/database/src/std/filters/ts.c
+++ b/modules/database/src/std/filters/ts.c
@@ -35,7 +35,7 @@ static db_field_log* filter(void* pvt, dbChannel *chan, db_field_log *pfl) {
 
     /* If reference and not already copied,
        must make a copy (to ensure coherence between time and data) */
-    if (pfl->type == dbfl_type_ref && !pfl->u.r.dtor) {
+    if (pfl->type == dbfl_type_ref && !pfl->dtor) {
         void *pTarget = calloc(pfl->no_elements, pfl->field_size);
         void *pSource = pfl->u.r.field;
         if (pTarget) {
@@ -46,7 +46,7 @@ static db_field_log* filter(void* pvt, dbChannel *chan, db_field_log *pfl) {
             dbExtractArray(pSource, pTarget, pfl->field_size,
                 nSource, pfl->no_elements, offset, 1);
             pfl->u.r.field = pTarget;
-            pfl->u.r.dtor = freeArray;
+            pfl->dtor = freeArray;
             pfl->u.r.pvt = pvt;
             dbScanUnlock(dbChannelRecord(chan));
         }

--- a/modules/database/test/ioc/db/chfPluginTest.c
+++ b/modules/database/test/ioc/db/chfPluginTest.c
@@ -302,7 +302,7 @@ static db_field_log * pre(void *user, dbChannel *chan, db_field_log *pLog) {
     pLog->field_type++;
 
     if (my->offpre == 0) {  /* The first one registers a dtor and saves pfl */
-        pLog->u.r.dtor = dtor;
+        pLog->dtor = dtor;
         dtorpfl = pLog;
     }
 
@@ -345,7 +345,7 @@ static db_field_log * post(void *user, dbChannel *chan, db_field_log *pLog) {
     pLog->field_type++;
 
     if (my->offpost == 0) { /* The first one registers a dtor and saves pfl */
-        pLog->u.r.dtor = dtor;
+        pLog->dtor = dtor;
         dtorpfl = pLog;
     }
 

--- a/modules/database/test/ioc/db/dbChArrTest.cpp
+++ b/modules/database/test/ioc/db/dbChArrTest.cpp
@@ -179,7 +179,7 @@ static void check(short dbr_type) {
     pfl->field_type = DBF_CHAR; \
     pfl->field_size = 1; \
     pfl->no_elements = 26; \
-    pfl->u.r.dtor = freeArray; \
+    pfl->dtor = freeArray; \
     pfl->u.r.field = epicsStrDup("abcdefghijklmnopqrsstuvwxyz"); \
     testOk(!dbChannelGetField(pch, DBR_LONG, buf, NULL, &req, pfl), "Got Field value"); \
     testOk(req == Size, "Got %ld elements (expected %d)", req, Size); \


### PR DESCRIPTION
wrt. [an issue](https://epics.anl.gov/tech-talk/2022/msg00831.php) reported by @MarkRivers.  The "bug" turns out to be in the MMU configuration of a vxWorks BSP.  Still, I take away the idea that the current definition of `db_field_log`, where the included union field overlays a float/int with a function pointer, is a bad idea as it allows speculative execution to cross a "boundary" between data and code.  This escalated a mis-configuration in a way which was very difficult to troubleshoot, and could have been triggered remotely.

This PR moves the function pointer out of the union.  This will add 4/8 bytes to `sizeof(db_field_log)`.  More significantly, it would break any out-of-tree filter code which is accessing the `dtor` field.

Would this change be worth the trouble?
