### PR TITLE
Add support for loongarch64 architecture.

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -25,6 +25,7 @@
 #	linux-arm              (GNU compiler used for host builds)
 #	linux-ppc              (GNU compiler used for host builds)
 #	linux-ppc64            (GNU compiler used for host builds)
+#	linux-loong64          (GNU compiler used for host builds)
 #	linux-x86              (GNU compiler used for host builds)
 #	linux-x86_64           (GNU compiler used for host builds)
 #	solaris-sparc          (Sun compiler used for host builds)
@@ -63,6 +64,7 @@
 #       ios-386                 (darwin-x86 host)
 #       linux-arm               (linux-x86 or -x86_64 host)
 #       linux-aarch64           (linux-x86_64 host)
+#       linux-loong64           (linux-x86_64 host)
 #       linux-microblaze
 #       linux-xscale_be
 #       vxWorks-486

--- a/configure/os/CONFIG.Common.linux-loong64
+++ b/configure/os/CONFIG.Common.linux-loong64
@@ -1,0 +1,13 @@
+# CONFIG.Common.linux-loong64
+#
+# Definitions for linux-loong64 target builds
+# Override these settings in CONFIG_SITE.Common.linux-loong64
+#-------------------------------------------------------
+
+# Include definitions common to all Linux targets
+include $(CONFIG)/os/CONFIG.Common.linuxCommon
+
+ARCH_CLASS = loongarch
+
+ARCH_DEP_CFLAGS = $(GNU_ARCH_CFLAGS) $(GNU_TUNE_CFLAGS)
+ARCH_DEP_CFLAGS += $(GNU_DEP_CFLAGS)

--- a/configure/os/CONFIG.linux-loong64.Common
+++ b/configure/os/CONFIG.linux-loong64.Common
@@ -1,0 +1,8 @@
+# CONFIG.linux-loong64.Common
+#
+# Definitions for linux-loong64 host builds
+# Sites may override these definitions in CONFIG_SITE.linux-loong64.Common
+#-------------------------------------------------------
+
+# Include definitions common to unix hosts
+include $(CONFIG)/os/CONFIG.UnixCommon.Common

--- a/configure/os/CONFIG.linux-loong64.linux-loong64
+++ b/configure/os/CONFIG.linux-loong64.linux-loong64
@@ -1,0 +1,8 @@
+# CONFIG.linux-loong64.linux-loong64
+#
+# Definitions for native linux-loong64 builds
+# Override these definitions in CONFIG_SITE.linux-loong64.linux-loong64
+#-------------------------------------------------------
+
+# Include common gnu compiler definitions
+include $(CONFIG)/CONFIG.gnuCommon

--- a/configure/os/CONFIG.linux-x86_64.linux-loong64
+++ b/configure/os/CONFIG.linux-x86_64.linux-loong64
@@ -1,0 +1,28 @@
+# CONFIG.linux-x86_64.linux-loong64
+#
+# Definitions for linux-x86_64 host - linux-loong64 target builds
+# Sites may override these in CONFIG_SITE.linux-x86_64.linux-loong64
+#-------------------------------------------------------
+
+VALID_BUILDS = Ioc Command
+GNU_TARGET = loongarch64-linux-gnu
+
+# prefix of compiler tools
+CMPLR_SUFFIX =
+CMPLR_PREFIX = $(addsuffix -,$(GNU_TARGET))
+
+# Provide a link-time path for readline if needed
+OP_SYS_INCLUDES += $(READLINE_DIR:%=-I%/include)
+READLINE_LDFLAGS = $(READLINE_DIR:%=-L%/lib)
+RUNTIME_LDFLAGS_READLINE_YES_NO = $(READLINE_DIR:%=-Wl,-rpath,%/lib)
+RUNTIME_LDFLAGS += \
+    $(RUNTIME_LDFLAGS_READLINE_$(LINKER_USE_RPATH)_$(STATIC_BUILD))
+SHRLIBDIR_LDFLAGS += $(READLINE_LDFLAGS)
+PRODDIR_LDFLAGS += $(READLINE_LDFLAGS)
+
+# Library flags
+STATIC_LDFLAGS_YES= -Wl,-Bstatic
+STATIC_LDFLAGS_NO=
+STATIC_LDLIBS_YES= -Wl,-Bdynamic
+STATIC_LDLIBS_NO=
+

