### PR TITLE
Fix undefined timestamp for NORD field

### DIFF
--- a/documentation/new-notes/PR-359.md
+++ b/documentation/new-notes/PR-359.md
@@ -1,0 +1,11 @@
+### Fix undefined timestamp for NORD field
+
+When monitoring non-val fields such as `NORD` for several record types updates
+are not sent out correctly resulting in incorrect timestamps. This fixes this
+for the record types `aai`, `aao`, `subArray`.
+
+Note that support modules that already implement this in the device support
+layer will need to be updated to avoid doubled monitor updates. If those modules
+are to be built against older versions of EPICS base then they will need to use
+the defined macros `AAO_POSTS_NORD`, `AAI_POSTS_NORD`, `SA_POSTS_NORD`, or
+`WF_POSTS_NORD` as appropriate to detect this change.

--- a/modules/database/src/std/dev/devAaiSoft.c
+++ b/modules/database/src/std/dev/devAaiSoft.c
@@ -85,7 +85,6 @@ static long readLocked(struct link *pinp, void *dummy)
 
 static long read_aai(aaiRecord *prec)
 {
-    epicsUInt32 nord = prec->nord;
     struct link *pinp = prec->simm == menuYesNoYES ? &prec->siol : &prec->inp;
     long status;
 
@@ -95,9 +94,6 @@ static long read_aai(aaiRecord *prec)
     status = dbLinkDoLocked(pinp, readLocked, NULL);
     if (status == S_db_noLSET)
         status = readLocked(pinp, NULL);
-
-    if (!status && nord != prec->nord)
-        db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
 
     return status;
 }

