### PR TITLE
turn most warnings into errors in github build

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -66,6 +66,8 @@ jobs:
                                   -Wno-error=sizeof-pointer-memaccess
                                   -Wno-error=nonnull
                                   -Wno-error=dangling-pointer
+                                  -Wno-error=format-overflow
+                                  -Wno-error=format-security
                                   -Wno-error=stringop-overread'"
 
           - os: ubuntu-20.04

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -51,6 +51,23 @@ jobs:
       matrix:
         # Job names also name artifacts, character limitations apply
         include:
+          - os: ubuntu-22.04
+            cmp: gcc-12
+            name: "Ub-22 gcc-12 c++20 Werror"
+            # Turn all warnings into errors,
+            # except for those we could not fix (yet).
+            # Remove respective -Wno-error=... flag once it is fixed.
+            extra: "CMD_CXXFLAGS=-std=c++20
+                    CMD_CPPFLAGS='-fdiagnostics-color
+                                  -Werror
+                                  -Wno-error=deprecated-declarations
+                                  -Wno-error=stringop-truncation
+                                  -Wno-error=restrict
+                                  -Wno-error=sizeof-pointer-memaccess
+                                  -Wno-error=nonnull
+                                  -Wno-error=dangling-pointer
+                                  -Wno-error=stringop-overread'"
+
           - os: ubuntu-20.04
             cmp: gcc
             configuration: default


### PR DESCRIPTION
Added compilation with gcc-12 using c++20 and turned most warnings into errors.
Fails currently but should succeed as soon as all my warning fixing PRs are merged.