### PR TITLE
Allow adding error symbols in support modules

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -102,6 +102,10 @@ and string formats, some of which support full nanosecond precision.
 More information is included in the filters documentation, which can be found in
 the `html/filters.html` document that is generated during the build
 
+### Allow adding new error symbols at any time
+
+`errSymbolAdd` can now be called after early initialization.
+
 ### Add conditional output (OOPT) to the longout record
 
 The longout record can now be configured using its new OOPT and OOCH fields

--- a/modules/libcom/src/error/Makefile
+++ b/modules/libcom/src/error/Makefile
@@ -26,6 +26,7 @@ ERR_S_FILES += $(LIBCOM)/as/asLib.h
 ERR_S_FILES += $(LIBCOM)/misc/epicsStdlib.h
 ERR_S_FILES += $(LIBCOM)/pool/epicsThreadPool.h
 ERR_S_FILES += $(LIBCOM)/error/errMdef.h
+ERR_S_FILES += $(LIBCOM)/error/errSymTbl.h
 ERR_S_FILES += $(TOP)/modules/database/src/ioc/db/dbAccessDefs.h
 ERR_S_FILES += $(TOP)/modules/database/src/ioc/dbStatic/dbStaticLib.h
 

--- a/modules/libcom/src/error/errMdef.h
+++ b/modules/libcom/src/error/errMdef.h
@@ -32,6 +32,7 @@
 #define M_stdlib        (504 << 16) /* EPICS Standard library */
 #define M_pool          (505 << 16) /* Thread pool */
 #define M_time          (506 << 16) /* epicsTime */
+#define M_err           (507 << 16) /* Error */
 
 /* ioc */
 #define M_dbAccess      (511 << 16) /* Database Access Routines */

--- a/modules/libcom/src/error/errMdef.h
+++ b/modules/libcom/src/error/errMdef.h
@@ -19,6 +19,7 @@
 #define RTN_SUCCESS(STATUS) ((STATUS)==0)
 
 /* Module numbers start above 500 for compatibility with vxWorks errnoLib */
+#define MIN_MODULE_NUM 501
 
 /* FIXME: M_xxx values could be declared as integer variables and set
  * at runtime from registration routines; the S_xxx definitions would

--- a/modules/libcom/src/error/errSymLib.c
+++ b/modules/libcom/src/error/errSymLib.c
@@ -80,7 +80,7 @@ static epicsUInt16 errhash(long errNum)
 
     modnum = (unsigned short) (errNum >> 16);
     errnum = (unsigned short) (errNum & 0xffff);
-    return (((modnum - 500) * 20) + errnum) % NHASH;
+    return ((modnum - (MIN_MODULE_NUM - 1)) * 20 + errnum) % NHASH;
 }
 
 /****************************************************************
@@ -94,7 +94,7 @@ int errSymbolAdd(long errNum, const char *name)
     ERRNUMNODE *pNew = NULL;
     int modnum = (epicsUInt16) (errNum >> 16);
 
-    if (modnum < 501)
+    if (modnum < MIN_MODULE_NUM)
         return S_err_invCode;
 
     epicsUInt16 hashInd = errhash(errNum);
@@ -154,7 +154,7 @@ const char* errSymLookupInternal(long status)
     modNum = (unsigned) status;
     modNum >>= 16;
     modNum &= 0xffff;
-    if (modNum <= 500) {
+    if (modNum < MIN_MODULE_NUM) {
         const char * pStr = strerror ((int) status);
         if (pStr) {
             return pStr;
@@ -244,9 +244,10 @@ void errSymTestPrint(long errNum)
     message[0] = '\0';
     modnum = (epicsUInt16) (errNum >> 16);
     errnum = (epicsUInt16) (errNum & 0xffff);
-    if (modnum < 501) {
+    if (modnum < MIN_MODULE_NUM) {
         fprintf(stderr, "Usage:  errSymTestPrint(long errNum) \n");
-        fprintf(stderr, "errSymTestPrint: module number < 501 \n");
+        fprintf(stderr,
+                "errSymTestPrint: module number < %d\n", MIN_MODULE_NUM);
         return;
     }
     errSymLookup(errNum, message, sizeof(message));
@@ -266,7 +267,7 @@ void errSymTest(epicsUInt16 modnum, epicsUInt16 begErrNum,
     epicsUInt16  errnum;
 
     if (!initialized) errSymBld();
-    if (modnum < 501)
+    if (modnum < MIN_MODULE_NUM)
         return;
 
     /* print range of error messages */

