### PR TITLE
For links, treat "" the same as unset.

### DIFF
--- a/modules/database/src/ioc/db/dbConstLink.c
+++ b/modules/database/src/ioc/db/dbConstLink.c
@@ -154,7 +154,7 @@ static long dbConstLoadScalar(struct link *plink, short dbrType, void *pbuffer)
     const char *pstr = plink->value.constantStr;
     size_t len;
 
-    if (!pstr)
+    if (!pstr || !pstr[0])
         return S_db_badField;
     len = strlen(pstr);
 
@@ -181,7 +181,7 @@ static long dbConstLoadLS(struct link *plink, char *pbuffer, epicsUInt32 size,
     const char *pstr = plink->value.constantStr;
     long status;
 
-    if (!pstr)
+    if (!pstr || !pstr[0])
         return S_db_badField;
 
     status = dbLSConvertJSON(pstr, pbuffer, size, plen);
@@ -197,7 +197,7 @@ static long dbConstLoadArray(struct link *plink, short dbrType, void *pbuffer,
     const char *pstr = plink->value.constantStr;
     long status;
 
-    if (!pstr)
+    if (!pstr || !pstr[0])
         return S_db_badField;
 
     /* Choice values must be numeric */


### PR DESCRIPTION
Reverse an apparent behavior change some time since the 3.14 series where a link which is never set (implicitly a const link with NULL) behaves differently to an empty string (const link with empty string).

cf. https://epics.anl.gov/tech-talk/2023/msg00279.php

```
record(longout, "lo1") {
    field(DOL, "")
    field(VAL, "42")
}
record(longout, "lo2") {
    field(VAL, "42")
}
record(longout, "lo3") {
    field(DOL, "42")
}
```

All should result in `VAL` set to `42`.  However at present, `lo1.VAL` is set to `0`.
