### PR TITLE
Fix missing test dependencies

### DIFF
--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -372,7 +372,7 @@ $(MODNAME): %$(MODEXT): %$(EXE)
 #---------------------------------------------------------------
 # Automated testing
 
-runtests: run-tap-tests
+runtests: build run-tap-tests
 run-tap-tests: $(TESTSCRIPTS.t)
 ifneq ($(TESTSCRIPTS.t),)
 ifdef RUNTESTS_ENABLED


### PR DESCRIPTION
See https://github.com/epics-base/epics-base/issues/293. The gist is that tests with custom perl wrappers do not register their dependencies on their source files, which can result in tests failing if test are modified or removed after they are built.