### PR TITLE
Add `epicsThreadMap2()`

### DIFF
--- a/modules/libcom/src/osi/epicsThread.cpp
+++ b/modules/libcom/src/osi/epicsThread.cpp
@@ -43,6 +43,18 @@ epicsThreadId epicsStdCall epicsThreadCreate (
     return epicsThreadCreateOpt(name, funptr, parm, &opts);
 }
 
+static
+void mapadapt(epicsThreadId thread, void *raw)
+{
+    EPICS_THREAD_HOOK_ROUTINE func = (EPICS_THREAD_HOOK_ROUTINE)raw;
+    (*func)(thread);
+}
+
+void epicsThreadMap(EPICS_THREAD_HOOK_ROUTINE func)
+{
+    epicsThreadMap2(mapadapt, (void*)func, EPICS_THREAD_MAP_EPICS|EPICS_THREAD_MAP_MAIN);
+}
+
 epicsThreadRunable::~epicsThreadRunable () {}
 void epicsThreadRunable::run () {}
 void epicsThreadRunable::show ( unsigned int ) const {}

--- a/modules/libcom/src/osi/epicsThread.h
+++ b/modules/libcom/src/osi/epicsThread.h
@@ -307,6 +307,9 @@ LIBCOM_API void epicsStdCall epicsThreadShow(
  **/
 typedef void (*EPICS_THREAD_HOOK_ROUTINE)(epicsThreadId id);
 
+/** See epicsThreadMap2() */
+typedef void (*EPICS_THREAD_MAP_ROUTINE)(epicsThreadId id, void* ptr);
+
 /**
  * Register a routine to be called by every new thread before the thread
  * function gets run. Hook routines will often register a thread exit
@@ -327,8 +330,42 @@ LIBCOM_API void epicsThreadHooksShow(void);
 
 /**
  * Call func once for every known thread.
+ *
+ * Equivalent to:
+ * \code
+ * epicsThreadMap2(func, NULL, EPICS_THREAD_MAP_EPICS|EPICS_THREAD_MAP_MAIN);
+ * \endcode
  **/
 LIBCOM_API void epicsThreadMap(EPICS_THREAD_HOOK_ROUTINE func);
+
+/** Include EPICS threads created by epicsThreadCreate*() */
+#define EPICS_THREAD_MAP_EPICS (1u)
+
+/** Include the "main" thread.
+ *  On targets where this is significant.
+ *  The first non-EPICS thread to call one of the epicsThread*() functions.
+ *  Usually, but not always, the same as process main() function.
+ */
+#define EPICS_THREAD_MAP_MAIN (2u)
+
+/** Include non-EPICS threads which have called some epicsThread*() functions.
+ *  This include the "main" thread.
+ */
+#define EPICS_THREAD_MAP_IMPLICIT (6u)
+
+/** \brief Call func(thr, ptr) once for every known thread.
+ *  \param func The callback function pointer.
+ *  \param ptr  Arbitrary pointer passed through to callback function.
+ *  \param flags Bitwise "or" of one or more EPICS_THREAD_MAP_*
+ *
+ *  \warning Callbacks are invoked while holding the internal mutex used
+ *           to guard the thread list.
+ *
+ *  \since UNRELEASED
+ **/
+LIBCOM_API void epicsThreadMap2(EPICS_THREAD_MAP_ROUTINE func,
+                                void* ptr,
+                                size_t flags);
 
 /** Thread local storage */
 typedef struct epicsThreadPrivateOSD * epicsThreadPrivateId;

--- a/modules/libcom/src/osi/os/Linux/osdThread.h
+++ b/modules/libcom/src/osi/os/Linux/osdThread.h
@@ -33,7 +33,7 @@ typedef struct epicsThreadOSD {
     void              *createArg;
     epicsEventId       suspendEvent;
     int                isSuspended;
-    int                isEpicsThread;
+    unsigned           mapMask;
     int                isRealTimeScheduled;
     int                isOnThreadList;
     unsigned int       osiPriority;

--- a/modules/libcom/src/osi/os/posix/osdThread.h
+++ b/modules/libcom/src/osi/os/posix/osdThread.h
@@ -31,7 +31,7 @@ typedef struct epicsThreadOSD {
     void              *createArg;
     epicsEventId       suspendEvent;
     int                isSuspended;
-    int                isEpicsThread;
+    unsigned           mapMask;
     int                isRealTimeScheduled;
     int                isOnThreadList;
     unsigned int       osiPriority;

--- a/modules/libcom/src/osi/os/vxWorks/osdThread.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdThread.c
@@ -458,11 +458,14 @@ void epicsThreadGetName (epicsThreadId id, char *name, size_t size)
     name[size-1] = '\0';
 }
 
-LIBCOM_API void epicsThreadMap ( EPICS_THREAD_HOOK_ROUTINE func )
+LIBCOM_API void epicsThreadMap2 ( EPICS_THREAD_MAP_ROUTINE func, void *ptr, size_t mask )
 {
     int noTasks = 0;
     int i;
     int result;
+
+    if(!( mask & EPICS_THREAD_MAP_EPICS ))
+        return;
 
     result = semTake(epicsThreadListMutex, WAIT_FOREVER);
     assert(result == OK);
@@ -477,7 +480,7 @@ LIBCOM_API void epicsThreadMap ( EPICS_THREAD_HOOK_ROUTINE func )
         }
     }
     for (i = 0; i < noTasks; i++) {
-        func ((epicsThreadId)taskIdList[i]);
+        func ((epicsThreadId)taskIdList[i], ptr);
     }
     semGive(epicsThreadListMutex);
 }


### PR DESCRIPTION
Expand to allow filtering by thread type (EPICS, main, or implicit), also to pass a `void*` through to the callback function.

Something I did while looking into #241.  I'm not sure if it is useful.