### PR TITLE
fix missing newline at end of file

### DIFF
--- a/modules/libcom/src/freeList/freeList.h
+++ b/modules/libcom/src/freeList/freeList.h
@@ -41,4 +41,3 @@ LIBCOM_API size_t epicsStdCall freeListItemsAvail(void *pvt);
 #endif
 
 #endif /*INCfreeListh*/
- 


### PR DESCRIPTION
Some compilers complain about files not ending in newline. freeList.h ended in a space.