### PR TITLE
Validate target record name when creating an alias

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1257,7 +1257,7 @@ static void dbAlias(char *name, char *alias)
     DBENTRY dbEntry;
     DBENTRY *pdbEntry = &dbEntry;
 
-    if(dbRecordNameValidate(alias))
+    if(dbRecordNameValidate(alias) || dbRecordNameValidate(name))
         return;
 
     dbInitEntry(pdbbase, pdbEntry);

--- a/modules/database/test/ioc/db/Makefile
+++ b/modules/database/test/ioc/db/Makefile
@@ -181,6 +181,8 @@ dbStaticTest_SRCS += dbStaticTest.c
 dbStaticTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbStaticTest.c
 TESTFILES += ../dbStaticTest.db
+TESTFILES += ../dbStaticTestAlias1.db
+TESTFILES += ../dbStaticTestAlias2.db
 TESTS += dbStaticTest
 
 # This runs all the test programs in a known working order:

--- a/modules/database/test/ioc/db/dbStaticTest.c
+++ b/modules/database/test/ioc/db/dbStaticTest.c
@@ -291,6 +291,18 @@ static void testDbVerify(const char *record)
     dbFinishEntry(&entry);
 }
 
+static void testWrongAliasRecord(const char *filename)
+{
+    FILE *fp = NULL;
+    dbPath(pdbbase,"." OSI_PATH_LIST_SEPARATOR "..");
+    dbOpenFile(pdbbase, filename, &fp);
+    if(!fp) {
+        testAbort("Unable to read %s", filename);
+    }
+    testOk(dbReadDatabaseFP(&pdbbase, fp, NULL, NULL) != 0,
+           "Wrong alias record in %s is expected to fail", filename);
+}
+
 void dbTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 MAIN(dbStaticTest)
@@ -298,19 +310,23 @@ MAIN(dbStaticTest)
     const char *ldir;
     FILE *fp = NULL;
 
-    testPlan(310);
+    testPlan(312);
     testdbPrepare();
 
     testdbReadDatabase("dbTestIoc.dbd", NULL, NULL);
     dbTestIoc_registerRecordDeviceDriver(pdbbase);
     dbPath(pdbbase,"." OSI_PATH_LIST_SEPARATOR "..");
-    if(!(ldir = dbOpenFile(pdbbase, "dbStaticTest.db", &fp))) {
+    ldir = dbOpenFile(pdbbase, "dbStaticTest.db", &fp);
+    if(!fp) {
         testAbort("Unable to read dbStaticTest.db");
     }
     if(dbReadDatabaseFP(&pdbbase, fp, NULL, NULL)) {
         testAbort("Unable to load %s%sdbStaticTest.db",
                   ldir, OSI_PATH_LIST_SEPARATOR);
     }
+
+    testWrongAliasRecord("dbStaticTestAlias1.db");
+    testWrongAliasRecord("dbStaticTestAlias2.db");
 
     testEntry("testrec.VAL");
     testEntry("testalias.VAL");

--- a/modules/database/test/ioc/db/dbStaticTestAlias1.db
+++ b/modules/database/test/ioc/db/dbStaticTestAlias1.db
@@ -1,0 +1,4 @@
+record(x, "testrec2alias") {
+}
+
+alias("testrec2alias.NAME", "testalias4")

--- a/modules/database/test/ioc/db/dbStaticTestAlias2.db
+++ b/modules/database/test/ioc/db/dbStaticTestAlias2.db
@@ -1,0 +1,4 @@
+record(x, "testrec2alias2") {
+}
+
+alias("testrec2alias2", "testalias5.NAME")


### PR DESCRIPTION
This fixes issue https://github.com/epics-base/epics-base/issues/312 by printing an error when a field is specified