### PR TITLE
Discard search requests in CA client

### DIFF
--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -681,6 +681,13 @@ bool udpiiu :: searchRespAction (
     }
 
     /*
+     * CA requires this field to be 0 in the search response
+     */
+    if (msg.m_count != 0) {
+        return true;
+    }
+
+    /*
      * Starting with CA V4.1 the minor version number
      * is appended to the end of each UDP search reply.
      * This value is ignored by earlier clients.


### PR DESCRIPTION
Search requests could accidentally reach a CA client if an IOC is configured with `EPICS_CA_SERVER_PORT=5065`.

This change filters those messages to prevent parsing a search request as a search reply and receiving several log with
"Identical process variable names on multiple servers" in which the address is invalid.

The filtering is done by checking the data count field (which in a search response, should be 0).

This fixes #378 