### PR TITLE
Conflicting macro ECHO from termios.h

### DIFF
--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -29,6 +29,8 @@
 #include "postfix.h"
 #include "asLib.h"
 
+#undef ECHO /* from termios.h */
+
 int asCheckClientIP;
 
 static epicsMutexId asLock;


### PR DESCRIPTION
On some Linux architectures, the macro `ECHO` in https://github.com/epics-base/epics-base/blob/fa00572780a00bea2f57dbff69653b14bd792be0/modules/libcom/src/flex/scan.c#L49 conflicts with a macro with the same name from bits/termios.h:
```
#define ECHO	0000010
```
(or other values like `0000008`, depending on the system).

The compiler print this warning:
```
In file included from ../as/asLib.y:205:
asLib_lex.c:26:1: warning: "ECHO" redefined
```

As scan.c is originally a generated file, I did not fix it there but rather in asLibRoutines.c, from where termios.h had been (indirectly) included.