### PR TITLE
RTEMS 6 Updates for Legacy Networking, Makefile.inc and MVME2700

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS
+++ b/configure/os/CONFIG.Common.RTEMS
@@ -65,7 +65,7 @@ CXXFLAGS = $($(BUILD_CLASS)_CXXFLAGS) $(POSIX_CXXFLAGS) $(OPT_CXXFLAGS)\
  $(USR_CXXFLAGS) $(CMD_CXXFLAGS) $(ARCH_DEP_CXXFLAGS) $(CODE_CXXFLAGS)\
  $(STATIC_CXXFLAGS) $(OP_SYS_CXXFLAGS) $(LIBRARY_SRC_CFLAGS)
 
-LDFLAGS = $(OPT_LDFLAGS) $(TARGET_LDFLAGS) $(USR_LDFLAGS) $(CMD_LDFLAGS)\
+LDFLAGS += $(OPT_LDFLAGS) $(TARGET_LDFLAGS) $(USR_LDFLAGS) $(CMD_LDFLAGS)\
  $(POSIX_LDFLAGS) $(ARCH_DEP_LDFLAGS) $(DEBUG_LDFLAGS) $(OP_SYS_LDFLAGS)\
  $($(BUILD_CLASS)_LDFLAGS) $(RUNTIME_LDFLAGS) $(CODE_LDFLAGS)
 
@@ -102,15 +102,47 @@ OS_CLASS = RTEMS
 # Operating system compile & link flags
 OP_SYS_CFLAGS += -D__LINUX_ERRNO_EXTENSIONS__
 
-OP_SYS_CFLAGS_NET_yes = -DRTEMS_LEGACY_STACK
-OP_SYS_CFLAGS += $(OP_SYS_CFLAGS_NET_$(RTEMS_HAS_NETWORKING))
-
-ifeq ($(RTEMS_HAS_POSIX_API),yes)
-POSIX_CPPFLAGS = -D_GNU_SOURCE -D_DEFAULT_SOURCE
+# Has RTEMS been built with the internal legacy stack?
+ifeq ($(RTEMS_LEGACY_NETWORKING_INTERNAL),yes)
+RTEMS_HAS_NETWORKING = yes
+RTEMS_NETWORKING = legacy_internal
 endif
 
-OP_SYS_LDLIBS_posix_NET_yes = -ltftpfs -lnfs -lz -ltelnetd
-OP_SYS_LDLIBS_posix_NET_no = -ltftpfs -lbsd -lz
+# Has RTEMS been built with the legacy stack as a separate package?
+ifeq ($(RTEMS_LEGACY_NETWORKING),yes)
+RTEMS_HAS_NETWORKING = yes
+RTEMS_NETWORKING = legacy
+endif
+
+# Has RTEMS been built with the libbsd stack as a separate package?
+ifeq ($(RTEMS_BSD_NETWORKING),yes)
+RTEMS_HAS_NETWORKING = yes
+RTEMS_NETWORKING = bsd
+endif
+
+RTEMS_LEGACY_NET_LIB_no=
+
+# Legacy network with RTEMS 5 and earlier
+RTEMS_NET_LIB_legacy_internal=-lnfs
+OP_SYS_CFLAGS_NET_legacy_internal = -DRTEMS_LEGACY_STACK
+
+# Legacy network with RTEMS 6 is a separate package and library
+RTEMS_NET_LIB_legacy=-lnfs -lnetworking -lnfs
+OP_SYS_CFLAGS_NET_legacy = -DRTEMS_LEGACY_STACK
+
+# LibBSD network with RTEMS 5 and 6 is a separate package and library
+RTEMS_NET_LIB_bsd=-lbsd
+OP_SYS_CFLAGS_NET_bsd = -DRTEMS_LIBBSD_STACK
+
+# Set the networking flags
+OP_SYS_CFLAGS += $(OP_SYS_CFLAGS_NET_$(RTEMS_NETWORKING))
+
+POSIX_CPPFLAGS_posix = -D_GNU_SOURCE -D_DEFAULT_SOURCE
+POSIX_CPPFLAGS = $(POSIX_CPPFLAGS_$(OS_API))
+
+OP_SYS_LDLIBS_posix_NET_yes = -ltftpfs -lz -ltelnetd
+OP_SYS_LDLIBS_posix_NET_yes += $(RTEMS_NET_LIB_$(RTEMS_NETWORKING))
+OP_SYS_LDLIBS_posix_NET_no = -ltftpfs -lz
 OP_SYS_LDLIBS_score_NET_yes = -lnfs
 OP_SYS_LDLIBS_score_NET_no = -lnfs
 OP_SYS_LDLIBS += -lrtemsCom -lCom

--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -23,7 +23,7 @@ endef
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS
 
-ifeq ($(RTEMS_VERSION), $(word 1, $(sort 5 $(RTEMS_VERSION))))
+ifeq ($(shell test $(RTEMS_VERSION) -ge 5; echo $$?),0)
 RTEMS_BSP = mvme2700
 else
 RTEMS_BSP = mvme2307

--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -1,7 +1,6 @@
 #
 # Author: Matt Rippa
 #
