### PR TITLE
fix problem with commands returning multiple trailing newlines

### DIFF
--- a/src/tools/genVersionHeader.pl
+++ b/src/tools/genVersionHeader.pl
@@ -55,7 +55,7 @@ if (-d '_darcs') { # Darcs
     # v1-4-dirty
     # is tag 'v1' plus 4 patches
     # with uncommited modifications
-    my @tags = `darcs show tags`;
+    my @tags = split('\n', `darcs show tags`);
     my $count = `darcs changes --count --from-tag .` - 1;
     my $result = $tags[0] . '-' . $count;
     print "== darcs show tags, changes:\n$result\n==\n" if $opt_v;

--- a/src/tools/genVersionHeader.pl
+++ b/src/tools/genVersionHeader.pl
@@ -20,6 +20,9 @@ use POSIX qw(strftime);
 
 use strict;
 
+# Make sure that chomp removes all trailing newlines
+$/='';
+
 # RFC 8601 date+time w/ zone (eg "2014-08-29T09:42-0700")
 my $tfmt = '%Y-%m-%dT%H:%M';
 $tfmt .= '%z' unless $^O eq 'MSWin32'; # %z returns zone name on Windows


### PR DESCRIPTION
The command `git show -s --format=%ci HEAD` may output more than one trailing newline under some circumstances (git version 1.8.3.1 if the commit is a merge). This leads to invalid C-code in epicsVCS.h if not all trailing newlines are removed. The default for `chomp` is to remove only one newline, unless one sets `$/='';` first. https://perldoc.perl.org/functions/chomp.