### PR TITLE
Remove global constructors from libCom

### DIFF
--- a/modules/libcom/src/cxxTemplates/epicsSingleton.h
+++ b/modules/libcom/src/cxxTemplates/epicsSingleton.h
@@ -23,6 +23,9 @@
 
 class SingletonUntyped {
 public:
+#if __cplusplus>=201103L
+    constexpr
+#endif
     SingletonUntyped () :_pInstance ( 0 ), _refCount ( 0 ) {}
 #   if 0
     ~SingletonUntyped () {
@@ -112,6 +115,9 @@ public:
         epicsSingleton * _pSingleton;
     };
     friend class reference;
+#if __cplusplus>=201103L
+    constexpr
+#endif
     epicsSingleton () {}
     // mutex lock/unlock pair overhead incurred
     // when either of these are called

--- a/modules/libcom/src/fdmgr/fdManager.h
+++ b/modules/libcom/src/fdmgr/fdManager.h
@@ -113,7 +113,9 @@ private:
 //
 // default file descriptor manager
 //
-LIBCOM_API extern fdManager fileDescriptorManager;
+LIBCOM_API
+fdManager& fileDescriptorManagerInstance();
+#define fileDescriptorManager fileDescriptorManagerInstance()
 
 //
 // fdReg
@@ -127,7 +129,9 @@ class LIBCOM_API fdReg :
 public:
 
     fdReg (const SOCKET fdIn, const fdRegType type,
-        const bool onceOnly=false, fdManager &manager = fileDescriptorManager);
+        const bool onceOnly=false);
+    fdReg (const SOCKET fdIn, const fdRegType type,
+        const bool onceOnly, fdManager &manager);
     virtual ~fdReg ();
 
     virtual void show (unsigned level) const;

--- a/modules/libcom/src/osi/epicsThread.cpp
+++ b/modules/libcom/src/osi/epicsThread.cpp
@@ -382,12 +382,3 @@ extern "C" {
         return id;
     }
 } // extern "C"
-
-static epicsThreadId initMainThread(void) {
-    epicsThreadId main = epicsThreadGetIdSelf();
-    epicsThreadSetOkToBlock(1);
-    return main;
-}
-
-// Ensure the main thread gets a unique ID and allows blocking I/O
-epicsThreadId epicsThreadMainId = initMainThread();


### PR DESCRIPTION
C++ global constructors have well known pitfalls with respect to initialization order.  With Com they also trigger #286.

Status as of 1d19ba4cc2e8c9ab17288b684022a0682e398bde :

- [X] `epicsSingleton` constructors
  -  Fixed by 8f1243da406aebf5a8cebda65ea84e5dbeeff286 when building with `-std=c++11` or later.
- [ ] `fileDescriptorManager` singleton
  - https://github.com/epics-base/epics-base/pull/298 has an example of making the singleton lazy, now out of date.
- [X] `localRegister()` in iocsh.cpp
  - Fixed by 7830345e5927ca1f262dda17a1f819286c5b5821
- [ ] `initMainThread()`
  - Removed by #451
- [ ] `timeRegister()` really two separate instances
  - [ ] in `posix/osdTime.cpp`
  - [ ] in `Darwin/osdTime.cpp`

The remaining `timeRegister()` in the various `osdTime.cpp` seem less trivial.  Some of this work might be moved to `generalTime_Init()`.  Which might require changes around the `useOsdGetCurrent` optimization.  Something different would be needed for `osdMonotonicInit()`.
