### PR TITLE
Add space to the message printed by errMessage()

### DIFF
--- a/modules/database/src/ioc/as/asCa.c
+++ b/modules/database/src/ioc/as/asCa.c
@@ -241,7 +241,7 @@ void asCaStart(void)
                                      epicsThreadGetStackSize(epicsThreadStackBig),
                                      (EPICSTHREADFUNC)asCaTask,0);
         if(threadid==0) {
-            errMessage(0,"asCaStart: taskSpawn Failure\n");
+            errMessage(0,"asCaStart: taskSpawn Failure");
         }
     }
     epicsMutexMustLock(asCaTaskLock);

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -73,6 +73,8 @@ LIBCOM_API extern int errVerbose;
  * the status symbol and string values, and the name of the task which invoked errMessage.
  * It also prints the name of the source file and the line number from which the call was issued.
  *
+ * The message to print should not include a newline as one is added implicitly.
+ *
  * The status code used for the 1st argument is:
  * - 0: Find latest vxWorks or Unix error (errno value).
  * - -1: Don't report status.
@@ -82,7 +84,7 @@ LIBCOM_API extern int errVerbose;
  * \param PM The message to print
  */
 #define errMessage(S, PM) \
-     errPrintf(S, __FILE__, __LINE__, "%s", PM)
+     errPrintf(S, __FILE__, __LINE__, " %s\n", PM)
 
 /** epicsPrintf is an old name for errlog routines */
 #define epicsPrintf errlogPrintf

--- a/modules/libcom/src/osi/os/posix/osdMonotonic.c
+++ b/modules/libcom/src/osi/os/posix/osdMonotonic.c
@@ -47,7 +47,7 @@ clockid_t ids[] = {
         return;
     }
 
-    errMessage(errlogMinor, "Warning: failed to setup monotonic time source\n");
+    errMessage(errlogMinor, "Warning: failed to setup monotonic time source");
 }
 
 epicsUInt64 epicsMonotonicResolution(void)


### PR DESCRIPTION
The way `errMessage()` is used throughout epics-base, a space and a newline should be added around the message provided by the caller. Here is an example from `dbStaticLib.c`:

    errMessage(-1, "dbCreateAlias: Add to PVD failed");

When called this way, the message sticks to the line number on the left and to the next log entry to the right. It's a sensible way to use this macro, so instead of fixing the call sites, I propose fixing the macro instead.