### PR TITLE
Improve `logClientPrefix`

### DIFF
--- a/modules/libcom/test/epicsErrlogTest.c
+++ b/modules/libcom/test/epicsErrlogTest.c
@@ -97,14 +97,16 @@ static SOCKET sock;
 static SOCKET insock;
 
 static const char* prefixactualmsg[]= {
-                     "A message without prefix",
-                     "A message with prefix",
-                     "DONE"
+                     "A message without prefix\n with leftovers",
+                     "A message with \na second prefix\n",
+                     "DONE\n"
                      };
 static const char *prefixstring = "fac=LI21 ";
-static const char prefixexpectedmsg[] = "A message without prefix"
-                     "fac=LI21 A message with prefix"
-                     "fac=LI21 DONE"
+static const char prefixexpectedmsg[] = "A message without prefix\n"
+                     " with leftovers"
+                     "fac=LI21 A message with \n"
+                     "fac=LI21 a second prefix\n"
+                     "fac=LI21 DONE\n"
                      ;
 static char prefixmsgbuffer[1024];
 


### PR DESCRIPTION
@dirk-zimoch Example of what I had in mind when writing https://github.com/epics-base/epics-base/pull/281#issuecomment-1206630893.  I've only tested that epicsErrlogTest passes.  There are still cases which may need to be considered.  eg. Multiple newline `"\n\n"`, possibly split over two calls.