-RTEMS_BSP = mvme2307
 RTEMS_TARGET_CPU = powerpc
 ARCH_DEP_CFLAGS += -DMY_DO_BOOTP=NULL
 ARCH_DEP_CFLAGS += -DHAVE_PPCBUG
@@ -23,3 +22,9 @@ define MUNCH_CMD
 endef
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS
+
+ifeq ($(RTEMS_VERSION), $(word 1, $(sort 5 $(RTEMS_VERSION))))
+RTEMS_BSP = mvme2700
+else
+RTEMS_BSP = mvme2307
+endif

--- a/configure/os/CONFIG.Common.RTEMS-pc386
+++ b/configure/os/CONFIG.Common.RTEMS-pc386
@@ -25,7 +25,7 @@ include $(CONFIG)/os/CONFIG.Common.RTEMS
 OP_SYS_LDFLAGS += -Wl,-Ttext,0x100000
 
 # This check must appear after the above include
-ifeq ($(RTEMS_VERSION),5)
+ifeq ($(shell test $(RTEMS_VERSION) -ge 5; echo $$?),0)
   $(info *** This target is not compatible with the configured RTEMS version.)
   $(info *** Build the RTEMS-pc686 (-qemu) target for RTEMS 5.x)
   $(error Can't continue)

--- a/configure/os/CONFIG.Common.RTEMS-pc686
+++ b/configure/os/CONFIG.Common.RTEMS-pc686
@@ -32,7 +32,7 @@ OP_SYS_LDFLAGS += -Wl,-Ttext,0x100000
 
 
 # This check must appear after the above include
-ifneq ($(RTEMS_VERSION),5)
+ifeq ($(shell test $(RTEMS_VERSION) -lt 5; echo $$?),0)
   $(info *** This target is not compatible with the configured RTEMS version.)
   $(info *** Build the RTEMS-pc386 (-qemu) target for RTEMS 4.x)
   $(error Can't continue)

--- a/configure/toolchain.c
+++ b/configure/toolchain.c
@@ -30,9 +30,26 @@ MSVC_VER = _MSC_VER
 #ifdef __rtems__
 #include <rtems/score/cpuopts.h>
 #  if __RTEMS_MAJOR__>=5
-OS_API = posix
+     OS_API = posix
 #  else
-OS_API = score
+     OS_API = score
+#  endif
+#  if defined(RTEMS_NETWORKING)
+     /* legacy stack circa RTEMS <= 5 and networking internal to RTEMS */
+     RTEMS_LEGACY_NETWORKING_INTERNAL = yes
+#  else
+#    if !defined(__has_include)
+       /* assume old GCC implies RTEMS < 5 with mis-configured BSP */
+#      error rebuild BSP with --enable-network
+#    elif __has_include(<machine/rtems-net-legacy.h>)
+       /* legacy stack circa RTEMS > 5 */
+       RTEMS_LEGACY_NETWORKING = yes
+#    elif __has_include(<machine/rtems-bsd-version.h>)
+       /* libbsd stack */
+       RTEMS_BSD_NETWORKING = yes
+#    else
+#      error Cannot determine RTEMS network configuration
+#    endif
 #  endif
 #endif
 
@@ -51,4 +68,3 @@ COMMANDLINE_LIBRARY ?= $(strip $(if $(wildcard $(if $(GNU_DIR),$(GNU_DIR)/includ
 #if defined(_FORTIFY_SOURCE) && _FORTIFY_SOURCE>2
 OP_SYS_CPPFLAGS += -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 #endif
-

--- a/modules/libcom/RTEMS/posix/rtems_config.c
+++ b/modules/libcom/RTEMS/posix/rtems_config.c
@@ -2,7 +2,7 @@
 * Copyright (c) 2002 The University of Saskatchewan
 * EPICS BASE Versions 3.13.7
 * and higher are distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution. 
+* in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*
  * RTEMS configuration for EPICS
@@ -128,16 +128,17 @@ extern void *POSIX_Init(void *argument);
   &rtems_shell_SYSCTL_Command
 #else // LEGACY_STACK:
 #define CONFIGURE_SHELL_USER_COMMANDS \
-  &bsp_interrupt_shell_command, \
-  &rtems_shell_PING_Command, \
-  &rtems_shell_ROUTE_Command, \
-  &rtems_shell_IFCONFIG_Command
-#endif
+  &bsp_interrupt_shell_command
+#endif // not LEGACY_STACK
 
 #define CONFIGURE_SHELL_COMMAND_CPUUSE
 #define CONFIGURE_SHELL_COMMAND_PERIODUSE
 #define CONFIGURE_SHELL_COMMAND_STACKUSE
 #define CONFIGURE_SHELL_COMMAND_PROFREPORT
+#define CONFIGURE_SHELL_COMMAND_TOP
+#define CONFIGURE_SHELL_COMMAND_RTEMS
+
+#define CONFIGURE_SHELL_COMMANDS_ALL_NETWORKING
 
 #define CONFIGURE_SHELL_COMMAND_CP
 #define CONFIGURE_SHELL_COMMAND_PWD
@@ -155,14 +156,15 @@ extern void *POSIX_Init(void *argument);
 #define CONFIGURE_SHELL_COMMAND_SHUTDOWN
 
 #include <rtems/shellconfig.h>
+
 #define RTEMS_BSD_CONFIG_BSP_CONFIG
 #define RTEMS_BSD_CONFIG_SERVICE_TELNETD
 #define RTEMS_BSD_CONFIG_TELNETD_STACK_SIZE (16 * 1024)
 #define RTEMS_BSD_CONFIG_SERVICE_FTPD
 #define RTEMS_BSD_CONFIG_FIREWALL_PF
-#else
+#else // __RTEMS_MAJOR__ > 4
 #include <rtems/shellconfig.h>
-#endif // not LEGACY_STACK
+#endif // __RTEMS_MAJOR__ > 4
 
 #if __RTEMS_MAJOR__ < 5 // still needed in Version 4?
 #define CONFIGURE_MAXIMUM_TASKS             rtems_resource_unlimited(30)

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -102,9 +102,9 @@ char bootp_server_name_init[128] = "1001.1001@10.0.5.1:/epics";
 char bootp_boot_file_name_init[128] = "/epics/myExample/bin/RTEMS-beatnik/myExample.boot";
 char bootp_cmdline_init[128] = "/epics/myExample/iocBoot/iocmyExample/st.cmd";
 
-struct in_addr rtems_bsdnet_bootp_server_address;
 /* TODO check rtems_bsdnet_bootp_cmdline */
 #ifndef RTEMS_LEGACY_STACK
+struct in_addr rtems_bsdnet_bootp_server_address;
 char *rtems_bsdnet_bootp_server_name = bootp_server_name_init;
 char *rtems_bsdnet_bootp_boot_file_name = bootp_boot_file_name_init;
 char *rtems_bsdnet_bootp_cmdline = bootp_cmdline_init;

--- a/modules/libcom/src/osi/os/RTEMS-posix/osdThreadExtra.c
+++ b/modules/libcom/src/osi/os/RTEMS-posix/osdThreadExtra.c
@@ -1,0 +1,52 @@
+/*************************************************************************\
+* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
+*     National Laboratory.
+* Copyright (c) 2002 The Regents of the University of California, as
+*     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/* Author:  Marty Kraimer Date:    18JAN2000 */
+/* Author:  Chris Johns   Date:    21JUL2023 */
+
+/* This is part of the posix implementation of epicsThread */
+
+#include "epicsStdio.h"
+#include "ellLib.h"
+#include "epicsEvent.h"
+#include "epicsThread.h"
+
+#include <pthread.h>
+
+void epicsThreadShowInfo(epicsThreadOSD *pthreadInfo, unsigned int level)
+{
+    if(!pthreadInfo) {
+        fprintf(epicsGetStdout(),"            NAME       EPICS ID   "
+            "PTHREAD ID   OSIPRI  OSSPRI  STATE\n");
+    } else {
+        struct sched_param param;
+        int policy;
+        int priority = 0;
+
+        if(pthreadInfo->tid) {
+            int status;
+            status = pthread_getschedparam(pthreadInfo->tid,&policy,&param);
+            if(!status) priority = param.sched_priority;
+        }
+        fprintf(epicsGetStdout(),"%16.16s %14p %12lu    %3d%8d %8.8s\n",
+             pthreadInfo->name,(void *)
+             pthreadInfo,(unsigned long)pthreadInfo->tid,
+             pthreadInfo->osiPriority,priority,
+             pthreadInfo->isSuspended?"SUSPEND":"OK");
+    }
+}
+
+static void thread_hook(epicsThreadId pthreadInfo)
+{
+    pthread_setname_np(pthreadInfo->tid, pthreadInfo->name);
+}
+
+EPICS_THREAD_HOOK_ROUTINE epicsThreadHookDefault = thread_hook;
+EPICS_THREAD_HOOK_ROUTINE epicsThreadHookMain = thread_hook;


### PR DESCRIPTION
These patches update the RTEMS 6 in EPICS 7.0 to:

1. Add support for the Legacy Networking stack as a separate package. RTEMS 6 moved the legacy network stack from the `rtems.git` repo to the `rtems-net-legacy.git` repo for long term maintenance support. The legacy stack can be built as a 3rd party library like LibBSD and this change lets EPICS 7 support it. The change is backwards compatible with RTEMS 5.3.0 with the networking enabled. It automatically detects the install stack or an error is raised.
2. Fix `CONFIG.Common.RTEMS` to use the `Makefile.inc` provided `LDFLAGS`. A patch for RTEMS 6's `Makefile.inc` support fixes the build issue related to `DBLINK` errors and the `link.h` header file. The RTEMS 6 patch is needed for RTEMS 6 and EPICS 7 to build for the MVME2700 BSP.
3. RTEMS 6 now supports the MVME2700 BSP. The patch supports MVME2700 on RTEMS 6 while supporting `mvme2307` on RTEMS 5.
4. Clean up of the bootp server address declaration in `rtems_config.c`.
5. Fix the shell command declarations for use with the legacy stack as a 3rd party library. I also added `top` and `rtems` while making the change.