### PR TITLE
Fix generalTimeReport interest level argument type

### DIFF
--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -447,7 +447,7 @@ static void epicsThreadResumeCallFunc(const iocshArgBuf *args)
 }
 
 /* generalTimeReport */
-static const iocshArg generalTimeReportArg0 = { "interest_level", iocshArgArgv};
+static const iocshArg generalTimeReportArg0 = { "interest_level", iocshArgInt};
 static const iocshArg * const generalTimeReportArgs[1] = { &generalTimeReportArg0 };
 static const iocshFuncDef generalTimeReportFuncDef = {"generalTimeReport",1,generalTimeReportArgs,
                                                       "Display time providers and their priority levels"


### PR DESCRIPTION
Currently the `interest_level` argument is being parsed as `iocshArgArgv`, which makes it always be tested as true in the `generalTimeReport` function.

Setting to iocshArgInt actually makes the function verbosity to be able to be controlled by the value