### PR TITLE
fix compiler warning on 32 bit Linux

### DIFF
--- a/modules/libcom/src/osi/os/posix/osdElfFindAddr.c
+++ b/modules/libcom/src/osi/os/posix/osdElfFindAddr.c
@@ -639,7 +639,7 @@ epicsFindAddr(void *addr, epicsSymbol *sym_p)
 
     if ( nearest.raw && ( (idx = ARR(c,nearest,0,st_name)) < es->strMap->max ) ) {
         sym_p->s_nam = strtab + idx;
-        sym_p->s_val = (char*) ARR(c, nearest, 0, st_value) + es->addr;
+        sym_p->s_val = (char*)(uintptr_t) ARR(c, nearest, 0, st_value) + es->addr;
     }
 
     return 0;


### PR DESCRIPTION
When compiling for 32 bit Linux, the compiler complains because a 64 bit integer is converted to a (32 bit) pointer. The cause is in the macro `ARR` which expands to something like `condition ? a_32_bit_integer : a_64_bit_integer`. This promotes the result to a 64 bit integer, even when the 32 bit integer is chosen. The intermediate cast to `uintptr_t` tells the compiler that we know what we are doing.