### PR TITLE
Add missing AFTC field documentation

### DIFF
--- a/modules/database/src/std/rec/calcRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcRecord.dbd.pod
@@ -460,12 +460,17 @@ conditions.
 
 The HYST field defines an alarm deadband for each limit.
 
+The AFTC field sets the time constant on a low-pass filter that delays the
+reporting of limit alarms until the signal has been within the alarm range for
+that number of seconds (the default AFTC value of zero retains the previous
+behavior).
+
 See L<Alarm Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#alarm-specification>
 for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.
 
-=fields HIHI, HIGH, LOW, LOLO, HHSV, HSV, LSV, LLSV, HYST
+=fields HIHI, HIGH, LOW, LOLO, HHSV, HSV, LSV, LLSV, HYST, AFTC
 
 =head3 Monitor Parameters
 
@@ -496,7 +501,7 @@ manner for the VAL field.
 
 =cut
 
-	include "dbCommon.dbd" 
+	include "dbCommon.dbd"
 	field(VAL,DBF_DOUBLE) {
 		prompt("Result")
 		promptgroup("50 - Output")

--- a/modules/database/src/std/rec/longinRecord.dbd.pod
+++ b/modules/database/src/std/rec/longinRecord.dbd.pod
@@ -74,6 +74,11 @@ The HYST field controls hysteresis to prevent alarm chattering from an input
 signal that is close to one of the limits and suffers from significant readout
 noise.
 
+The AFTC field sets the time constant on a low-pass filter that delays the
+reporting of limit alarms until the signal has been within the alarm range for
+that number of seconds (the default AFTC value of zero retains the previous
+behavior).
+
 The limit alarms are configured by the user in the HIHI, LOLO, HIGH, and LOW
 fields using numerical values. For each of these fields, there is a
 corresponding severity field which can be either NO_ALARM, MINOR, or MAJOR. The
@@ -81,7 +86,7 @@ HYST field can be used to specify a deadband around each limit.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists the fields related to
 alarms that are common to all record types.
 
-=fields HIHI, HIGH, LOW, LOLO, HHSV, HSV, LSV, LLSV, HYST
+=fields HIHI, HIGH, LOW, LOLO, HHSV, HSV, LSV, LLSV, HYST, AFTC
 
 =head3 Monitor Parameters
 

--- a/modules/database/src/std/rec/longinRecord.dbd.pod
+++ b/modules/database/src/std/rec/longinRecord.dbd.pod
@@ -70,6 +70,10 @@ The possible alarm conditions for long inputs are the SCAN, READ, and limit
 alarms. The SCAN and READ alarms are called by the record or device support
 routines.
 
+The HYST field controls hysteresis to prevent alarm chattering from an input
+signal that is close to one of the limits and suffers from significant readout
+noise.
+
 The limit alarms are configured by the user in the HIHI, LOLO, HIGH, and LOW
 fields using numerical values. For each of these fields, there is a
 corresponding severity field which can be either NO_ALARM, MINOR, or MAJOR. The

--- a/modules/database/src/std/rec/mbbiRecord.dbd.pod
+++ b/modules/database/src/std/rec/mbbiRecord.dbd.pod
@@ -405,6 +405,11 @@ and state alarms. The state alarms are configured in the below severity fields.
 These fields have the usual possible values for severity fields: NO_ALARM,
 MINOR, and MAJOR.
 
+The AFTC field sets the time constant on a low-pass filter that delays the
+reporting of limit alarms until the signal has been within the alarm range for
+that number of seconds (the default AFTC value of zero retains the previous
+behavior).
+
 The unknown state severity (UNSV) field, if set to MINOR or MAJOR, triggers an
 alarm when the record support routine cannot find a matching value in the state
 value fields for C<<< rval >>>.
@@ -420,7 +425,7 @@ for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.
 
-=fields UNSV, COSV, ZRSV, ONSV, TWSV, THSV, FRSV, FVSV, SXSV, SVSV, EISV, NISV, TESV, ELSV, TVSV, TTSV, FTSV, FFSV
+=fields UNSV, COSV, ZRSV, ONSV, TWSV, THSV, FRSV, FVSV, SXSV, SVSV, EISV, NISV, TESV, ELSV, TVSV, TTSV, FTSV, FFSV, AFTC
 
 =cut
 


### PR DESCRIPTION
Fixes #313 

Also added a missing paragraph describing the HYST field in longin