### PR TITLE
avoid accessing dbr_text[type] when type is out of range

### DIFF
--- a/modules/ca/src/client/test_event.cpp
+++ b/modules/ca/src/client/test_event.cpp
@@ -56,6 +56,7 @@ extern "C" void epicsStdCall ca_dump_dbr (
 
     if ( INVALID_DB_REQ ( type ) ) {
         printf ( "bad DBR type %ld\n", type );
+        return;
     }
 
     printf ( "%s\t", dbr_text[type] );


### PR DESCRIPTION
No need to call the rest of ca_dump_dbr when type is out of range. Compiler complains that dbr_text[type] may be out of range.