### PR TITLE
Modify pointer type in example to match options from epicsTypes.h

### DIFF
--- a/modules/database/src/std/rec/aSubRecord.dbd.pod
+++ b/modules/database/src/std/rec/aSubRecord.dbd.pod
@@ -2354,11 +2354,11 @@ The associated subroutine code that uses the A field might look like this:
 
     static long my_asub_routine(aSubRecord *prec) {
         long i;
-        epicsUInt32 *a;
+        epicsInt32 *a;
 
         double sum=0;
         ...
-        a = (epicsUInt32 *)prec->a;
+        a = (epicsInt32 *)prec->a;
         for (i=0; i<prec->noa; i++) {
             sum += a[i];
         }

--- a/modules/database/src/std/rec/aSubRecord.dbd.pod
+++ b/modules/database/src/std/rec/aSubRecord.dbd.pod
@@ -2353,10 +2353,12 @@ value, you would either delete the NOA specification, or specify it as "1".
 The associated subroutine code that uses the A field might look like this:
 
     static long my_asub_routine(aSubRecord *prec) {
-        long i, *a;
+        long i;
+        epicsUInt32 *a;
+
         double sum=0;
         ...
-        a = (long *)prec->a;
+        a = (epicsUInt32 *)prec->a;
         for (i=0; i<prec->noa; i++) {
             sum += a[i];
         }


### PR DESCRIPTION
This example in the documentation was somewhat misleading and caused us a bit of a headache when running similar code on our real-time linux servers.  For the aSub record in this example, the pointer to input A is declared as long*, while instead it should be declared as a pointer to a type selected from epicsTypes.h.  In our case, our linuxRT C/C++ compiler assumes long to be 8 bytes, whereas input A in the aSub record was declared as an EPICS LONG, hence 4 bytes.  As a result, we would only read every other array element in the subroutine and resulted in incorrect calculations.