### PR TITLE
editorconfig: add initial version forcing final newlines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# Documentation for this file: https://EditorConfig.org
+
+root = true
+
+# Unix-style newlines ending every file,
+# as some compilers complain about files not ending in newline
+[*]
+insert_final_newline = true

--- a/.github/workflows/check-editorconfig.yml
+++ b/.github/workflows/check-editorconfig.yml
@@ -1,0 +1,13 @@
+name: Check EditorConfig
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  editorconfig:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: EditorConfig-Action
+        uses: greut/eclint-action@v0


### PR DESCRIPTION
As per comment https://github.com/epics-base/epics-base/pull/337#issuecomment-1458388011

CC @anjohnson 

This file may be extended later if we want to enforce tabs / space length by filetype.