### PR TITLE
COMMANDLINE_LIBRARY fallback to $(wildcard $(GNU_DIR)

### DIFF
--- a/configure/toolchain.c
+++ b/configure/toolchain.c
@@ -45,5 +45,5 @@ COMMANDLINE_LIBRARY ?= READLINE
 COMMANDLINE_LIBRARY ?= EPICS
 #  endif
 #else
-COMMANDLINE_LIBRARY ?= EPICS
+COMMANDLINE_LIBRARY ?= $(strip $(if $(wildcard $(if $(GNU_DIR),$(GNU_DIR)/include/readline/readline.h)), READLINE, EPICS))
 #endif


### PR DESCRIPTION
Attempt to restore auto-detect with older compilers (eg. GCC 4.8 circa RHEL7).  cf #254

https://epics.anl.gov/core-talk/2022/msg00381.php

This PR is not a simple revert.  For simplicity, the older `$(wildcard)` logic is placed in an `#else` clause within `configure/toolchain.c` (which is really a makefile) where it will be run for all targets, not just the select`linux*` targets where it was previously found (cf. 42c7dbcd21b82ee4c9d43e1d43b05ec8445009f3).

As this change tests for `GNU_DIR` being not-empty, I don't think this would effect MSVC or RTEMS targets.  It might effect linux, apple, solaris, cygwin, mingw, and vxworks.  Where it could cause breakage if some (misconfigured) target has GNU_DIR set incorrectly (eg. for the host of a cross build), or if the headers are detect but the library is not in the search path.
