### PR TITLE
Adding new epicsThreadCreateJoinable function

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -16,6 +16,10 @@ should also be read to understand what has changed since earlier releases.
 
 <!-- Insert new items immediately below here ... -->
 
+### Add `epicsThreadCreateJoinable` function
+
+Adds a function to the libcom API for shorthand creation of joinable threads, without the use of `epicsThreadCreateOpt`.
+
 ### Perl CA support for empty long strings
 
 The Perl CA bindings have been fixed to handle zero-length long string data

--- a/modules/database/src/ioc/db/dbCa.c
+++ b/modules/database/src/ioc/db/dbCa.c
@@ -319,11 +319,6 @@ void dbCaShutdown(void)
 
 static void dbCaLinkInitImpl(int isolate)
 {
-    epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
-
-    opts.stackSize = epicsThreadGetStackSize(epicsThreadStackBig);
-    opts.priority = epicsThreadPriorityMedium;
-    opts.joinable = 1;
 
     dbServiceIsolate = isolate;
     dbServiceIOInit();
@@ -337,7 +332,9 @@ static void dbCaLinkInitImpl(int isolate)
         startStopEvent = epicsEventMustCreate(epicsEventEmpty);
     dbCaCtl = ctlPause;
 
-    dbCaWorker = epicsThreadCreateOpt("dbCaLink", dbCaTask, NULL, &opts);
+    dbCaWorker = epicsThreadCreateJoinable("dbCaLink", epicsThreadPriorityMedium,
+                        epicsThreadStackBig, dbCaTask, NULL);
+    
     /* wait for worker to startup and initialize dbCaClientContext */
     epicsEventMustWait(startStopEvent);
 }

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -1131,11 +1131,6 @@ int db_start_events (
     void *init_func_arg, unsigned osiPriority )
 {
      struct event_user * const evUser = (struct event_user *) ctx;
-     epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
-
-     opts.stackSize = epicsThreadGetStackSize(epicsThreadStackMedium);
-     opts.priority = osiPriority;
-     opts.joinable = 1;
 
      epicsMutexMustLock ( evUser->lock );
 
@@ -1153,8 +1148,9 @@ int db_start_events (
      if (!taskname) {
          taskname = EVENT_PEND_NAME;
      }
-     evUser->taskid = epicsThreadCreateOpt (
-         taskname, event_task, (void *)evUser, &opts);
+     evUser->taskid = epicsThreadCreateJoinable(taskname, osiPriority, 
+                                                epicsThreadGetStackSize(epicsThreadStackMedium), 
+                                                event_task, (void *)evUser);
      if (!evUser->taskid) {
          epicsMutexUnlock ( evUser->lock );
          return DB_EVENT_ERROR;

--- a/modules/database/src/ioc/db/dbUnitTest.h
+++ b/modules/database/src/ioc/db/dbUnitTest.h
@@ -297,11 +297,8 @@ DBCORE_API void testGlobalUnlock(void);
  * @code
  * epicsEventId evt;
  * void thread1() {
- *     epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
- *     epicsThreadId t2;
- *     opts.joinable = 1;
  *     evt = epicsEventMustCreate(...);
- *     t2 = epicsThreadCreateOpt("thread2", &thread2, NULL, &opts);
+ *     epicsThreadId t2 = epicsThreadCreateJoinable("thread2", epicsThreadPriorityLow, epicsThreadStackMedium, &thread2, NULL);
  *     assert(t2);
  *     epicsEventMustWait(evt);
  *     epicsThreadMustJoin(t2);

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -525,11 +525,6 @@ static void errlogInitPvt(void *arg)
 {
     struct initArgs *pconfig = (struct initArgs *) arg;
     epicsThreadId tid = NULL;
-    epicsThreadOpts topts = EPICS_THREAD_OPTS_INIT;
-
-    topts.priority = epicsThreadPriorityLow;
-    topts.stackSize = epicsThreadStackSmall;
-    topts.joinable = 1;
 
     /* Use of *Must* alloc functions would recurse on failure since
      * cantProceed() calls us.
@@ -560,7 +555,7 @@ static void errlogInitPvt(void *arg)
             && pvt.log->base
             && pvt.print->base
             ) {
-        tid = epicsThreadCreateOpt("errlog", (EPICSTHREADFUNC)errlogThread, 0, &topts);
+        tid = epicsThreadCreateJoinable("errlog", epicsThreadPriorityLow, epicsThreadStackSmall, (EPICSTHREADFUNC)errlogThread, 0);
     }
     if (tid) {
         pvt.errlogInitFailed = FALSE;

--- a/modules/libcom/src/osi/epicsThread.cpp
+++ b/modules/libcom/src/osi/epicsThread.cpp
@@ -43,6 +43,18 @@ epicsThreadId epicsStdCall epicsThreadCreate (
     return epicsThreadCreateOpt(name, funptr, parm, &opts);
 }
 
+epicsThreadId epicsStdCall epicsThreadCreateJoinable (
+    const char * name, unsigned int priority, unsigned int stackSize,
+    EPICSTHREADFUNC funptr,void * parm )
+{
+    epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
+    opts.priority = priority;
+    opts.stackSize = stackSize;
+    opts.joinable = 1;
+
+    return epicsThreadCreateOpt(name, funptr, parm, &opts);
+}
+
 epicsThreadRunable::~epicsThreadRunable () {}
 void epicsThreadRunable::run () {}
 void epicsThreadRunable::show ( unsigned int ) const {}

--- a/modules/libcom/src/osi/epicsThread.h
+++ b/modules/libcom/src/osi/epicsThread.h
@@ -188,6 +188,10 @@ LIBCOM_API epicsThreadId epicsThreadCreateOpt (
 LIBCOM_API epicsThreadId epicsStdCall epicsThreadCreate (
     const char * name, unsigned int priority, unsigned int stackSize,
     EPICSTHREADFUNC funptr,void * parm );
+/** Short-hand for epicsThreadCreateOpt() to create a joinable thread. */
+LIBCOM_API epicsThreadId epicsStdCall epicsThreadCreateJoinable (
+    const char * name, unsigned int priority, unsigned int stackSize,
+    EPICSTHREADFUNC funptr,void * parm );
 /** Short-hand for epicsThreadCreateOpt() to create an un-joinable thread.
  * On error calls cantProceed()
  */

--- a/modules/libcom/test/epicsThreadTest.cpp
+++ b/modules/libcom/test/epicsThreadTest.cpp
@@ -195,6 +195,10 @@ void testJoining()
     stuff.opts = &opts2;
     epicsThreadCreateOpt("parent", &joinTests, &stuff, &opts1);
     testOk(finished.wait(10.0), "Join tests #2 completed");
+
+    // Test shorthand function for creating joinable threads
+    epicsThreadCreateJoinable("parent", 40, epicsThreadStackMedium, &joinTests, &stuff);
+    testOk(finished.wait(10.0), "Join tests #3 completed");
 }
 
 } // namespace
@@ -243,7 +247,7 @@ static void testOkToBlock()
 
 MAIN(epicsThreadTest)
 {
-    testPlan(17);
+    testPlan(20);
 
     unsigned int ncpus = epicsThreadGetCPUs();
     testDiag("System has %u CPUs", ncpus);

--- a/modules/libcom/test/osiSockTest.c
+++ b/modules/libcom/test/osiSockTest.c
@@ -276,15 +276,12 @@ void udpSockFanoutTestIface(const osiSockAddr* addr)
     SOCKET sender;
     struct TInfo rx1, rx2;
     epicsThreadId trx1, trx2;
-    epicsThreadOpts topts = EPICS_THREAD_OPTS_INIT;
     int opt = 1;
     unsigned i;
     osiSockAddr any;
     epicsUInt32 key = 0xdeadbeef ^ ntohl(addr->ia.sin_addr.s_addr);
     union CASearchU buf;
     int ret;
-
-    topts.joinable = 1;
 
     /* we bind to any for lack of a portable way to find the
      * interface address from the interface broadcast address
@@ -332,8 +329,8 @@ void udpSockFanoutTestIface(const osiSockAddr* addr)
         goto cleanup;
     }
 
-    trx1 = epicsThreadCreateOpt("rx1", &udpSockFanoutTestRx, &rx1, &topts);
-    trx2 = epicsThreadCreateOpt("rx2", &udpSockFanoutTestRx, &rx2, &topts);
+    trx1 = epicsThreadCreateJoinable("rx1", epicsThreadPriorityLow, epicsThreadStackMedium, &udpSockFanoutTestRx, &rx1);
+    trx2 = epicsThreadCreateJoinable("rx2", epicsThreadPriorityLow, epicsThreadStackMedium, &udpSockFanoutTestRx, &rx2);
 
     for(i=0; i<nrepeat; i++) {
         /* don't spam */


### PR DESCRIPTION
Adding a simple utility function for shorthand creation of joinable threads. Just as with `epicsThreadCreate` I think it's easier to remember usage for this rather than initializing the opts manually for `epicsThreadCtreateOpt`