--- a/modules/libcom/src/error/errSymLib.c
+++ b/modules/libcom/src/error/errSymLib.c
@@ -105,7 +105,12 @@ int errSymbolAdd(long errNum, const char *name)
     /* search for last node (NULL) of hashnode linked list */
     while (pNextNode) {
         if (pNextNode->errNum == errNum) {
-            return S_err_codeExists;
+            if(strcmp(name, pNextNode->message)) {
+                return S_err_codeExists;
+            }
+            else {
+                return 0;
+            }
         }
         phashnode = &pNextNode->hashnode;
         pNextNode = *phashnode;

--- a/modules/libcom/src/error/errSymLib.c
+++ b/modules/libcom/src/error/errSymLib.c
@@ -39,7 +39,7 @@ typedef struct errnumnode {
     long               pad;
 } ERRNUMNODE;
 
-static ERRNUMNODE **hashtable;
+static ERRNUMNODE *hashtable[NHASH];
 static int initialized = 0;
 extern ERRSYMTAB_ID errSymTbl;
 
@@ -58,9 +58,6 @@ int errSymBld(void)
 
     if (initialized)
         return(0);
-
-    hashtable = (ERRNUMNODE**)callocMustSucceed
-        (NHASH, sizeof(ERRNUMNODE*),"errSymBld");
 
     for (i = 0; i < errSymTbl->nsymbols; i++, errArray++) {
         if (errSymbolAdd(errArray->errNum, errArray->name)) {

--- a/modules/libcom/src/error/errSymLib.c
+++ b/modules/libcom/src/error/errSymLib.c
@@ -23,6 +23,7 @@
 #include "cantProceed.h"
 #include "epicsAssert.h"
 #include "epicsStdio.h"
+#include "epicsTypes.h"
 #include "epicsMutex.h"
 #include "epicsThread.h"
 #include "errMdef.h"
@@ -104,13 +105,12 @@ int errSymbolAdd(long errNum, const char *name)
     ERRNUMNODE **phashnode = NULL;
     ERRNUMNODE *pNew = NULL;
     int modnum = (epicsUInt16) (errNum >> 16);
+    epicsUInt16 hashInd = errhash(errNum);
 
     if (modnum < MIN_MODULE_NUM)
         return S_err_invCode;
 
     initErrorHashTable();
-
-    epicsUInt16 hashInd = errhash(errNum);
 
     epicsMutexLock(errHashTable.tableMutexId);
     phashnode = (ERRNUMNODE**)&errHashTable.table[hashInd];

--- a/modules/libcom/src/error/errSymTbl.h
+++ b/modules/libcom/src/error/errSymTbl.h
@@ -16,6 +16,9 @@
 #include "libComAPI.h"
 #include "epicsTypes.h"
 
+#define S_err_invCode (M_err | 1)       /* Invalid error symbol code */
+#define S_err_codeExists (M_err | 2)    /* Error code already exists */
+
 /* ERRSYMBOL - entry in symbol table */
 typedef struct {
     long errNum;        /* errMessage symbol number */

--- a/modules/libcom/test/epicsErrlogTest.c
+++ b/modules/libcom/test/epicsErrlogTest.c
@@ -29,6 +29,7 @@
 #include "osiSock.h"
 #include "fdmgr.h"
 #include "epicsString.h"
+#include "errSymTbl.h"
 
 /* private between errlog.c and this test */
 LIBCOM_API
@@ -197,13 +198,53 @@ void testANSIStrip(void)
 #undef testEscape
 }
 
+static void testErrorMessageMatches(long status, const char *expected)
+{
+    const char *msg = errSymMsg(status);
+    testOk(strcmp(msg, expected) == 0,
+           "Error code %ld returns \"%s\", expected message \"%s\"", status,
+           msg, expected
+          );
+}
+
+static void testGettingExistingErrorSymbol()
+{
+    testErrorMessageMatches(S_err_invCode, "Invalid error symbol code");
+}
+
+static void testGettingNonExistingErrorSymbol()
+{
+    long invented_code = (0x7999 << 16) | 0x9998;
+    testErrorMessageMatches(invented_code, "<Unknown code>");
+}
+
+static void testAddingErrorSymbol()
+{
+    long invented_code = (0x7999 << 16) | 0x9999;
+    errSymbolAdd(invented_code, "Invented Error Message");
+    testErrorMessageMatches(invented_code, "Invented Error Message");
+}
+
+static void testAddingInvalidErrorSymbol()
+{
+    long invented_code = (500 << 16) | 0x1;
+    testOk(errSymbolAdd(invented_code, "No matter"),
+           "Adding error symbol with module code < 501 should fail");
+}
+
+static void testAddingExistingErrorSymbol()
+{
+    testOk(errSymbolAdd(S_err_invCode, "Duplicate"),
+           "Adding an error symbol with an existing error code should fail");
+}
+
 MAIN(epicsErrlogTest)
 {
     size_t mlen, i, N;
     char msg[256];
     clientPvt pvt, pvt2;
 
-    testPlan(48);
+    testPlan(53);
 
     testANSIStrip();
 
@@ -413,6 +454,12 @@ MAIN(epicsErrlogTest)
     osiSockAttach();
     testLogPrefix();
     osiSockRelease();
+
+    testGettingExistingErrorSymbol();
+    testGettingNonExistingErrorSymbol();
+    testAddingErrorSymbol();
+    testAddingInvalidErrorSymbol();
+    testAddingExistingErrorSymbol();
 
     return testDone();
 }

--- a/modules/libcom/test/epicsErrlogTest.c
+++ b/modules/libcom/test/epicsErrlogTest.c
@@ -238,13 +238,21 @@ static void testAddingExistingErrorSymbol()
            "Adding an error symbol with an existing error code should fail");
 }
 
+static void testAddingExistingErrorSymbolWithSameMessage()
+{
+    long invented_code = (0x7999 << 16) | 0x9997;
+    errSymbolAdd(invented_code, "Invented Error Message");
+    testOk(!errSymbolAdd(invented_code, "Invented Error Message"),
+           "Adding identical error symbol shouldn't fail");
+}
+
 MAIN(epicsErrlogTest)
 {
     size_t mlen, i, N;
     char msg[256];
     clientPvt pvt, pvt2;
 
-    testPlan(53);
+    testPlan(54);
 
     testANSIStrip();
 
@@ -460,6 +468,7 @@ MAIN(epicsErrlogTest)
     testAddingErrorSymbol();
     testAddingInvalidErrorSymbol();
     testAddingExistingErrorSymbol();
+    testAddingExistingErrorSymbolWithSameMessage();
 
     return testDone();
 }


### PR DESCRIPTION
This was acomplished by making errSymbolAdd add the error symbol directly into the global hash table and removing errnumlist which is not needed anymore.

Unit tests were added for checking the following cases:
- Adding a valid symbol and checking that it exists (fixed by this change)
- Getting an existing error symbol
- Getting a non existing error symbol
- Adding an invalid error symbol (fixed by this change)
- Adding an error symbol with a code that already exists (fixed by this change)

Therefore, issue #268 was fixed