### PR TITLE
`iocShutdown()`: Always stop worker threads

### DIFF
--- a/modules/database/src/ioc/db/callback.c
+++ b/modules/database/src/ioc/db/callback.c
@@ -301,13 +301,16 @@ void callbackInit(void)
             callbackQueue[i].threadsConfigured = callbackThreadsDefault;
 
         for (j = 0; j < callbackQueue[i].threadsConfigured; j++) {
+            epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
+            opts.joinable = 0;
+            opts.priority = threadPriority[i];
+            opts.stackSize = epicsThreadStackBig;
             if (callbackQueue[i].threadsConfigured > 1 )
                 sprintf(threadName, "%s-%d", threadNamePrefix[i], j);
             else
                 strcpy(threadName, threadNamePrefix[i]);
-            tid = epicsThreadCreate(threadName, threadPriority[i],
-                epicsThreadGetStackSize(epicsThreadStackBig),
-                (EPICSTHREADFUNC)callbackTask, &priorityValue[i]);
+            tid = epicsThreadCreateOpt(threadName,
+                (EPICSTHREADFUNC)callbackTask, &priorityValue[i], &opts);
             if (tid == 0) {
                 cantProceed("Failed to spawn callback thread %s\n", threadName);
             } else {

--- a/modules/database/src/ioc/db/callback.c
+++ b/modules/database/src/ioc/db/callback.c
@@ -58,6 +58,7 @@ typedef struct cbQueueSet {
     int shutdown; // use atomic
     int threadsConfigured;
     int threadsRunning;
+    epicsThreadId *threads;
 } cbQueueSet;
 
 static cbQueueSet callbackQueue[NUM_CALLBACK_PRIORITIES];
@@ -242,10 +243,14 @@ void callbackStop(void)
 
     for (i = 0; i < NUM_CALLBACK_PRIORITIES; i++) {
         cbQueueSet *mySet = &callbackQueue[i];
+        int j;
 
         while (epicsAtomicGetIntT(&mySet->threadsRunning)) {
             epicsEventSignal(mySet->semWakeUp);
             epicsEventWaitWithTimeout(startStopEvent, 0.1);
+        }
+        for(j=0; j<mySet->threadsConfigured; j++) {
+            epicsThreadMustJoin(mySet->threads[j]);
         }
     }
 }
@@ -266,6 +271,8 @@ void callbackCleanup(void)
         mySet->semWakeUp = NULL;
         epicsRingPointerDelete(mySet->queue);
         mySet->queue = NULL;
+        free(mySet->threads);
+        mySet->threads = NULL;
     }
 
     epicsTimerQueueRelease(timerQueue);
@@ -297,19 +304,24 @@ void callbackInit(void)
             cantProceed("epicsRingPointerLockedCreate failed for %s\n",
                 threadNamePrefix[i]);
         callbackQueue[i].queueOverflow = FALSE;
+
         if (callbackQueue[i].threadsConfigured == 0)
             callbackQueue[i].threadsConfigured = callbackThreadsDefault;
 