--- a/modules/database/src/std/dev/devSASoft.c
+++ b/modules/database/src/std/dev/devSASoft.c
@@ -93,7 +93,6 @@ static long read_sa(subArrayRecord *prec)
 {
     long status;
     struct sart rt;
-    epicsUInt32 nord = prec->nord;
 
     rt.nRequest = prec->indx + prec->nelm;
     if (rt.nRequest > prec->malm)
@@ -118,9 +117,6 @@ static long read_sa(subArrayRecord *prec)
 
     if (!status) {
         subset(prec, rt.nRequest);
-
-        if (nord != prec->nord)
-            db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
     }
 
     return status;

--- a/modules/database/src/std/dev/devWfSoft.c
+++ b/modules/database/src/std/dev/devWfSoft.c
@@ -72,7 +72,6 @@ static long read_wf(waveformRecord *prec)
 {
     long status;
     struct wfrt rt;
-    epicsUInt32 nord = prec->nord;
 
     rt.nRequest = prec->nelm;
     rt.ptime = (dbLinkIsConstant(&prec->tsel) &&
@@ -88,8 +87,6 @@ static long read_wf(waveformRecord *prec)
     if (!status) {
         prec->nord = rt.nRequest;
         prec->udf = FALSE;
-        if (nord != prec->nord)
-            db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
     }
 
     return status;

--- a/modules/database/src/std/rec/aaiRecord.c
+++ b/modules/database/src/std/rec/aaiRecord.c
@@ -156,8 +156,9 @@ static long process(struct dbCommon *pcommon)
 {
     struct aaiRecord *prec = (struct aaiRecord *)pcommon;
     aaidset *pdset = (aaidset *)(prec->dset);
-    long status;
     unsigned char pact = prec->pact;
+    epicsUInt32 nord = prec->nord;
+    long status;
 
     if (pdset == NULL || pdset->read_aai == NULL) {
         prec->pact = TRUE;
@@ -173,7 +174,11 @@ static long process(struct dbCommon *pcommon)
     prec->udf = FALSE;
     recGblGetTimeStampSimm(prec, prec->simm, &prec->siol);
 
+    if (nord != prec->nord) {
+        db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
+    }
     monitor(prec);
+
     /* process the forward scan link record */
     recGblFwdLink(prec);
 
@@ -233,8 +238,9 @@ static long put_array_info(DBADDR *paddr, long nNew)
     if (prec->nord > prec->nelm)
         prec->nord = prec->nelm;
 
-    if (nord != prec->nord)
+    if (nord != prec->nord) {
         db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
+    }
     return 0;
 }
 

--- a/modules/database/src/std/rec/aaiRecord.dbd.pod
+++ b/modules/database/src/std/rec/aaiRecord.dbd.pod
@@ -303,6 +303,7 @@ Scan forward link if necessary, set PACT FALSE, and return.
     %    long (*read_aai)(struct aaiRecord *prec); /*returns: (-1,0)=>(failure,success)*/
     %} aaidset;
     %#define HAS_aaidset
+	%#define AAI_POSTS_NORD
 	%#define AAI_DEVINIT_PASS1 2
     %
 	field(VAL,DBF_NOACCESS) {

--- a/modules/database/src/std/rec/aaoRecord.c
+++ b/modules/database/src/std/rec/aaoRecord.c
@@ -153,6 +153,7 @@ static long process(struct dbCommon *pcommon)
     aaodset *pdset = (aaodset *)(prec->dset);
     long status;
     unsigned char pact = prec->pact;
+    epicsUInt32 nord = prec->nord;
 
     if (pdset == NULL || pdset->write_aao == NULL) {
         prec->pact = TRUE;
@@ -180,6 +181,9 @@ static long process(struct dbCommon *pcommon)
         recGblGetTimeStampSimm(prec, prec->simm, NULL);
     }
 
+    if (nord != prec->nord) {
+      db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
+    }
     monitor(prec);
     /* process the forward scan link record */
     recGblFwdLink(prec);

--- a/modules/database/src/std/rec/aaoRecord.dbd.pod
+++ b/modules/database/src/std/rec/aaoRecord.dbd.pod
@@ -326,6 +326,7 @@ Scan forward link if necessary, set PACT FALSE, and return.
     %    long (*write_aao)(struct aaoRecord *prec); /*returns: (-1,0)=>(failure,success)*/
     %} aaodset;
     %#define HAS_aaodset
+	%#define AAO_POSTS_NORD
     %
 	field(VAL,DBF_NOACCESS) {
 		prompt("Value")

--- a/modules/database/src/std/rec/subArrayRecord.c
+++ b/modules/database/src/std/rec/subArrayRecord.c
@@ -129,6 +129,7 @@ static long process(struct dbCommon *pcommon)
     sadset *pdset = (sadset *)(prec->dset);
     long           status;
     unsigned char  pact=prec->pact;
+    epicsUInt32 nord = prec->nord;
 
     if ((pdset==NULL) || (pdset->read_sa==NULL)) {
         prec->pact=TRUE;
@@ -147,6 +148,9 @@ static long process(struct dbCommon *pcommon)
     prec->udf = !!status; /* 0 or 1 */
     if (status)
         recGblSetSevr(prec, UDF_ALARM, prec->udfs);
+
+    if (nord != prec->nord)
+        db_post_events(prec, &prec->nord, DBE_VALUE | DBE_LOG);
 
     monitor(prec);
 

--- a/modules/database/src/std/rec/subArrayRecord.dbd.pod
+++ b/modules/database/src/std/rec/subArrayRecord.dbd.pod
@@ -319,6 +319,7 @@ INP is expected to point to an array field of a waveform record or similar.
     %    long (*read_sa)(struct subArrayRecord *prec); /*returns: (-1,0)=>(failure,success)*/
     %} sadset;
     %#define HAS_sadset
+	%#define SA_POSTS_NORD
     %
 	field(VAL,DBF_NOACCESS) {
 		prompt("Value")

--- a/modules/database/src/std/rec/waveformRecord.dbd.pod
+++ b/modules/database/src/std/rec/waveformRecord.dbd.pod
@@ -396,6 +396,7 @@ routine and NORD is also set at that time.
     %    long (*read_wf)(struct waveformRecord *prec); /*returns: (-1,0)=>(failure,success)*/
     %} wfdset;
     %#define HAS_wfdset
+	%#define WF_POSTS_NORD
     %
 	field(VAL,DBF_NOACCESS) {
 		prompt("Value")


### PR DESCRIPTION
This PR addresses the issues mentioned in #280.

- Adds posting event when NORD is updated only after getting a timestamp.
- Removes posting this same event in the device support layer

Affects aai, aao and waveform records