### PR TITLE
Added the new annotation EPICS_PRINTF_STYLE_ANNOTATION

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -162,13 +162,15 @@ jobs:
 
           - os: windows-2019
             cmp: vs2019
-            configuration: default
+            configuration: debug
             name: "Win2019 MSC-19"
+            extra: "CMD_CXXFLAGS=-analysis"
 
           - os: windows-2019
             cmp: vs2019
-            configuration: static
+            configuration: static-debug
             name: "Win2019 MSC-19, static"
+            extra: "CMD_CXXFLAGS=-analysis"
 
           - os: windows-2019
             cmp: vs2019

--- a/modules/database/src/ioc/db/recGbl.h
+++ b/modules/database/src/ioc/db/recGbl.h
@@ -75,7 +75,7 @@ DBCORE_API void recGblInheritSevr(int msMode, void *precord, epicsEnum16 stat,
     epicsEnum16 sevr);
 DBCORE_API int recGblSetSevrMsg(void *precord, epicsEnum16 new_stat,
                                 epicsEnum16 new_sevr,
-                                const char *msg, ...) EPICS_PRINTF_STYLE(4,5);
+                                EPICS_PRINTF_STYLE_ANNOTATION const char *msg, ...) EPICS_PRINTF_STYLE(4,5);
 DBCORE_API int recGblSetSevrVMsg(void *precord, epicsEnum16 new_stat,
                                  epicsEnum16 new_sevr,
                                  const char *msg, va_list args);

--- a/modules/database/src/ioc/db/recGbl.h
+++ b/modules/database/src/ioc/db/recGbl.h
@@ -75,7 +75,7 @@ DBCORE_API void recGblInheritSevr(int msMode, void *precord, epicsEnum16 stat,
     epicsEnum16 sevr);
 DBCORE_API int recGblSetSevrMsg(void *precord, epicsEnum16 new_stat,
                                 epicsEnum16 new_sevr,
-                                EPICS_PRINTF_STYLE_ANNOTATION const char *msg, ...) EPICS_PRINTF_STYLE(4,5);
+                                EPICS_PRINTF_FMT(const char *msg), ...) EPICS_PRINTF_STYLE(4,5);
 DBCORE_API int recGblSetSevrVMsg(void *precord, epicsEnum16 new_stat,
                                  epicsEnum16 new_sevr,
                                  const char *msg, va_list args);

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -39,7 +39,7 @@ char *dbRecordName(DBENTRY *pdbentry);
 char *dbGetStringNum(DBENTRY *pdbentry);
 long dbPutStringNum(DBENTRY *pdbentry,const char *pstring);
 
-void dbMsgPrint(DBENTRY *pdbentry, const char *fmt, ...) EPICS_PRINTF_STYLE(2,3);
+void dbMsgPrint(DBENTRY *pdbentry, EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...) EPICS_PRINTF_STYLE(2,3);
 
 void dbPutStringSuggest(DBENTRY *pdbentry, const char *pstring);
 

--- a/modules/database/src/ioc/dbStatic/dbStaticPvt.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticPvt.h
@@ -39,7 +39,9 @@ char *dbRecordName(DBENTRY *pdbentry);
 char *dbGetStringNum(DBENTRY *pdbentry);
 long dbPutStringNum(DBENTRY *pdbentry,const char *pstring);
 
-void dbMsgPrint(DBENTRY *pdbentry, EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...) EPICS_PRINTF_STYLE(2,3);
+void dbMsgPrint(
+    DBENTRY *pdbentry, EPICS_PRINTF_FMT(const char *fmt), ...
+) EPICS_PRINTF_STYLE(2,3);
 
 void dbPutStringSuggest(DBENTRY *pdbentry, const char *pstring);
 

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -97,7 +97,7 @@ LIBCOM_API extern int errVerbose;
  * that the output is sent to the errlog task. Unless configured not to, the output
  * will appear on the console as well.
  */
