### PR TITLE
Add support for CA tools timeout from environment variable

### DIFF
--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -436,11 +436,6 @@ int main (int argc, char *argv[])
             enumAsNr = 1;
             break;
         case 'w':               /* Set CA timeout value */
-            /*
-             * epicsScanDouble is a macro defined as epicsParseDouble,
-             * (found in modules/libcom/src/misc) which will only
-             * change caTimeout here if it finds an acceptable value.
-             */
             if(epicsScanDouble(optarg, &caTimeout) != 1)
             {
                 fprintf(stderr, "'%s' is not a valid timeout value "

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -24,8 +24,6 @@
  *     Added field separators
  *  2009/04/01 Ralph Lange (HZB/BESSY)
  *     Added support for long strings (array of char) and quoting of nonprintable characters
- *  2022/12/06 Doug Murray (SLAC)
- *     Added CA timeout environment variable
  *
  */
 
@@ -391,20 +389,10 @@ int main (int argc, char *argv[])
 
     int nPvs;                   /* Number of PVs */
     pv* pvs;                    /* Array of PV structures */
-    const char* tmo;            /* timeout from environment var */
 
     LINE_BUFFER(stdout);        /* Configure stdout buffering */
 
-    if ((tmo = getenv(DEFAULT_TIMEOUT_ENV)) != NULL)
-    {
-    if(epicsScanDouble(tmo, &caTimeout) != 1)
-            {
-                fprintf(stderr, "'%s' is not a valid timeout value "
-                        "(from '%s' in the environment) - ignored. ('caget -h' for help.)\n", tmo, DEFAULT_TIMEOUT_ENV);
-                caTimeout = DEFAULT_TIMEOUT;
-            }
-
-    }
+    use_ca_timeout_env ( &caTimeout);
 
     while ((opt = getopt(argc, argv, ":taicnhsSVe:f:g:l:#:d:0:w:p:F:")) != -1) {
         switch (opt) {

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -436,15 +436,16 @@ int main (int argc, char *argv[])
             enumAsNr = 1;
             break;
         case 'w':               /* Set CA timeout value */
+            /*
+             * epicsScanDouble is a macro defined as epicsParseDouble,
+             * (found in modules/libcom/src/misc) which will only
+             * change caTimeout here if it finds an acceptable value.
+             */
+            if(epicsScanDouble(optarg, &caTimeout) != 1)
             {
-                double prevTimeout = caTimeout;
-                if(epicsScanDouble(optarg, &caTimeout) != 1)
-                {
-                    caTimeout = prevTimeout;
-                    fprintf(stderr, "'%s' is not a valid timeout value "
-                            "- ignored, using '%.1f'. ('caget -h' for help.)\n",
-                            optarg, caTimeout);
-                }
+                fprintf(stderr, "'%s' is not a valid timeout value "
+                        "- ignored, using '%.1f'. ('caget -h' for help.)\n",
+                        optarg, caTimeout);
             }
             break;
         case '#':               /* Array count */

--- a/modules/ca/src/tools/cainfo.c
+++ b/modules/ca/src/tools/cainfo.c
@@ -152,15 +152,16 @@ int main (int argc, char *argv[])
             printf( "\nEPICS Version %s, CA Protocol version %s\n", EPICS_VERSION_STRING, ca_version() );
             return 0;
         case 'w':               /* Set CA timeout value */
+            /*
+             * epicsScanDouble is a macro defined as epicsParseDouble,
+             * (found in modules/libcom/src/misc) which will only
+             * change caTimeout here if it finds an acceptable value.
+             */
+            if(epicsScanDouble(optarg, &caTimeout) != 1)
             {
-                double prevTimeout = caTimeout;
-                if(epicsScanDouble(optarg, &caTimeout) != 1)
-                {
-                    caTimeout = prevTimeout;
-                    fprintf(stderr, "'%s' is not a valid timeout value "
-                            "- ignored, using '%.1f'. ('cainfo -h' for help.)\n",
-                            optarg, caTimeout);
-                }
+                fprintf(stderr, "'%s' is not a valid timeout value "
+                        "- ignored, using '%.1f'. ('cainfo -h' for help.)\n",
+                        optarg, caTimeout);
             }
             break;
         case 's':               /* ca_client_status interest level */

--- a/modules/ca/src/tools/cainfo.c
+++ b/modules/ca/src/tools/cainfo.c
@@ -19,8 +19,6 @@
  *     Updated usage info
  *  2009/04/01 Ralph Lange (HZB/BESSY)
  *     Clarified output for native data type
- *  2022/12/06 Doug Murray (SLAC)
- *     Added CA timeout environment variable
  *
  */
 
@@ -140,20 +138,10 @@ int main (int argc, char *argv[])
 
     int nPvs;                   /* Number of PVs */
     pv* pvs;                    /* Array of PV structures */
-    const char* tmo;            /* timeout from environment var */
 
     LINE_BUFFER(stdout);        /* Configure stdout buffering */
 
-    if ((tmo = getenv(DEFAULT_TIMEOUT_ENV)) != NULL)
-    {
-    if(epicsScanDouble(tmo, &caTimeout) != 1)
-            {
-                fprintf(stderr, "'%s' is not a valid timeout value "
-                        "(from '%s' in the environment) - ignored. ('caget -h' for help.)\n", tmo, DEFAULT_TIMEOUT_ENV);
-                caTimeout = DEFAULT_TIMEOUT;
-            }
-
-    }
+    use_ca_timeout_env ( &caTimeout);
 
     while ((opt = getopt(argc, argv, ":nhVw:s:p:")) != -1) {
         switch (opt) {
@@ -170,7 +158,7 @@ int main (int argc, char *argv[])
                 {
                     caTimeout = prevTimeout;
                     fprintf(stderr, "'%s' is not a valid timeout value "
-                            "- ignored, using '%.1f'. ('caget -h' for help.)\n",
+                            "- ignored, using '%.1f'. ('cainfo -h' for help.)\n",
                             optarg, caTimeout);
                 }
             }

--- a/modules/ca/src/tools/camonitor.c
+++ b/modules/ca/src/tools/camonitor.c
@@ -21,6 +21,8 @@
  *     Added field separators
  *  2009/04/01 Ralph Lange (HZB/BESSY)
  *     Added support for long strings (array of char) and quoting of nonprintable characters
+ *  2022/12/06 Doug Murray (SLAC)
+ *     Added CA timeout environment variable
  *
  */
 
@@ -216,8 +218,20 @@ int main (int argc, char *argv[])
 
     int nPvs;                   /* Number of PVs */
     pv* pvs;                    /* Array of PV structures */
+    const char* tmo;            /* timeout from environment var */
 
     LINE_BUFFER(stdout);        /* Configure stdout buffering */
+
+    if ((tmo = getenv(DEFAULT_TIMEOUT_ENV)) != NULL)
+    {
+    if(epicsScanDouble(tmo, &caTimeout) != 1)
+            {
+                fprintf(stderr, "'%s' is not a valid timeout value "
+                        "(from '%s' in the environment) - ignored. ('caget -h' for help.)\n", tmo, DEFAULT_TIMEOUT_ENV);
+                caTimeout = DEFAULT_TIMEOUT;
+            }
+
+    }
 
     while ((opt = getopt(argc, argv, ":nhVm:sSe:f:g:l:#:0:w:t:p:F:")) != -1) {
         switch (opt) {
@@ -251,11 +265,15 @@ int main (int argc, char *argv[])
             }
             break;
         case 'w':               /* Set CA timeout value */
-            if(epicsScanDouble(optarg, &caTimeout) != 1)
             {
-                fprintf(stderr, "'%s' is not a valid timeout value "
-                        "- ignored. ('camonitor -h' for help.)\n", optarg);
-                caTimeout = DEFAULT_TIMEOUT;
+                double prevTimeout = caTimeout;
+                if(epicsScanDouble(optarg, &caTimeout) != 1)
+                {
+                    caTimeout = prevTimeout;
+                    fprintf(stderr, "'%s' is not a valid timeout value "
+                            "- ignored, using '%.1f'. ('caget -h' for help.)\n",
+                            optarg, caTimeout);
+                }
             }
             break;
         case '#':               /* Array count */

--- a/modules/ca/src/tools/camonitor.c
+++ b/modules/ca/src/tools/camonitor.c
@@ -253,15 +253,16 @@ int main (int argc, char *argv[])
             }
             break;
         case 'w':               /* Set CA timeout value */
+            /*
+             * epicsScanDouble is a macro defined as epicsParseDouble,
+             * (found in modules/libcom/src/misc) which will only
+             * change caTimeout here if it finds an acceptable value.
+             */
+            if(epicsScanDouble(optarg, &caTimeout) != 1)
             {
-                double prevTimeout = caTimeout;
-                if(epicsScanDouble(optarg, &caTimeout) != 1)
-                {
-                    caTimeout = prevTimeout;
-                    fprintf(stderr, "'%s' is not a valid timeout value "
-                            "- ignored, using '%.1f'. ('camonitor -h' for help.)\n",
-                            optarg, caTimeout);
-                }
+                fprintf(stderr, "'%s' is not a valid timeout value "
+                        "- ignored, using '%.1f'. ('camonitor -h' for help.)\n",
+                        optarg, caTimeout);
             }
             break;
         case '#':               /* Array count */

--- a/modules/ca/src/tools/camonitor.c
+++ b/modules/ca/src/tools/camonitor.c
@@ -21,8 +21,6 @@
  *     Added field separators
  *  2009/04/01 Ralph Lange (HZB/BESSY)
  *     Added support for long strings (array of char) and quoting of nonprintable characters
- *  2022/12/06 Doug Murray (SLAC)
- *     Added CA timeout environment variable
  *
  */
 
@@ -218,20 +216,10 @@ int main (int argc, char *argv[])
 
     int nPvs;                   /* Number of PVs */
     pv* pvs;                    /* Array of PV structures */
-    const char* tmo;            /* timeout from environment var */
 
     LINE_BUFFER(stdout);        /* Configure stdout buffering */
 
-    if ((tmo = getenv(DEFAULT_TIMEOUT_ENV)) != NULL)
-    {
-    if(epicsScanDouble(tmo, &caTimeout) != 1)
-            {
-                fprintf(stderr, "'%s' is not a valid timeout value "
-                        "(from '%s' in the environment) - ignored. ('caget -h' for help.)\n", tmo, DEFAULT_TIMEOUT_ENV);
-                caTimeout = DEFAULT_TIMEOUT;
-            }
-
-    }
+    use_ca_timeout_env ( &caTimeout);
 
     while ((opt = getopt(argc, argv, ":nhVm:sSe:f:g:l:#:0:w:t:p:F:")) != -1) {
         switch (opt) {
@@ -271,7 +259,7 @@ int main (int argc, char *argv[])
                 {
                     caTimeout = prevTimeout;
                     fprintf(stderr, "'%s' is not a valid timeout value "
-                            "- ignored, using '%.1f'. ('caget -h' for help.)\n",
+                            "- ignored, using '%.1f'. ('camonitor -h' for help.)\n",
                             optarg, caTimeout);
                 }
             }

--- a/modules/ca/src/tools/caput.c
+++ b/modules/ca/src/tools/caput.c
@@ -27,8 +27,6 @@
  *     Added field separators
  *  2009/04/01 Ralph Lange (HZB/BESSY)
  *     Added support for long strings (array of char) and quoting of nonprintable characters
- *  2022/12/06 Doug Murray (SLAC)
- *     Added CA timeout environment variable
  *
  */
 
@@ -279,7 +277,6 @@ int main (int argc, char *argv[])
     int len = 0;
     int waitStatus;
     struct dbr_gr_enum bufGrEnum;
-    const char *tmo;            /* timeout from environment var */
 
     int nPvs;                   /* Number of PVs */
     pv* pvs;                /* Array of PV structures */
@@ -287,16 +284,7 @@ int main (int argc, char *argv[])
     LINE_BUFFER(stdout);        /* Configure stdout buffering */
     putenv("POSIXLY_CORRECT="); /* Behave correct on GNU getopt systems */
 
-    if ((tmo = getenv(DEFAULT_TIMEOUT_ENV)) != NULL)
-    {
-    if(epicsScanDouble(tmo, &caTimeout) != 1)
-            {
-                fprintf(stderr, "'%s' is not a valid timeout value "
-                        "(from '%s' in the environment) - ignored. ('caget -h' for help.)\n", tmo, DEFAULT_TIMEOUT_ENV);
-                caTimeout = DEFAULT_TIMEOUT;
-            }
-
-    }
+    use_ca_timeout_env ( &caTimeout);
 
     while ((opt = getopt(argc, argv, ":cnlhatsVS#:w:p:F:")) != -1) {
         switch (opt) {
@@ -338,7 +326,7 @@ int main (int argc, char *argv[])
                 {
                     caTimeout = prevTimeout;
                     fprintf(stderr, "'%s' is not a valid timeout value "
-                            "- ignored, using '%.1f'. ('caget -h' for help.)\n",
+                            "- ignored, using '%.1f'. ('caput -h' for help.)\n",
                             optarg, caTimeout);
                 }
             }
@@ -355,7 +343,7 @@ int main (int argc, char *argv[])
             if (sscanf(optarg,"%u", &caPriority) != 1)
             {
                 fprintf(stderr, "'%s' is not a valid CA priority "
-                        "- ignored. ('caget -h' for help.)\n", optarg);
+                        "- ignored. ('caput -h' for help.)\n", optarg);
                 caPriority = DEFAULT_CA_PRIORITY;
             }
             if (caPriority > CA_PRIORITY_MAX) caPriority = CA_PRIORITY_MAX;

--- a/modules/ca/src/tools/caput.c
+++ b/modules/ca/src/tools/caput.c
@@ -320,15 +320,16 @@ int main (int argc, char *argv[])
             request = callback;
             break;
         case 'w':               /* Set CA timeout value */
+            /*
+             * epicsScanDouble is a macro defined as epicsParseDouble,
+             * (found in modules/libcom/src/misc) which will only
+             * change caTimeout here if it finds an acceptable value.
+             */
+            if(epicsScanDouble(optarg, &caTimeout) != 1)
             {
-                double prevTimeout = caTimeout;
-                if(epicsScanDouble(optarg, &caTimeout) != 1)
-                {
-                    caTimeout = prevTimeout;
-                    fprintf(stderr, "'%s' is not a valid timeout value "
-                            "- ignored, using '%.1f'. ('caput -h' for help.)\n",
-                            optarg, caTimeout);
-                }
+                fprintf(stderr, "'%s' is not a valid timeout value "
+                        "- ignored, using '%.1f'. ('caput -h' for help.)\n",
+                        optarg, caTimeout);
             }
             break;
         case '#':               /* Array count */

--- a/modules/ca/src/tools/tool_lib.c
+++ b/modules/ca/src/tools/tool_lib.c
@@ -19,8 +19,6 @@
  *     Added field separators
  *  2009/04/01 Ralph Lange (HZB/BESSY)
  *     Added support for long strings (array of char) and quoting of nonprintable characters
- *  2022/12/06 Doug Murray (SLAC)
- *     Changed caTimeout from 1.0 to DEFAULT_TIMEOUT
  *
  */
 
@@ -30,6 +28,7 @@
 
 #include <alarm.h>
 #include <epicsTime.h>
+#include <epicsStdlib.h>
 #include <epicsString.h>
 #include <cadef.h>
 
@@ -640,4 +639,33 @@ int connect_pvs (pv* pvs, int nPvs)
         }
     }
     return returncode;
+}
+
+
+/*+**************************************************************************
+ *
+ * Function:    use_ca_timeout_env
+ *
+ * Description: Set the variable at the given address to the
+ *              value of the CA timeout environment variable
+ *
+ * Arg(s) In:   timeout - Pointer to double
+ *
+ **************************************************************************-*/
+
+void use_ca_timeout_env ( double* timeout)
+{
+    const char* tmoStr;            /* contents of environment var */
+
+    if ((tmoStr = getenv("EPICS_CLI_TIMEOUT")) != NULL && timeout != NULL)
+    {
+        if(epicsScanDouble(tmoStr, timeout) != 1)
+        {
+            fprintf(stderr, "'%s' is not a valid timeout value "
+                "(from 'EPICS_CLI_TIMEOUT' in the environment) - "
+                "ignored. (use '-h' for help.)\n", tmoStr);
+            *timeout = DEFAULT_TIMEOUT;
+        }
+
+    }
 }

--- a/modules/ca/src/tools/tool_lib.c
+++ b/modules/ca/src/tools/tool_lib.c
@@ -19,6 +19,8 @@
  *     Added field separators
  *  2009/04/01 Ralph Lange (HZB/BESSY)
  *     Added support for long strings (array of char) and quoting of nonprintable characters
+ *  2022/12/06 Doug Murray (SLAC)
+ *     Changed caTimeout from 1.0 to DEFAULT_TIMEOUT
  *
  */
 
@@ -53,7 +55,7 @@ char fieldSeparator = ' ';          /* OFS default is whitespace */
 
 int enumAsNr = 0;        /* used for -n option - get DBF_ENUM as number */
 int charArrAsStr = 0;    /* used for -S option - treat char array as (long) string */
-double caTimeout = 1.0;  /* wait time default (see -w option) */
+double caTimeout = DEFAULT_TIMEOUT;  /* wait time default (see -w option) */
 capri caPriority = DEFAULT_CA_PRIORITY;  /* CA Priority */
 
 #define TIMETEXTLEN 28          /* Length of timestamp text buffer */

--- a/modules/ca/src/tools/tool_lib.c
+++ b/modules/ca/src/tools/tool_lib.c
@@ -642,17 +642,7 @@ int connect_pvs (pv* pvs, int nPvs)
 }
 
 
-/*+**************************************************************************
- *
- * Function:    use_ca_timeout_env
- *
- * Description: Set the variable at the given address to the
- *              value of the CA timeout environment variable
- *
- * Arg(s) In:   timeout - Pointer to double
- *
- **************************************************************************-*/
-
+/* Set the timeout to EPICS_CLI_TIMEOUT */
 void use_ca_timeout_env ( double* timeout)
 {
     const char* tmoStr;            /* contents of environment var */

--- a/modules/ca/src/tools/tool_lib.h
+++ b/modules/ca/src/tools/tool_lib.h
@@ -16,6 +16,8 @@
  *  Modification History
  *  2009/03/31 Larry Hoff (BNL)
  *     Added field separators
+ *  2022/12/06 Doug Murray (SLAC)
+ *      Added CA timeout environment variable definition
  *
  */
 
@@ -49,6 +51,7 @@
 
 #define DEFAULT_CA_PRIORITY 0  /* Default CA priority */
 #define DEFAULT_TIMEOUT 1.0     /* Default CA timeout */
+#define DEFAULT_TIMEOUT_ENV "EPICS_CLI_TIMEOUT" /* CA timeout environment var */
 
 #ifndef _WIN32
 #  define LINE_BUFFER(stream) setvbuf(stream, NULL, _IOLBF, BUFSIZ)

--- a/modules/ca/src/tools/tool_lib.h
+++ b/modules/ca/src/tools/tool_lib.h
@@ -16,8 +16,6 @@
  *  Modification History
  *  2009/03/31 Larry Hoff (BNL)
  *     Added field separators
- *  2022/12/06 Doug Murray (SLAC)
- *      Added CA timeout environment variable definition
  *
  */
 
@@ -51,7 +49,6 @@
 
 #define DEFAULT_CA_PRIORITY 0  /* Default CA priority */
 #define DEFAULT_TIMEOUT 1.0     /* Default CA timeout */
-#define DEFAULT_TIMEOUT_ENV "EPICS_CLI_TIMEOUT" /* CA timeout environment var */
 
 #ifndef _WIN32
 #  define LINE_BUFFER(stream) setvbuf(stream, NULL, _IOLBF, BUFSIZ)
@@ -103,6 +100,7 @@ extern char *dbr2str (const void *value, unsigned type);
 extern void print_time_val_sts (pv *pv, unsigned long reqElems);
 extern int  create_pvs (pv *pvs, int nPvs, caCh *pCB );
 extern int  connect_pvs (pv *pvs, int nPvs );
+extern void use_ca_timeout_env (double* timeout);
 
 /*
  * no additions below this endif

--- a/modules/libcom/src/misc/epicsStdlib.h
+++ b/modules/libcom/src/misc/epicsStdlib.h
@@ -87,8 +87,8 @@ LIBCOM_API int
  * \brief Convert a string to a double type
  *
  * \param str Pointer to a constant character array
- * \param to Pointer to the specified type (this will be set during the conversion)
- * \param units Pointer to a char * (this will be set with the units string)
+ * \param to Pointer to the specified type (this will be set only upon successful conversion)
+ * \param units Pointer to a char * (this will be set with the units string only upon successful conversion)
  * \return Status code (0=OK, see macro definitions for possible errors)
  */
 LIBCOM_API int


### PR DESCRIPTION
It would be useful to have EPICS Channel Access tools use an environment variable to specify a connection timeout to override the default of 1.0 seconds.  The '-w' flag will override the env variable (EPICS_CLI_TIMEOUT) for caput, caget, camonitor, and cainfo.