### PR TITLE
errlog fixes

### DIFF
--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -178,6 +178,9 @@ LIBCOM_API void errlogAddListener(errlogListener listener, void *pPrivate);
  *
  * \param listener Function pointer of type ::errlogListener
  * \param pPrivate This will be passed as the first argument of listener()
+ *
+ * \since UNRELEASED Safe to call from a listener callback.
+ * \until UNRELEASED Self-removal from a listener callback caused corruption.
  */
 LIBCOM_API int errlogRemoveListeners(errlogListener listener,
     void *pPrivate);


### PR DESCRIPTION
- errlog: worker exit when buffer is empty

Ensure buffered messages are printed when errlog shuts down.

This is likely a regression introduced by #113.

- errlogRemoveListeners() handle self-removal

Make `errlogRemoveListeners()` safe for self-removal from a listener callback.  Current code corrupts the `listenerList`.

This was an issue prior to #113 as well.