### PR TITLE
Fix epicsStrPrintEscaped to detect error in fprintf and return

### DIFF
--- a/modules/libcom/src/misc/epicsString.c
+++ b/modules/libcom/src/misc/epicsString.c
@@ -233,24 +233,30 @@ int epicsStrPrintEscaped(FILE *fp, const char *s, size_t len)
 
    while (len--) {
        char c = *s++;
+       int rc = 0;
 
        switch (c) {
-       case '\a':  nout += fprintf(fp, "\\a");  break;
-       case '\b':  nout += fprintf(fp, "\\b");  break;
-       case '\f':  nout += fprintf(fp, "\\f");  break;
-       case '\n':  nout += fprintf(fp, "\\n");  break;
-       case '\r':  nout += fprintf(fp, "\\r");  break;
-       case '\t':  nout += fprintf(fp, "\\t");  break;
-       case '\v':  nout += fprintf(fp, "\\v");  break;
-       case '\\':  nout += fprintf(fp, "\\\\"); break;
-       case '\'':  nout += fprintf(fp, "\\'");  break;
-       case '\"':  nout += fprintf(fp, "\\\"");  break;
+       case '\a':  rc = fprintf(fp, "\\a");  break;
+       case '\b':  rc = fprintf(fp, "\\b");  break;
+       case '\f':  rc = fprintf(fp, "\\f");  break;
+       case '\n':  rc = fprintf(fp, "\\n");  break;
+       case '\r':  rc = fprintf(fp, "\\r");  break;
+       case '\t':  rc = fprintf(fp, "\\t");  break;
+       case '\v':  rc = fprintf(fp, "\\v");  break;
+       case '\\':  rc = fprintf(fp, "\\\\"); break;
+       case '\'':  rc = fprintf(fp, "\\'");  break;
+       case '\"':  rc = fprintf(fp, "\\\"");  break;
        default:
            if (isprint(0xff & (int)c))
-               nout += fprintf(fp, "%c", c);
+               rc = fprintf(fp, "%c", c);
            else
-               nout += fprintf(fp, "\\x%02x", (unsigned char)c);
+               rc = fprintf(fp, "\\x%02x", (unsigned char)c);
            break;
+       }
+       if (rc < 0) {
+           return rc;
+       } else {
+           nout += rc;
        }
    }
    return nout;

