### PR TITLE
fix warning "if clause does not guard..."

### DIFF
--- a/modules/database/src/ioc/db/dbUnitTest.c
+++ b/modules/database/src/ioc/db/dbUnitTest.c
@@ -339,7 +339,7 @@ void testdbGetArrFieldEqual(const char* pv, short dbfType, long nRequest, unsign
                 break;
             }
 #define OP(DBR,Type,pat) case DBR: {Type expect = *(Type*)pbuf, actual = *(Type*)gbuf; assert(vSize==sizeof(Type)); match &= expect==actual; \
-    if(expect!=actual) testDiag("[%lu] expected=" pat " actual=" pat, n, expect, actual); break;}
+    if(expect!=actual) {testDiag("[%lu] expected=" pat " actual=" pat, n, expect, actual);} break;}
 
             OP(DBR_CHAR, char, "%c");
             OP(DBR_UCHAR, unsigned char, "%u");


### PR DESCRIPTION
The compiler sees an `if` followed by two statements on the same line. This is often a mistake as only the first statement depends on the `if` and the author (or the reader of the code) may be misled to think both are covered. In this case, it is intended. It is just all in one line to keep the macro compact. Use explicit braces to tell the compiler the intention. 