### PR TITLE
Optimize posix `epicsThreadOnce()`

### DIFF
--- a/modules/libcom/test/epicsThreadPerform.cpp
+++ b/modules/libcom/test/epicsThreadPerform.cpp
@@ -216,6 +216,42 @@ static void timeEpicsThreadPrivateGet ()
     printf("epicsThreadPrivateGet() takes %f microseconds\n", delay);
 }
 
+static void onceAction(void*) {}
+
+static void timeOnce ()
+{
+#define NITER 100
+    epicsThreadOnceId once[NITER];
+    double tSlow = 0.0, tFast = 0.0,
+           tSlow2= 0.0, tFast2= 0.0;
+    unsigned i;
+
+    for(i=0; i<NITER; i++) {
+        epicsUInt64 t0, t1, t2;
+
+        once[i] = EPICS_THREAD_ONCE_INIT;
+        t0 = epicsMonotonicGet();
+        epicsThreadOnce(&once[i], &onceAction, NULL);
+        t1 = epicsMonotonicGet();
+        epicsThreadOnce(&once[i], &onceAction, NULL);
+        t2 = epicsMonotonicGet();
+
+        tSlow += t1 - t0;
+        tSlow2 += (t1 - t0)*(t1 - t0);
+        tFast += t2 - t1;
+        tFast2 += (t2 - t1)*(t2 - t1);
+    }
+
+    tSlow /= NITER;
+    tSlow2 /= NITER;
+    tFast /= NITER;
+    tFast2 /= NITER;
+
+    printf("epicsThreadOnce(), slow path %.0f +- %.0f ns, fast path %.0f +- %.0f ns\n",
+           tSlow, sqrt(tSlow2 - tSlow*tSlow),
+           tFast, sqrt(tFast2 - tFast*tFast));
+#undef NITER
+}
 
 MAIN(epicsThreadPerform)
 {
@@ -224,5 +260,6 @@ MAIN(epicsThreadPerform)
     threadSleepTest ();
     epicsThreadGetIdSelfPerfTest ();
     timeEpicsThreadPrivateGet ();
+    timeOnce ();
     return 0;
 }


### PR DESCRIPTION
An optimization of the posix implementation of `epicsThreadOnce()` to use atomic operations to add a "fast path" when initialization is not needed which avoids locking the global `onceLock`.  This change is motivated by #298 and thinking about making `timeRegister()` lazy, which could mean a lot more calls to `epicsThreadOnce()`.

Since this is very much a micro optimization, I want to establish a clear benefit.  I've updated `epicsThreadPerform` to time calls to `epicsThreadOnce()`.  I run the test with privilege and high priority to reduce jitter.

The result is a improvement to the "fast path".  The "slow path" (when initialization happens) might be slightly slower, but the jitter is quite high.

Current code.

```
$ for n in `seq 10`; do sudo nice -n -20 ./modules/libcom/test/O.linux-x86_64/epicsThreadPerform 2>/dev/null |grep Once; done
epicsThreadOnce(), slow path 120 +- 196 ns, fast path 59 +- 4 ns
epicsThreadOnce(), slow path 122 +- 227 ns, fast path 58 +- 4 ns
epicsThreadOnce(), slow path 121 +- 218 ns, fast path 58 +- 4 ns
epicsThreadOnce(), slow path 121 +- 215 ns, fast path 58 +- 4 ns
epicsThreadOnce(), slow path 119 +- 191 ns, fast path 59 +- 3 ns
epicsThreadOnce(), slow path 121 +- 214 ns, fast path 58 +- 4 ns
epicsThreadOnce(), slow path 121 +- 219 ns, fast path 58 +- 4 ns
epicsThreadOnce(), slow path 120 +- 200 ns, fast path 59 +- 4 ns
epicsThreadOnce(), slow path 124 +- 247 ns, fast path 58 +- 4 ns
epicsThreadOnce(), slow path 121 +- 210 ns, fast path 58 +- 4 ns
```

With this PR

```
...
epicsThreadOnce(), slow path 140 +- 213 ns, fast path 37 +- 3 ns
epicsThreadOnce(), slow path 141 +- 209 ns, fast path 37 +- 3 ns
epicsThreadOnce(), slow path 147 +- 226 ns, fast path 37 +- 3 ns
epicsThreadOnce(), slow path 136 +- 157 ns, fast path 37 +- 3 ns
epicsThreadOnce(), slow path 141 +- 218 ns, fast path 37 +- 3 ns
epicsThreadOnce(), slow path 137 +- 183 ns, fast path 37 +- 3 ns
epicsThreadOnce(), slow path 142 +- 218 ns, fast path 37 +- 3 ns
epicsThreadOnce(), slow path 141 +- 209 ns, fast path 37 +- 3 ns
epicsThreadOnce(), slow path 144 +- 231 ns, fast path 37 +- 3 ns
epicsThreadOnce(), slow path 138 +- 192 ns, fast path 37 +- 3 ns
```
