### PR TITLE
Remove K&R function declaration from flex.

### DIFF
--- a/modules/libcom/src/flex/ccl.c
+++ b/modules/libcom/src/flex/ccl.c
@@ -132,7 +132,7 @@ void cclnegate(int cclp)
 void list_character_set(FILE *file, int cset[])
 {
     int i;
-    char *readable_form();
+    char *readable_form(int);
 
     putc( '[', file );
 

--- a/modules/libcom/src/flex/gen.c
+++ b/modules/libcom/src/flex/gen.c
@@ -237,7 +237,7 @@ void genecs(void)
 
     if ( trace )
         {
-        char *readable_form();
+        char *readable_form(int);
 
         fputs( "\n\nEquivalence Classes:\n\n", stderr );
 


### PR DESCRIPTION
A common header is a more adequate long term solution for this purpose. This commit only intends to fix a compilation error reported on the mailing list [1].

[1] https://epics.anl.gov/tech-talk/2023/msg00050.php