+        callbackQueue[i].threads = callocMustSucceed(callbackQueue[i].threadsConfigured,
+                                                     sizeof(*callbackQueue[i].threads),
+                                                     "callbackInit");
+
         for (j = 0; j < callbackQueue[i].threadsConfigured; j++) {
             epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
-            opts.joinable = 0;
+            opts.joinable = 1;
             opts.priority = threadPriority[i];
             opts.stackSize = epicsThreadStackBig;
             if (callbackQueue[i].threadsConfigured > 1 )
                 sprintf(threadName, "%s-%d", threadNamePrefix[i], j);
             else
                 strcpy(threadName, threadNamePrefix[i]);
-            tid = epicsThreadCreateOpt(threadName,
+            callbackQueue[i].threads[j] = tid = epicsThreadCreateOpt(threadName,
                 (EPICSTHREADFUNC)callbackTask, &priorityValue[i], &opts);
             if (tid == 0) {
                 cantProceed("Failed to spawn callback thread %s\n", threadName);

--- a/modules/database/src/ioc/db/dbScan.c
+++ b/modules/database/src/ioc/db/dbScan.c
@@ -168,9 +168,13 @@ void scanStop(void)
         epicsEventSignal(ppsl->loopEvent);
         epicsEventWait(startStopEvent);
     }
+    for (i = 0; i < nPeriodic; i++) {
+        epicsThreadMustJoin(periodicTaskId[i]);
+    }
 
     scanOnce((dbCommon *)&exitOnce);
     epicsEventWait(startStopEvent);
+    epicsThreadMustJoin(onceTaskId);
 }
 
 void scanCleanup(void)
@@ -762,7 +766,7 @@ void scanOnceQueueShow(const int reset)
 static void initOnce(void)
 {
     epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
-    opts.joinable = 0;
+    opts.joinable = 1;
     opts.priority = epicsThreadPriorityScanLow + nPeriodic;
     opts.stackSize = epicsThreadStackBig;
     if ((onceQ = epicsRingBytesLockedCreate(sizeof(onceEntry)*onceQueueSize)) == NULL) {
@@ -935,7 +939,7 @@ static void spawnPeriodic(int ind)
     periodic_scan_list *ppsl = papPeriodic[ind];
     char taskName[20];
     epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
-    opts.joinable = 0;
+    opts.joinable = 1;
     opts.priority = epicsThreadPriorityScanLow + ind;
     opts.stackSize = epicsThreadStackBig;
 

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -716,13 +716,13 @@ int iocShutdown(void)
     iterateRecords(doCloseLinks, NULL);
     initHookAnnounce(initHookAfterCloseLinks);
 
-    if (iocBuildMode == buildIsolated) {
-        /* stop and "join" threads */
-        scanStop();
-        initHookAnnounce(initHookAfterStopScan);
-        callbackStop();
-        initHookAnnounce(initHookAfterStopCallback);
-    } else {
+    /* stop and "join" threads */
+    scanStop();
+    initHookAnnounce(initHookAfterStopScan);
+    callbackStop();
+    initHookAnnounce(initHookAfterStopCallback);
+
+    if (iocBuildMode != buildIsolated) {
         dbStopServers();
     }
 

--- a/modules/libcom/src/iocsh/initHooks.h
+++ b/modules/libcom/src/iocsh/initHooks.h
@@ -95,9 +95,9 @@ typedef enum {
 
     initHookAtShutdown,             /**< Start of iocShutdown() (unit tests only) */
     initHookAfterCloseLinks,        /**< Links disabled/deleted */
-    initHookAfterStopScan,          /**< Scan tasks stopped */
+    initHookAfterStopScan,          /**< Scan tasks stopped.  Prior to UNRELEASED, triggered only by unittest code. */
     initHookAfterStopCallback,      /**< Callback tasks stopped */
-    initHookAfterStopLinks,         /**< CA links stopped */
+    initHookAfterStopLinks,         /**< CA links stopped.  Prior to UNRELEASED, triggered only by unittest code. */
     initHookBeforeFree,             /**< Resource cleanup about to happen */
     initHookAfterShutdown,          /**< End of iocShutdown() */
 

--- a/modules/libcom/src/osi/os/RTEMS-score/osdThread.c
+++ b/modules/libcom/src/osi/os/RTEMS-score/osdThread.c
@@ -371,6 +371,9 @@ void epicsThreadMustJoin(epicsThreadId id)
     rtems_id target_tid = (rtems_id)id, self_tid;
     struct taskVar *v = 0;
 
+    if(!id)
+        return;
+
     rtems_task_ident (RTEMS_SELF, 0, &self_tid);
 
     {


### PR DESCRIPTION
Something I'm testing following a [a tech-talk discussion](https://epics.anl.gov/tech-talk/2022/msg01081.php) involving ideas for improving IOC shutdown.

Switch `iocShutdown()` to unconditionally stop and join dbScan and callback worker threads.

The goal is to reduce the scope for race conditions in `epicsAtExit()` and `initHookAfterShutdown` callbacks.

Joining these threads opens up a possibility for a new deadlocks in user code if one of the threads being joined is eg. waiting on `epicsExit()`.  In the specific case of `epicsExit()`, the fix is switching to `epicsExitLater()` cf. 924350b362edde17f612dff575af5effaaff4886.