-LIBCOM_API int errlogPrintf(const char *pformat, ...)
+LIBCOM_API int errlogPrintf(EPICS_PRINTF_STYLE_ANNOTATION const char *pformat, ...)
     EPICS_PRINTF_STYLE(1,2);
 
 /**
@@ -118,7 +118,7 @@ LIBCOM_API int errlogVprintf(const char *pformat, va_list pvar);
  * \return int Consult printf documentation in C standard library
  */
 LIBCOM_API int errlogSevPrintf(const errlogSevEnum severity,
-    const char *pformat, ...) EPICS_PRINTF_STYLE(2,3);
+    EPICS_PRINTF_STYLE_ANNOTATION const char *pformat, ...) EPICS_PRINTF_STYLE(2,3);
 
 /**
  * This function is like ::errlogVprintf except that it adds the severity to the beginning
@@ -240,9 +240,9 @@ LIBCOM_API void errlogFlush(void);
  * ::errVerbose determines if the filename and line number are shown.
  */
 LIBCOM_API void errPrintf(long status, const char *pFileName, int lineno,
-    const char *pformat, ...) EPICS_PRINTF_STYLE(4,5);
+    EPICS_PRINTF_STYLE_ANNOTATION const char *pformat, ...) EPICS_PRINTF_STYLE(4,5);
 
-LIBCOM_API int errlogPrintfNoConsole(const char *pformat, ...)
+LIBCOM_API int errlogPrintfNoConsole(EPICS_PRINTF_STYLE_ANNOTATION const char *pformat, ...)
     EPICS_PRINTF_STYLE(1,2);
 LIBCOM_API int errlogVprintfNoConsole(const char *pformat,va_list pvar);
 

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -97,7 +97,7 @@ LIBCOM_API extern int errVerbose;
  * that the output is sent to the errlog task. Unless configured not to, the output
  * will appear on the console as well.
  */
-LIBCOM_API int errlogPrintf(EPICS_PRINTF_STYLE_ANNOTATION const char *pformat, ...)
+LIBCOM_API int errlogPrintf(EPICS_PRINTF_FMT(const char *pformat), ...)
     EPICS_PRINTF_STYLE(1,2);
 
 /**
@@ -118,7 +118,8 @@ LIBCOM_API int errlogVprintf(const char *pformat, va_list pvar);
  * \return int Consult printf documentation in C standard library
  */
 LIBCOM_API int errlogSevPrintf(const errlogSevEnum severity,
-    EPICS_PRINTF_STYLE_ANNOTATION const char *pformat, ...) EPICS_PRINTF_STYLE(2,3);
+    EPICS_PRINTF_FMT(const char *pformat), ...
+) EPICS_PRINTF_STYLE(2,3);
 
 /**
  * This function is like ::errlogVprintf except that it adds the severity to the beginning
@@ -239,11 +240,14 @@ LIBCOM_API void errlogFlush(void);
  * The remaining arguments are just like the arguments to the C printf routine.
  * ::errVerbose determines if the filename and line number are shown.
  */
-LIBCOM_API void errPrintf(long status, const char *pFileName, int lineno,
-    EPICS_PRINTF_STYLE_ANNOTATION const char *pformat, ...) EPICS_PRINTF_STYLE(4,5);
+LIBCOM_API void errPrintf(
+    long status, const char *pFileName, int lineno, 
+    EPICS_PRINTF_FMT(const char *pformat), ...
+) EPICS_PRINTF_STYLE(4,5);
 
-LIBCOM_API int errlogPrintfNoConsole(EPICS_PRINTF_STYLE_ANNOTATION const char *pformat, ...)
-    EPICS_PRINTF_STYLE(1,2);
+LIBCOM_API int errlogPrintfNoConsole(
+    EPICS_PRINTF_FMT(const char *pformat), ...
+) EPICS_PRINTF_STYLE(1,2);
 LIBCOM_API int errlogVprintfNoConsole(const char *pformat,va_list pvar);
 
 /**

--- a/modules/libcom/src/misc/cantProceed.h
+++ b/modules/libcom/src/misc/cantProceed.h
@@ -43,7 +43,7 @@ extern "C" {
  * \param errorMessage A printf-style error message describing the error.
  * \param ... Any parameters required for the error message.
  */
-LIBCOM_API void cantProceed(const char *errorMessage, ...)
+LIBCOM_API void cantProceed(EPICS_PRINTF_STYLE_ANNOTATION const char *errorMessage, ...)
     EPICS_PRINTF_STYLE(1,2);
 
 /** \name Memory Allocation Functions

--- a/modules/libcom/src/misc/cantProceed.h
+++ b/modules/libcom/src/misc/cantProceed.h
@@ -43,8 +43,9 @@ extern "C" {
  * \param errorMessage A printf-style error message describing the error.
  * \param ... Any parameters required for the error message.
  */