--- a/modules/libcom/src/misc/epicsString.c
+++ b/modules/libcom/src/misc/epicsString.c
@@ -231,6 +231,12 @@ int epicsStrPrintEscaped(FILE *fp, const char *s, size_t len)
 {
    int nout = 0;
 
+   if (fp == NULL)
+       return -1;
+
+   if (s == NULL || strlen(s) == 0 || len == 0)
+       return 0; // No work to do
+
    while (len--) {
        char c = *s++;
        int rc = 0;

--- a/modules/libcom/test/epicsStringTest.c
+++ b/modules/libcom/test/epicsStringTest.c
@@ -199,24 +199,24 @@ static
 void testEpicsStrPrintEscaped(void)
 {   
     const char *filename = "testEpicsStrPrintEscaped";
-    // Create a file then re-open it read only
-    FILE *readOnly = fopen(filename, "a");
-    fclose(readOnly);
-    readOnly = fopen(filename, "r");
+    // Avoid printing to stdout by redirecting everything to a file
+    FILE *testFile = fopen(filename, "a");
+    FILE *readOnly = fopen(filename, "r");
 
     testDiag("testEpicsStrPrintEscaped()");
 
     // Passing cases
-    testOk1(epicsStrPrintEscaped(stdout, "1234", 4) == 4);
-    testOk1(epicsStrPrintEscaped(stdout, "\a\b\f\n\r\t\v\\\'\"", 10) == 20);
+    testOk1(epicsStrPrintEscaped(testFile, "1234", 4) == 4);
+    testOk1(epicsStrPrintEscaped(testFile, "\a\b\f\n\r\t\v\\\'\"", 10) == 20);
 
     //Failing cases
     testOk1(epicsStrPrintEscaped(readOnly, "1234", 4) == -1);
     testOk1(epicsStrPrintEscaped(NULL, "1234", 4) == -1);
-    testOk1(epicsStrPrintEscaped(stdout, NULL, 4) == 0);
-    testOk1(epicsStrPrintEscaped(stdout, "", 4) == 0);
-    testOk1(epicsStrPrintEscaped(stdout, "1234", 0) == 0);
+    testOk1(epicsStrPrintEscaped(testFile, NULL, 4) == 0);
+    testOk1(epicsStrPrintEscaped(testFile, "", 4) == 0);
+    testOk1(epicsStrPrintEscaped(testFile, "1234", 0) == 0);
 
+    fclose(testFile);
     fclose(readOnly);
     remove(filename);
 }

--- a/modules/libcom/test/epicsStringTest.c
+++ b/modules/libcom/test/epicsStringTest.c
@@ -195,6 +195,32 @@ void testStrTok(void)
     testTok(NULL, " \t", "bbb ", "bbb", "");
 }
 
+static
+void testEpicsStrPrintEscaped(void)
+{   
+    const char *filename = "testEpicsStrPrintEscaped";
+    // Create a file then re-open it read only
+    FILE *readOnly = fopen(filename, "a");
+    fclose(readOnly);
+    readOnly = fopen(filename, "r");
+
+    testDiag("testEpicsStrPrintEscaped()");
+
+    // Passing cases
+    testOk1(epicsStrPrintEscaped(stdout, "1234", 4) == 4);
+    testOk1(epicsStrPrintEscaped(stdout, "\a\b\f\n\r\t\v\\\'\"", 10) == 20);
+
+    //Failing cases
+    testOk1(epicsStrPrintEscaped(readOnly, "1234", 4) == -1);
+    testOk1(epicsStrPrintEscaped(NULL, "1234", 4) == -1);
+    testOk1(epicsStrPrintEscaped(stdout, NULL, 4) == 0);
+    testOk1(epicsStrPrintEscaped(stdout, "", 4) == 0);
+    testOk1(epicsStrPrintEscaped(stdout, "1234", 0) == 0);
+
+    fclose(readOnly);
+    remove(filename);
+}
+
 MAIN(epicsStringTest)
 {
     const char * const empty = "";
@@ -209,7 +235,7 @@ MAIN(epicsStringTest)
     char *s;
     int status;
 
-    testPlan(439);
+    testPlan(446);
 
     testChars();
 
@@ -407,6 +433,7 @@ MAIN(epicsStringTest)
 
     testDistance();
     testStrTok();
+    testEpicsStrPrintEscaped();
 
     return testDone();
 }

--- a/modules/libcom/test/epicsStringTest.c
+++ b/modules/libcom/test/epicsStringTest.c
@@ -209,9 +209,19 @@ void testEpicsStrPrintEscaped(void)
     testOk1(epicsStrPrintEscaped(testFile, "1234", 4) == 4);
     testOk1(epicsStrPrintEscaped(testFile, "\a\b\f\n\r\t\v\\\'\"", 10) == 20);
 
-    //Failing cases
-    testOk1(epicsStrPrintEscaped(readOnly, "1234", 4) == -1);
+    // Failing cases
     testOk1(epicsStrPrintEscaped(NULL, "1234", 4) == -1);
+    // On some platforms (specifially certain versions of MinGW-w64), fprintf
+    // is broken and does not return -1 when the write operation fails. On
+    // those platforms, epicsStrPrintEscaped cannot detect failure either, so
+    // testing that it reports failure does not make sense on those platforms.
+    // For this reason, we only test this behavior of epcisStrPrintEscaped when
+    // after checking that fprintf behaves correctly.
+    if (fprintf(readOnly, "test") == -1) {
+        testOk1(epicsStrPrintEscaped(readOnly, "1234", 4) == -1);
+    } else {
+        testSkip(1, "fprintf is broken on this system");
+    }
     testOk1(epicsStrPrintEscaped(testFile, NULL, 4) == 0);
     testOk1(epicsStrPrintEscaped(testFile, "", 4) == 0);
     testOk1(epicsStrPrintEscaped(testFile, "1234", 0) == 0);


### PR DESCRIPTION
This PR fixes issue #309.

`fprintf` returns a negative value in order to signal an error. We have to detect this situation in `epicsStrPrintEscaped` and return a negative when `fprintf` returns a negative value in order to give the calling code a chance to detect this situation.

The old implementation (of simply accumulating the return values of `fprintf`) was wrong anyway, because it would not only cause an error in `fprintf` to be lost but would also cause the returned number to be too small (not representing the actual number of bytes written) in such a case.

The only case where the old implementation would work correctly was when all calls to `fprintf` succeeded or all these calls failed.