### PR TITLE
iocinf.cpp: Hostnames may be longer than 32 bytes

### DIFF
--- a/modules/ca/src/client/iocinf.cpp
+++ b/modules/ca/src/client/iocinf.cpp
@@ -79,7 +79,7 @@ extern "C" int epicsStdCall addAddrToChannelAccessAddressList
     const char *pStr;
     const char *pToken;
     struct sockaddr_in addr;
-    char buf[32u]; /* large enough to hold an IP address */
+    char buf[256u]; /* large enough to hold an IP address or hostname */
     int status, ret = -1;
 
     pStr = envGetConfigParamPtr (pEnv);


### PR DESCRIPTION
Found here at ESS:

(all in one line)
EPICS_PVA_ADDR_LIST=averylonghostname.mylabnetwork.technicalnetwork.example.com
EPICS_PVA_AUTO_ADDR_LIST=NO
pvget somePVnam

leads to something like this:
CA.Client.Exception...............................................
    Warning: "Empty PV search address list"
    Source File: ../udpiiu.cpp line 403
    Current Time: Thu Jun 09 2022 10:10:47.804161447

Solution:
Increase the buf size in addAddrToChannelAccessAddressList() from 32 to 256