### PR TITLE
Errlog fixes

### DIFF
--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -234,22 +234,19 @@ int isATTY(FILE* fp)
 static
 int isATTY(FILE* fp)
 {
+#ifdef ENABLE_VIRTUAL_TERMINAL_PROCESSING
     HANDLE hand = NULL;
     DWORD mode = 0;
     if(fp==stdout)
         hand = GetStdHandle(STD_OUTPUT_HANDLE);
     else if(fp==stderr)
         hand = GetStdHandle(STD_ERROR_HANDLE);
-#ifdef ENABLE_VIRTUAL_TERMINAL_PROCESSING
     if(hand && GetConsoleMode(hand, &mode)) {
         (void)SetConsoleMode(hand, mode|ENABLE_VIRTUAL_TERMINAL_PROCESSING);
         mode = 0;
         if(GetConsoleMode(hand, &mode) && (mode&ENABLE_VIRTUAL_TERMINAL_PROCESSING))
             return 1;
     }
-#else
-    (void)hand;
-    (void)mode;
 #endif
     return 0;
 }


### PR DESCRIPTION
Allow partial messages. This fixes a problem with logMsg on VxWorks when using iocLogPrefix. Because logMsg sends partial messages to errlog, each format specifier in the messages had the prefix prepended and appended.
See bug report https://bugs.launchpad.net/epics-base/+bug/1983385.
Now, the message is accumulated until a part ends in \n. The the whole message is then sent and optionally prefixed.
Also avoid usage of %z (for VxWorks), make types more consistent (for Windows).