### PR TITLE
Allow access to the TIME field

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -63,6 +63,41 @@ The compress record now supports the use of partially-filled buffers when using
 any of the N-to-one algorithms. This is achieved by setting the new field `PBUF`
 to `YES`.
 
+### Allow access to the TIME field of a record
+
+Accessing the TIME field no longer fails, but instead accesses the timestamp via
+the `"ts"` channel filter, giving the non-integral number of seconds since
+epoch as DOUBLE.
+
+Example:
+
+```
+record(longin, "test:record1") {
+    field(SCAN, "1 second")
+}
+
+record(longin, "test:record2") {
+    field(SCAN, "2 second")
+}
+
+record(calc, "test:timediff") {
+    field(SCAN, "1 second")
+    field(CALC, "A - B")
+    field(INPA, "test:record1.TIME")
+    field(INPB, "test:record2.TIME")
+}
+```
+
+```
+Hal$ camonitor test:timediff
+test:timediff                  2021-03-12 14:59:41.915976 1.00684
+test:timediff                  2021-03-12 14:59:42.915920 0.00693679
+test:timediff                  2021-03-12 14:59:43.916152 1.00705
+test:timediff                  2021-03-12 14:59:44.915869 0.00690341
+```
+
+This fixes [launchpad bug #1182091](https://bugs.launchpad.net/epics-base/+bug/1182091).
+
 ### Extended timestamp channel filter
 
 The `"ts"` filter can now retrieve the record's timestamp in several numeric

--- a/modules/database/src/ioc/db/dbChannel.c
+++ b/modules/database/src/ioc/db/dbChannel.c
@@ -464,7 +464,7 @@ dbChannel * dbChannelCreate(const char *name)
         static int exists_ts = -1;
 
         size_t namelen = strlen(name);
-        size_t reclen = namelen - 5; /* subtract strlen(".TIME"), MSVC won't optimize */
+        size_t reclen = namelen - sizeof(".TIME") + 1;
         int has_time = reclen > 0 && !strcmp(name + reclen, ".TIME");
 
         if (exists_ts == -1) {

--- a/modules/database/src/ioc/db/dbChannel.c
+++ b/modules/database/src/ioc/db/dbChannel.c
@@ -465,7 +465,7 @@ dbChannel * dbChannelCreate(const char *name)
 
         size_t namelen = strlen(name);
         size_t reclen = namelen - sizeof(".TIME") + 1;
-        int has_time = reclen > 0 && !strcmp(name + reclen, ".TIME");
+        int has_time = namelen >= sizeof(".TIME") && !strcmp(name + reclen, ".TIME");
 
         if (exists_ts == -1) {
             /* Only look for the filter on first use. */

--- a/modules/database/src/ioc/db/dbCommon.dbd.pod
+++ b/modules/database/src/ioc/db/dbCommon.dbd.pod
@@ -487,7 +487,11 @@ The B<RDES> field contains the address of dbRecordType
 The B<RPRO> field specifies a reprocessing of the record when current
 processing completes.
 
-The B<TIME> field holds the time stamp when this record was last processed.
+The B<TIME> field contains the time when this record was last processed in
+standard format. Reading this field will return a value of type DOUBLE
+representing fractional number of seconds since the epoch. Note that the value
+obtained this way cannot have nanosecond precision. The L<"ts" channel
+filter|filters> can be used to retreive the timestamp with full precision.
 
 The B<UTAG> field can be used to hold a site-specific 64-bit User Tag value
 that is associated with the record's time stamp.

--- a/modules/database/test/std/filters/tsTest.c
+++ b/modules/database/test/std/filters/tsTest.c
@@ -246,6 +246,7 @@ MAIN(tsTest) {
     const chFilterPlugin *plug;
 
     static TestSpec const tests[] = {
+        {"x.TIME",                                             type_check_double,   value_check_double},
         {"x.VAL{ts:{\"num\": \"dbl\"}}",                       type_check_double,   value_check_double},
         {"x.VAL{ts:{\"num\": \"sec\"}}",                       type_check_sec_nsec, value_check_sec},
         {"x.VAL{ts:{\"num\": \"nsec\"}}",                      type_check_sec_nsec, value_check_nsec},


### PR DESCRIPTION
This is a followup to #126, which it was split from. Based on the discussion in that pull request, I implemented access to TIME by simply chopping away the ".TIME" part of the channel name, replacing it with a JSON fragment for the `ts` filter, and letting things happen as if the user had requested a timestamp as a `double`.