### PR TITLE
ci: add cross-compilation tests for aarch64, arm soft and hard float

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -151,6 +151,26 @@ jobs:
             configuration: default
             name: "Win2019 mingw"
 
+          # Cross builds
+
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            name: "Cross linux-aarch64"
+            cross: linux-aarch64
+
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            name: "Cross linux-arm gnueabi"
+            cross: linux-arm@arm-linux-gnueabi
+
+          - os: ubuntu-latest
+            cmp: gcc
+            configuration: default
+            name: "Cross linux-arm gnueabihf"
+            cross: linux-arm@arm-linux-gnueabihf
+
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Part of Codeathon 2023.

Pinging @mdavidsaver as that was his proposal, and @ralphlange as this involves CI.

Right now, only tests with gcc and using shared libraries are run. Let me know if you want me to add more.

Linking implementation PR: epics-base/ci-scripts#69