### PR TITLE
Fix ringPointerTest priority

### DIFF
--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -758,6 +758,9 @@ LIBCOM_API void epicsStdCall epicsThreadSetPriority(epicsThreadId pthreadInfo,un
     assert(epicsThreadOnceCalled);
     assert(pthreadInfo);
     if(!pthreadInfo->isEpicsThread) {
+        /* not allowed to avoid dealing with (potentially) different scheduling
+         * policies (FIFO vs. RR vs. OTHER vs. ...)
+         */
         fprintf(stderr,"epicsThreadSetPriority called by non epics thread\n");
         return;
     }


### PR DESCRIPTION
Correctly avoid call to `epicsThreadSetPriority()` from non-epics thread `main()` (`prio==0` does not imply non-epics thread).

@hjunkes fyi.  What we looked at during the recent BNL meeting.