### PR TITLE
Fix potentially buggy strncpy calls and add epicsStrnCpy

### DIFF
--- a/modules/database/src/ioc/db/dbConvert.c
+++ b/modules/database/src/ioc/db/dbConvert.c
@@ -881,6 +881,7 @@ static long getMenuString(const dbAddr *paddr,
         return(S_db_badChoice);
     }
     strncpy(pdst, pchoice, MAX_STRING_SIZE);
+    pdst[MAX_STRING_SIZE-1] = 0;
     return 0;
 }
 
@@ -907,6 +908,7 @@ static long getDeviceString(const dbAddr *paddr,
         return(S_db_badChoice);
     }
     strncpy(pdst, pchoice, MAX_STRING_SIZE);
+    pdst[MAX_STRING_SIZE-1] = 0;
     return 0;
 }
 

--- a/modules/database/src/ioc/db/dbDbLink.c
+++ b/modules/database/src/ioc/db/dbDbLink.c
@@ -337,6 +337,7 @@ static long dbDbGetUnits(const struct link *plink, char *units, int unitsSize)
         return status;
 
     strncpy(units, buffer.units, unitsSize);
+    units[unitsSize-1] = 0;
     return 0;
 }
 

--- a/modules/database/src/ioc/db/dbFastLinkConv.c
+++ b/modules/database/src/ioc/db/dbFastLinkConv.c
@@ -1351,6 +1351,7 @@ static long cvt_menu_st(
         return(S_db_badChoice);
     }
     strncpy(to,pchoice,MAX_STRING_SIZE);
+    to[MAX_STRING_SIZE-1] = 0;
     return(0);
  }
 
@@ -1376,6 +1377,7 @@ static long cvt_device_st(
         return(S_db_badChoice);
     }
     strncpy(to,pchoice,MAX_STRING_SIZE);
+    to[MAX_STRING_SIZE-1] = 0;
     return(0);
  }
 

--- a/modules/database/src/ioc/db/dbScan.c
+++ b/modules/database/src/ioc/db/dbScan.c
@@ -510,8 +510,10 @@ event_list *eventNameToHandle(const char *eventname)
             sprintf(pel->eventname, "%i", (int)eventnumber);
             pevent_list[(int)eventnumber] = pel;
         }
-        else
+        else {
             strncpy(pel->eventname, eventname, namelength);
+            pel->eventname[namelength-1] = '\0';
+        }
         for (prio = 0; prio < NUM_CALLBACK_PRIORITIES; prio++) {
             callbackSetUser(&pel->scan_list[prio], &pel->callback[prio]);
             callbackSetPriority(prio, &pel->callback[prio]);

--- a/modules/database/src/ioc/db/db_access.c
+++ b/modules/database/src/ioc/db/db_access.c
@@ -647,8 +647,10 @@ int dbChannel_get_count(
             no_str = newSt.no_str;
             if (no_str>16) no_str=16;
             pold->no_str = no_str;
-            for (i = 0; i < no_str; i++)
+            for (i = 0; i < no_str; i++) {
                 strncpy(pold->strs[i], newSt.strs[i], sizeof(pold->strs[i]));
+                pold->strs[i][sizeof(pold->strs[i])-1] = '\0';
+            }
             /*now get values*/
             options = 0;
             status = dbChannelGet(chan, DBR_ENUM, &pold->value, &options,

--- a/modules/database/src/std/link/lnkConst.c
+++ b/modules/database/src/std/link/lnkConst.c
@@ -212,7 +212,7 @@ static jlif_result lnkConst_string(jlink *pjlink, const char *val, size_t len)
             return jlif_stop;
 
         strncpy(str, val, len);
-        str[len] = '\0';
+        str[len-1] = '\0';
         clink->type = sc40;
         clink->value.scalar_string = str;
         break;
@@ -229,7 +229,7 @@ static jlif_result lnkConst_string(jlink *pjlink, const char *val, size_t len)
             return jlif_stop;
 
         strncpy(str, val, len);
-        str[len] = '\0';
+        str[len-1] = '\0';
         vec[clink->nElems] = str;
         clink->value.pstrings = vec;
         break;
@@ -496,7 +496,7 @@ static long lnkConst_loadArray(struct link *plink, short dbrType, void *pbuffer,
         else {
             /* Long string conversion */
             strncpy(pbuffer, clink->value.scalar_string, *pnReq);
-            ((char *)pbuffer)[*pnReq] = 0;
+            ((char *)pbuffer)[*pnReq-1] = 0;
             nElems = strlen(pbuffer) + 1;
             status = 0;
         }

--- a/modules/libcom/src/misc/epicsString.c
+++ b/modules/libcom/src/misc/epicsString.c
@@ -442,3 +442,11 @@ done:
     free(dist1);
     return ret;
 }
+
+/* Identical to strncpy but ensures dest is terminated */
+char* epicsStrnCpy(char* dest, const char* src, size_t destSize)
+{
+    char* ret = strncpy(dest, src, destSize);
+    dest[destSize-1] = 0;
+    return ret;
+}

--- a/modules/libcom/src/misc/epicsString.h
+++ b/modules/libcom/src/misc/epicsString.h
@@ -37,6 +37,9 @@ LIBCOM_API int epicsStrPrintEscaped(FILE *fp, const char *s, size_t n);
 #define epicsStrSnPrintEscaped epicsStrnEscapedFromRaw
 LIBCOM_API size_t epicsStrnLen(const char *s, size_t maxlen);
 
+/* Behaves identically to strncpy except that it always NULL terminates dest */
+LIBCOM_API char* epicsStrnCpy(char* dest, const char* src, size_t destSize);
+
 /** Matches a string against a pattern.
  *
  * Checks if str matches the glob style pattern, which may contain ? or * wildcards.
@@ -80,6 +83,15 @@ LIBCOM_API int dbTranslateEscape(char *s, const char *ct);
 
 #ifdef __cplusplus
 }
+#endif
+
+#if __cplusplus >= 201103L
+
+template<size_t N>
+static inline char* epicsStrnCpy(char(&dest)[N], const char* src) {
+    return epicsStrnCpy(dest, src, N);
+}
+
 #endif
 
 #endif /* INC_epicsString_H */


### PR DESCRIPTION
In a few places, strings were not explicitly null terminated following calls to `strncpy`, which doesn't always null terminate the destination buffer.

libcom's string handling library is a bit lacking, so I also added `epicsStrnCpy`. It's identical to `strncpy` except that it always null terminates the destination buffer for a bit of added safety.

For C++11 and higher, `epicsStrnCpy` is also provided as a template function that can deduce the input buffer size if working with C arrays. Example:
```
char buffer[64];
epicsStrnCpy(buffer, "my cool string");
```