### PR TITLE
MacOs: Use readline from MacPorts

### DIFF
--- a/configure/os/CONFIG_SITE.darwinCommon.darwinCommon
+++ b/configure/os/CONFIG_SITE.darwinCommon.darwinCommon
@@ -12,6 +12,9 @@ ifneq (,$(wildcard /opt/homebrew))
 else ifneq (,$(wildcard /usr/local/Homebrew))
   # Default location on x86_64
   HOMEBREW_DIR = /usr/local
+else ifneq (,$(wildcard /opt/local/include/readline))
+  # MacPorts
+  READLINE_DIR = /opt/local
 endif
 
 # Look for Homebrew's readline


### PR DESCRIPTION
Commit b38ff09f6e2465a1085ac718beb994628c5b7430 and commit d9ca8a70f05bc61a6e4dfbe1518da8ce4f515651 introduced the TAB completion in iocsh.

Commit 1f75813a4d4571a9236a9268a11b8806a5878d1d enabled it for MacOs having readline installed via HomeBrew.

This commit enables it for MacPorts.