### PR TITLE
Change compiler for FreeBSD 13: Use clang

### DIFF
--- a/configure/os/CONFIG.Common.freebsdCommon
+++ b/configure/os/CONFIG.Common.freebsdCommon
@@ -7,6 +7,10 @@
 
 # Include definitions common to all Unix targets
 include $(CONFIG)/os/CONFIG.Common.UnixCommon
+GNU         = NO
+CMPLR_CLASS = clang
+CC          = clang
+CCC         = clang++
 
 OS_CLASS = freebsd
 

--- a/configure/os/CONFIG.freebsd-x86.Common
+++ b/configure/os/CONFIG.freebsd-x86.Common
@@ -5,3 +5,4 @@
 
 #Include definitions common to unix hosts
 include $(CONFIG)/os/CONFIG.UnixCommon.Common
+CMPLR_CLASS = clang

--- a/configure/os/CONFIG.freebsd-x86.freebsd-x86
+++ b/configure/os/CONFIG.freebsd-x86.freebsd-x86
@@ -2,6 +2,7 @@
 # Definitions for freebsd-x86 host - freebsd-x86 target builds
 # Sites may override these definitions in CONFIG_SITE.freebsd-x86.freebsd-x86
 #-------------------------------------------------------
+GNU_DIR=/usr/local
 
 # Include common gnu compiler definitions
 include $(CONFIG)/CONFIG.gnuCommon

--- a/configure/os/CONFIG.freebsd-x86_64.freebsd-x86_64
+++ b/configure/os/CONFIG.freebsd-x86_64.freebsd-x86_64
@@ -2,6 +2,7 @@
 # Definitions for freebsd-x86_64 host - freebsd-x86_64 target builds
 # Sites may override these definitions in CONFIG_SITE.freebsd-x86_64.freebsd-x86_64
 #-------------------------------------------------------
+GNU_DIR=/usr/local
 
 # Include common gnu compiler definitions
 include $(CONFIG)/CONFIG.gnuCommon


### PR DESCRIPTION
FreeBSD 13 uses clang, not gcc.