-LIBCOM_API void cantProceed(EPICS_PRINTF_STYLE_ANNOTATION const char *errorMessage, ...)
-    EPICS_PRINTF_STYLE(1,2);
+LIBCOM_API void cantProceed(
+    EPICS_PRINTF_FMT(const char *errorMessage), ...
+) EPICS_PRINTF_STYLE(1,2);
 
 /** \name Memory Allocation Functions
  * These versions of calloc() and malloc() never fail, they suspend the

--- a/modules/libcom/src/misc/epicsUnitTest.h
+++ b/modules/libcom/src/misc/epicsUnitTest.h
@@ -174,7 +174,7 @@ LIBCOM_API void testPlan(int tests);
  * \param ... Any parameters required for the format string.
  * \return The value of \p pass.
  */
-LIBCOM_API int  testOk(int pass, const char *fmt, ...)
+LIBCOM_API int  testOk(int pass, EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
     EPICS_PRINTF_STYLE(2, 3);
 /** \brief Test result using expression as description
  * \param cond Expression to be evaluated and displayed.
@@ -192,13 +192,13 @@ LIBCOM_API int  testOkV(int pass, const char *fmt, va_list pvar);
  * \param fmt A printf-style format string describing the test.
  * \param ... Any parameters required for the format string.
  */
-LIBCOM_API void testPass(const char *fmt, ...)
+LIBCOM_API void testPass(EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
     EPICS_PRINTF_STYLE(1, 2);
 /** \brief Failing test result with printf-style description.
  * \param fmt A printf-style format string describing the test.
  * \param ... Any parameters required for the format string.
  */
-LIBCOM_API void testFail(const char *fmt, ...)
+LIBCOM_API void testFail(EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
     EPICS_PRINTF_STYLE(1, 2);
 /** @} */
 
@@ -223,7 +223,7 @@ LIBCOM_API void testTodoEnd(void);
  * \param fmt A printf-style format string giving the reason for stopping.
  * \param ... Any parameters required for the format string.
  */
-LIBCOM_API void testAbort(const char *fmt, ...)
+LIBCOM_API void testAbort(EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
     EPICS_PRINTF_STYLE(1, 2);
 /** @} */
 
@@ -231,7 +231,7 @@ LIBCOM_API void testAbort(const char *fmt, ...)
  * \param fmt A printf-style format string containing diagnostic information.
  * \param ... Any parameters required for the format string.
  */
-LIBCOM_API int  testDiag(const char *fmt, ...)
+LIBCOM_API int  testDiag(EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
     EPICS_PRINTF_STYLE(1, 2);
 /** \brief Mark the end of testing.
  */

--- a/modules/libcom/src/misc/epicsUnitTest.h
+++ b/modules/libcom/src/misc/epicsUnitTest.h
@@ -174,7 +174,7 @@ LIBCOM_API void testPlan(int tests);
  * \param ... Any parameters required for the format string.
  * \return The value of \p pass.
  */
-LIBCOM_API int  testOk(int pass, EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
+LIBCOM_API int  testOk(int pass, EPICS_PRINTF_FMT(const char *fmt), ...)
     EPICS_PRINTF_STYLE(2, 3);
 /** \brief Test result using expression as description
  * \param cond Expression to be evaluated and displayed.
@@ -192,13 +192,13 @@ LIBCOM_API int  testOkV(int pass, const char *fmt, va_list pvar);
  * \param fmt A printf-style format string describing the test.
  * \param ... Any parameters required for the format string.
  */
-LIBCOM_API void testPass(EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
+LIBCOM_API void testPass(EPICS_PRINTF_FMT(const char *fmt), ...)
     EPICS_PRINTF_STYLE(1, 2);
 /** \brief Failing test result with printf-style description.
  * \param fmt A printf-style format string describing the test.
  * \param ... Any parameters required for the format string.
  */
-LIBCOM_API void testFail(EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
+LIBCOM_API void testFail(EPICS_PRINTF_FMT(const char *fmt), ...)
     EPICS_PRINTF_STYLE(1, 2);
 /** @} */
 
@@ -223,7 +223,7 @@ LIBCOM_API void testTodoEnd(void);
  * \param fmt A printf-style format string giving the reason for stopping.
  * \param ... Any parameters required for the format string.
  */
-LIBCOM_API void testAbort(EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
+LIBCOM_API void testAbort(EPICS_PRINTF_FMT(const char *fmt), ...)
     EPICS_PRINTF_STYLE(1, 2);
 /** @} */
 
@@ -231,7 +231,7 @@ LIBCOM_API void testAbort(EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
  * \param fmt A printf-style format string containing diagnostic information.
  * \param ... Any parameters required for the format string.
  */
-LIBCOM_API int  testDiag(EPICS_PRINTF_STYLE_ANNOTATION const char *fmt, ...)
+LIBCOM_API int  testDiag(EPICS_PRINTF_FMT(const char *fmt), ...)
     EPICS_PRINTF_STYLE(1, 2);
 /** \brief Mark the end of testing.
  */

--- a/modules/libcom/src/osi/compiler/msvc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/msvc/compilerSpecific.h
@@ -44,5 +44,9 @@
 
 #endif /* __cplusplus */
 
+/*
+ * Enable format-string checking if possible
+ */
+#define EPICS_PRINTF_STYLE_ANNOTATION _Printf_format_string_
 
 #endif  /* ifndef compilerSpecific_h */

--- a/modules/libcom/src/osi/compiler/msvc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/msvc/compilerSpecific.h
@@ -45,8 +45,10 @@
 #endif /* __cplusplus */
 
 /*
- * Enable format-string checking if possible
+ * Enable format-string checking if compiler supports it (if msvc is 2015 or newer)
  */
-#define EPICS_PRINTF_STYLE_ANNOTATION _Printf_format_string_
+#if _MSC_VER >= 1900
+#   define EPICS_PRINTF_FMT(a) _Printf_format_string_ a
+#endif
 
 #endif  /* ifndef compilerSpecific_h */

--- a/modules/libcom/src/osi/compilerDependencies.h
+++ b/modules/libcom/src/osi/compilerDependencies.h
@@ -57,8 +57,15 @@
 #  define EPICS_FUNCTION __func__
 #else
 /* Expands to a 'const char*' which describes the name of the current function scope */
-#  define EPICS_FUNCTION ("<unknown function>")
+#   define EPICS_FUNCTION ("<unknown function>")
 #endif
+#endif
+
+#ifndef EPICS_PRINTF_STYLE_ANNOTATION
+/*
+ * No format-string checking annotation
+ */
+#   define EPICS_PRINTF_STYLE_ANNOTATION
 #endif
 
 #endif  /* ifndef compilerDependencies_h */

--- a/modules/libcom/src/osi/compilerDependencies.h
+++ b/modules/libcom/src/osi/compilerDependencies.h
@@ -57,15 +57,15 @@
 #  define EPICS_FUNCTION __func__
 #else
 /* Expands to a 'const char*' which describes the name of the current function scope */
-#   define EPICS_FUNCTION ("<unknown function>")
+#  define EPICS_FUNCTION ("<unknown function>")
 #endif
 #endif
 
-#ifndef EPICS_PRINTF_STYLE_ANNOTATION
+#ifndef EPICS_PRINTF_FMT
 /*
  * No format-string checking annotation
  */
-#   define EPICS_PRINTF_STYLE_ANNOTATION
+#   define EPICS_PRINTF_FMT(a) a
 #endif
 
 #endif  /* ifndef compilerDependencies_h */

--- a/modules/libcom/src/osi/epicsStdio.h
+++ b/modules/libcom/src/osi/epicsStdio.h
@@ -130,7 +130,7 @@ extern "C" {
  * output has been truncated if the return value is `size` or more.
  */
 LIBCOM_API int epicsStdCall epicsSnprintf(
-    char *str, size_t size, const char *format, ...) EPICS_PRINTF_STYLE(3,4);
+    char *str, size_t size, EPICS_PRINTF_STYLE_ANNOTATION const char *format, ...) EPICS_PRINTF_STYLE(3,4);
 /**
  * \brief epicsVsnprintf() is meant to have the same semantics as the C99
  * function vsnprintf()

--- a/modules/libcom/src/osi/epicsStdio.h
+++ b/modules/libcom/src/osi/epicsStdio.h
@@ -130,7 +130,8 @@ extern "C" {
  * output has been truncated if the return value is `size` or more.
  */
 LIBCOM_API int epicsStdCall epicsSnprintf(
-    char *str, size_t size, EPICS_PRINTF_STYLE_ANNOTATION const char *format, ...) EPICS_PRINTF_STYLE(3,4);
+    char *str, size_t size, EPICS_PRINTF_FMT(const char *format), ...
+) EPICS_PRINTF_STYLE(3,4);
 /**
  * \brief epicsVsnprintf() is meant to have the same semantics as the C99
  * function vsnprintf()


### PR DESCRIPTION
Added a preprocessor definition to the `printf` wrapper which will make them use [`_Printf_format_string_`](https://docs.microsoft.com/en-us/cpp/code-quality/annotating-function-parameters-and-return-values) when compiled with mcvs.