### PR TITLE
Add GHA job with `clang -fsanitize=undefined`

### DIFF
--- a/.ci-local/ubsan.supp
+++ b/.ci-local/ubsan.supp
@@ -1,0 +1,13 @@
+# int2ptr() craziness
+null:epicsEllTest.c
+
+# dbLocker::refs[] is actually dynamically sized, with a minimum of 2 elements
+object-size:dbLock.c
+
+# out of scope for epics-base tests
+alignment:pvData.so
+enum:pvData.so
+
+alignment:pvAccess.so
+enum:pvAccess.so
+

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -87,6 +87,12 @@ jobs:
           - os: ubuntu-20.04
             cmp: clang
             configuration: default
+            extra: "CMD_CFLAGS=-fsanitize=undefined CMD_CXXFLAGS=-fsanitize=undefined CMD_LDFLAGS=-fsanitize=undefined"
+            name: "Ub-20 clang-10 sanitize=undefined"
+
+          - os: ubuntu-20.04
+            cmp: clang
+            configuration: default
             extra: "CMD_CXXFLAGS=-std=c++11"
             name: "Ub-20 clang-10 C++11"
 
@@ -191,6 +197,8 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install qemu-system-x86 g++-mingw-w64-x86-64 gdb
       if: runner.os == 'Linux'
+    - name: Setup UBSAN_OPTIONS
+      run: echo "UBSAN_OPTIONS=log_path=$PWD/UBSAN:suppressions=$PWD/.ci-local/ubsan.supp:print_stacktrace=1" >> $GITHUB_ENV 
     - name: Prepare and compile dependencies
       run: python .ci/cue.py prepare
     - name: Build main module
@@ -207,6 +215,18 @@ jobs:
     - name: Collect and show test results
       if: ${{ always() }}
       run: python .ci/cue.py -T 5M test-results
+    - name: Show UBSAN logs
+      shell: bash
+      if: ${{ always() }}
+      run: |
+        ret=0
+        for ff in `find . -name 'UBSAN*'`
+        do
+          echo "==== $ff ===="
+          cat "$ff"
+          ret=1
+        done
+        exit $ret
 
   docker:
     name: ${{ matrix.name }}

--- a/modules/database/src/std/rec/mbboDirectRecord.c
+++ b/modules/database/src/std/rec/mbboDirectRecord.c
@@ -271,7 +271,7 @@ static long special(DBADDR *paddr, int after)
     } else if(after==1 && fieldIndex >= mbboDirectRecordB0 && fieldIndex <= mbboDirectRecordB1F) {
         /* Adjust VAL corresponding to the bit changed */
         epicsUInt8 *pBn = (epicsUInt8 *) paddr->pfield;
-        epicsUInt32 bit = 1 << (pBn - &prec->b0);
+        epicsUInt32 bit = 1u << (pBn - &prec->b0);
 
         /* Because this is !(VAL and PP), dbPut() will always post a monitor on this B* field
          * after we return.  We must keep track of this change separately from MLST to handle

--- a/modules/database/src/tools/dbdToRecordtypeH.pl
+++ b/modules/database/src/tools/dbdToRecordtypeH.pl
@@ -146,7 +146,7 @@ __EOF__
                 "    prt->papFldDes[${rn}Record${fn}]->size = " .
                 "sizeof(prec->${cn});\n" .
                 "    prt->papFldDes[${rn}Record${fn}]->offset = " .
-                "(unsigned short)((char *)&prec->${cn} - (char *)prec);"
+                "(unsigned short)offsetof(${rn}Record, ${cn});"
             } @fields), << "__EOF__";
 
     prt->rec_size = sizeof(*prec);

--- a/modules/database/test/std/rec/mbbioDirectTest.c
+++ b/modules/database/test/std/rec/mbbioDirectTest.c
@@ -123,7 +123,7 @@ MAIN(mbbioDirectTest)
 
     testDiag("##### clear bit 31 (0x1f) #####");
     putN("do%u.B1F", N, 0);
-    value &= ~(1<<31);
+    value &= ~(1u<<31u);
     testN("val%d", N,  value);
     testmbbioRecords(N, value);
 

--- a/modules/libcom/src/yacc/closure.c
+++ b/modules/libcom/src/yacc/closure.c
@@ -85,7 +85,7 @@ set_first_derives(void)
                 k = 0;
             }
 
-            if (cword & (1 << k))
+            if (cword & (1u << k))
             {
                 rp = derives[j];
                 while ((rule = *rp++) >= 0)
@@ -152,7 +152,7 @@ closure(short int *nucleus, int n)
         {
             for (i = 0; i < BITS_PER_WORD; ++i)
             {
-                if (word & (1 << i))
+                if (word & (1u << i))
                 {
                     itemno = rrhs[ruleno+i];
                     while (csp < csend && *csp < itemno)

--- a/modules/libcom/src/yacc/warshall.c
+++ b/modules/libcom/src/yacc/warshall.c
@@ -26,7 +26,7 @@ transitive_closure(unsigned int *R, int n)
 
         while (rowj < relend)
         {
-            if (*ccol & (1 << i))
+            if (*ccol & (1u << i))
             {
                 rp = rowi;
                 rend = rowj + rowsize;
@@ -68,7 +68,7 @@ reflexive_transitive_closure(unsigned int *R, int n)
     rp = R;
     while (rp < relend)
     {
-        *rp |= (1 << i);
+        *rp |= (1u << i);
         if (++i >= BITS_PER_WORD)
         {
             i = 0;


### PR DESCRIPTION
Adds a CI job which passes `-fsanitize=undefined` to clang, and does some basic management of log output.

Includes fixes for two common "issues" to reduce output volume.  Although this is still large...

* Use of `&prec->field - prec` where `prec=NULL`
* `1 << 31` as `1` is signed