--- a/configure/os/CONFIG_SITE.Common.linux-loong64
+++ b/configure/os/CONFIG_SITE.Common.linux-loong64
@@ -1,0 +1,48 @@
+# CONFIG_SITE.Common.linux-loong64
+#
+# Site Specific definitions for all linux-loong64 targets
+#-------------------------------------------------------
+
+# NOTE for SHARED_LIBRARIES: In most cases if this is set to YES the
+# shared libraries will be found automatically.  However if the .so
+# files are installed at a different path to their compile-time path
+# then in order to be found at runtime do one of these:
+# a) LD_LIBRARY_PATH must include the full absolute pathname to
+#    $(INSTALL_LOCATION)/lib/$(EPICS_HOST_ARCH) when invoking base
+#    executables.
+# b) Add the runtime path to SHRLIB_DEPLIB_DIRS and PROD_DEPLIB_DIRS, which 
+#    will add the named directory to the list contained in the executables.
+# c) Add the runtime path to /etc/ld.so.conf and run ldconfig
+#    to inform the system of the shared library location.
+
+# Depending on your version of Linux you'll want one of the following
+# lines to enable command-line editing and history in iocsh.  If you're
+# not sure which, start with the top one and work downwards until the
+# build doesn't fail to link the readline library.  If none of them work,
+# comment them all out to build without readline support.
+
+# No other libraries needed (recent Fedora, Ubuntu etc.):
+#COMMANDLINE_LIBRARY = READLINE
+
+# Needs -lncurses (RHEL 5 etc.):
+#COMMANDLINE_LIBRARY = READLINE_NCURSES
+
+# Needs -lcurses (older versions)
+#COMMANDLINE_LIBRARY = READLINE_CURSES
+
+# Readline is broken or you don't want use it:
+#COMMANDLINE_LIBRARY = EPICS
+
+
+# WARNING: Variables that are set in $(CONFIG)/CONFIG.gnuCommon cannot be
+# overridden in this file for native builds, e.g. variables such as
+#    OPT_CFLAGS_YES, WARN_CFLAGS, SHRLIB_LDFLAGS
+# They must be set in CONFIG_SITE.linux-loong64.linux-loong64 or for
+# cross-builds in CONFIG_SITE.<host-arch>.linux-loong64 instead.
+
+# Tune GNU compiler output for a specific cpu-type
+# (e.g. loongarch64, la264, la364, la464 etc.)
+#GNU_ARCH_CFLAGS = -march=loongarch64
+#GNU_TUNE_CFLAGS = -mtune=loongarch64
+# Enable soft-float feature (e.g. none, 32, 64)
+#GNU_DEP_CFLAGS = -mfpu=none

--- a/configure/os/CONFIG_SITE.linux-loong64.linux-loong64
+++ b/configure/os/CONFIG_SITE.linux-loong64.linux-loong64
@@ -1,0 +1,11 @@
+# CONFIG_SITE.linux-loong64.linux-loong64
+#
+# Site specific definitions for native linux-loong64 builds
+#-------------------------------------------------------
+
+# It makes sense to include debugging symbols even in optimized builds
+# in case you want to attach gdb to the process or examine a core-dump.
+# This does cost disk space, but not memory as debug symbols are not
+# loaded into RAM when the binary is loaded.
+#OPT_CFLAGS_YES += -g
+#OPT_CXXFLAGS_YES += -g

--- a/configure/os/CONFIG_SITE.linux-x86_64.linux-loong64
+++ b/configure/os/CONFIG_SITE.linux-x86_64.linux-loong64
@@ -1,0 +1,30 @@
+# CONFIG_SITE.linux-x86_64.linux-loong64
+#
+# Site specific definitions for linux-x86_64 host - linux-loong64 target builds
+#-------------------------------------------------------
+
+# Set GNU crosscompiler target name
+GNU_TARGET = loongarch64-linux-gnu
+
+# Set GNU tools install path
+# Examples is the installation at the APS:
+#GNU_DIR = /opt/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.2
+
+# If cross-building shared libraries and the paths on the target machine are
+# different than on the build host, you should uncomment the lines below to
+# disable embedding compile-time library paths into the generated files.
+# You will need to provide another way for programs to find their shared
+# libraries at runtime, such as by setting LD_LIBRARY_PATH or (better) using
+# mechanisms related to /etc/ld.so.conf
+#SHRLIBDIR_RPATH_LDFLAGS_YES_NO =
+#PRODDIR_RPATH_LDFLAGS_YES_NO =
+# However it is usually simpler to set STATIC_BUILD=YES here and not
+# try to use shared libraries at all when cross-building, like this:
+#STATIC_BUILD=YES
+#SHARED_LIBRARIES=NO
+
+# To use libreadline, point this to its install prefix
+#READLINE_DIR = $(GNU_DIR)
+#READLINE_DIR = /tools/cross/linux-x86.linux-loong64/readline
+# See CONFIG_SITE.Common.linux-loong64 for other COMMANDLINE_LIBRARY values
+#COMMANDLINE_LIBRARY = READLINE

--- a/src/tools/EpicsHostArch.pl
+++ b/src/tools/EpicsHostArch.pl
@@ -110,6 +110,7 @@ sub toEpicsArch {
         return 'linux-arm'      if m/^arm-linux/;
         return 'linux-aarch64'  if m/^aarch64-linux/;
         return 'linux-ppc64'    if m/^powerpc64-linux/;
+        return 'linux-loong64'  if m/^loongarch64-linux/;
         return 'windows-x64'    if m/^MSWin32-x64/;
         return 'win32-x86'      if m/^MSWin32-x86/;
         return "cygwin-x86_64"  if m/^x86_64-cygwin/;


### PR DESCRIPTION
### Add `loongarch64` architecture support.

Now base can be compiled successfully on Loongson 3A5000(loongarch64) CPU.

![2023-02-01_12-58-17](https://user-images.githubusercontent.com/22876709/216205977-a5e62302-d7fb-488c-8949-8c2054eb600f.png)

### Output dir
![2023-02-01_14-09-04](https://user-images.githubusercontent.com/22876709/216205998-51fd6a8d-dde1-4b33-be7d-70d6696deffc.png)

### Run softIoc
![2023-02-01_14-13-20](https://user-images.githubusercontent.com/22876709/216206017-f74c763e-4df8-483a-80c5-9bf41c4a1a4c.png)
