### PR TITLE
fix aSub with constant input links

### DIFF
--- a/modules/database/src/std/rec/aSubRecord.c
+++ b/modules/database/src/std/rec/aSubRecord.c
@@ -275,8 +275,11 @@ static long fetch_values(aSubRecord *prec)
 
     /* Get the input link values */
     for (i = 0; i < NUM_ARGS; i++) {
+        DBLINK *plink = &(&prec->inpa)[i];
         long nRequest = (&prec->noa)[i];
-        status = dbGetLink(&(&prec->inpa)[i], (&prec->fta)[i], (&prec->a)[i], 0,
+        if(dbLinkIsConstant(plink))
+            continue;
+        status = dbGetLink(plink, (&prec->fta)[i], (&prec->a)[i], 0,
             &nRequest);
         if (status)
             return status;

--- a/modules/database/test/std/rec/regressTest.c
+++ b/modules/database/test/std/rec/regressTest.c
@@ -76,11 +76,29 @@ void testArrayLength1(void)
 
 /*
  * https://bugs.launchpad.net/epics-base/+bug/1699445 and 1887981
+ *
+ * also https://github.com/epics-base/epics-base/issues/284
  */
 static
 void testHexConstantLinks(void)
 {
     startRegressTestIoc("regressHex.db");
+
+    testdbGetFieldEqual("ai1", DBR_LONG, 0x10);
+    testdbGetFieldEqual("li1", DBR_LONG, 0x10);
+    testdbGetFieldEqual("mi1", DBR_LONG, 0x10);
+    testdbGetFieldEqual("as1.A", DBR_LONG, 0x10);
+    testdbGetFieldEqual("as1.B", DBR_LONG, 0x10);
+    testdbGetFieldEqual("as1.C", DBR_LONG, 0x10);
+    testdbGetFieldEqual("as1.D", DBR_LONG, 0x10);
+    testdbGetFieldEqual("as1.E", DBR_LONG, 0x10);
+    testdbGetFieldEqual("as1.F", DBR_LONG, 0x10);
+    testdbGetFieldEqual("as1.G", DBR_LONG, 0x10);
+    testdbGetFieldEqual("as1.H", DBR_LONG, 0x10);
+
+    testdbPutFieldOk("ai1.PROC", DBR_LONG, 1);
+    testdbPutFieldOk("li1.PROC", DBR_LONG, 1);
+    testdbPutFieldOk("as1.PROC", DBR_LONG, 1);
 
     testdbGetFieldEqual("ai1", DBR_LONG, 0x10);
     testdbGetFieldEqual("li1", DBR_LONG, 0x10);
@@ -210,7 +228,7 @@ void testLinkSevr(void)
 
 MAIN(regressTest)
 {
-    testPlan(54);
+    testPlan(68);
     testArrayLength1();
     testHexConstantLinks();
     testLinkMS();


### PR DESCRIPTION
Attempt to fix #284

Open questions:

- [ ] Do other record types working with arrays need the same change? 

That is, places where `dbGetLink()` is called with `pnRequest!=NULL`.

rset and dset for aai, aao, subArray, waveform.  rset for compressRecord and printfRecord.  lnkCalc.c.