### PR TITLE
Return an error if subrecord processing fails due to bad INP links

### DIFF
--- a/modules/database/src/std/rec/subRecord.c
+++ b/modules/database/src/std/rec/subRecord.c
@@ -162,7 +162,7 @@ static long process(struct dbCommon *pcommon)
     recGblFwdLink(prec);
     prec->pact = FALSE;
 
-    return 0;
+    return status;
 }
 
 static long special(DBADDR *paddr, int after)

--- a/modules/database/test/std/rec/Makefile
+++ b/modules/database/test/std/rec/Makefile
@@ -160,6 +160,16 @@ asyncproctest_SRCS += asyncproctest_registerRecordDeviceDriver.cpp
 TESTFILES += $(COMMON_DIR)/asyncproctest.dbd ../asyncproctest.db
 TESTS += asyncproctest
 
+TARGETS += $(COMMON_DIR)/subproctest.dbd
+DBDDEPENDS_FILES += subproctest.dbd$(DEP)
+subproctest_DBD += base.dbd
+TESTPROD_HOST += subproctest
+subproctest_SRCS += subproctest.c
+subproctest_SRCS += subproctest_registerRecordDeviceDriver.cpp
+TESTFILES += $(COMMON_DIR)/subproctest.dbd ../subproctest.db
+TESTS += subproctest
+
+
 TESTPROD_HOST += linkFilterTest
 linkFilterTest_SRCS += linkFilterTest.c
 linkFilterTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp

--- a/modules/database/test/std/rec/subproctest.c
+++ b/modules/database/test/std/rec/subproctest.c
@@ -44,7 +44,7 @@ MAIN(subproctest)
     // Since the put to PROC above fails, subproc() never runs
     // and the value of PROC will not be set by subproc().  However,
     // the testdbPutField call above goes through, so we get a partial
-    // result of the PROC file being left as 1.
+    // result of the PROC field being left as 1.
     testdbGetFieldEqual("InvalidINPARec.PROC", DBF_LONG, 1);
     
     testIocShutdownOk();

--- a/modules/database/test/std/rec/subproctest.c
+++ b/modules/database/test/std/rec/subproctest.c
@@ -1,0 +1,55 @@
+/*************************************************************************\
+* Copyright (c) 2022 UChicago Argonne LLC, as Operator of Argonne
+*     National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/* This test covers tests related to invoking subrecords
+ */
+
+#include <testMain.h>
+#include <dbUnitTest.h>
+#include <dbAccess.h>
+#include <iocsh.h>
+#include "registryFunction.h"
+#include <subRecord.h>
+
+static
+long subproc(subRecord *prec)
+{
+    prec->proc = 77;
+    return 0;
+}
+
+void subproctest_registerRecordDeviceDriver(struct dbBase *);
+
+MAIN(subproctest)
+{
+    testPlan(2);
+
+    testdbPrepare();
+
+    testdbReadDatabase("subproctest.dbd", NULL, NULL);
+    subproctest_registerRecordDeviceDriver(pdbbase);
+    registryFunctionAdd("subproc", (REGISTRYFUNCTION) subproc);
+    testdbReadDatabase("subproctest.db", NULL, "TPRO=0");
+
+    testIocInitOk();
+    testDiag("===== Test that invalid link in INPA field fails a put request ======");
+
+    testdbPutFieldFail(-1, "InvalidINPARec.PROC", DBF_LONG, 1);
+
+    // Since the put to PROC above fails, subproc() never runs
+    // and the value of PROC will not be set by subproc().  However,
+    // the testdbPutField call above goes through, so we get a partial
+    // result of the PROC file being left as 1.
+    testdbGetFieldEqual("InvalidINPARec.PROC", DBF_LONG, 1);
+    
+    testIocShutdownOk();
+
+    testdbCleanup();
+
+    return testDone();
+}

--- a/modules/database/test/std/rec/subproctest.c
+++ b/modules/database/test/std/rec/subproctest.c
@@ -41,10 +41,10 @@ MAIN(subproctest)
 
     testdbPutFieldFail(-1, "InvalidINPARec.PROC", DBF_LONG, 1);
 
-    // Since the put to PROC above fails, subproc() never runs
-    // and the value of PROC will not be set by subproc().  However,
-    // the testdbPutField call above goes through, so we get a partial
-    // result of the PROC field being left as 1.
+    /* Since the put to PROC above fails, subproc() never runs
+     * and the value of PROC will not be set by subproc().  However,
+     * the testdbPutField call above goes through, so we get a partial
+     * result of the PROC field being left as 1. */
     testdbGetFieldEqual("InvalidINPARec.PROC", DBF_LONG, 1);
     
     testIocShutdownOk();

--- a/modules/database/test/std/rec/subproctest.db
+++ b/modules/database/test/std/rec/subproctest.db
@@ -1,0 +1,4 @@
+record(sub, "InvalidINPARec") {
+    field(SNAM, "subproc")
+    field(INPA, "nonexistent")
+}


### PR DESCRIPTION
If a sub record has an invalid INPx link, it was silently failing (and not running the proc function).  This change plumbs in the error, so the put fails and the user knows something went wrong.