### PR TITLE
make buffer large enough for any argument value

### DIFF
--- a/modules/libcom/src/flex/misc.c
+++ b/modules/libcom/src/flex/misc.c
@@ -663,7 +663,7 @@ int otoi(Char *str)
 
 char *readable_form(int c)
 {
-    static char rform[10];
+    static char rform[16];
 
     if ( (c >= 0 && c < 32) || c >= 127 )
         {


### PR DESCRIPTION
The compiler complains that a huge `int` may overrun the buffer `char rform[10]` when printing the argument with `sprintf( rform, "\\%.3o", c )` . In reality, only chars are passed as `c`, but the function takes an int argument and I hesitate to change that. Increasing the buffer size a bit is the least invasive solution.