### PR TITLE
epicsThreadShow() zombies

### DIFF
--- a/modules/libcom/src/osi/os/Linux/osdThread.h
+++ b/modules/libcom/src/osi/os/Linux/osdThread.h
@@ -36,6 +36,7 @@ typedef struct epicsThreadOSD {
     int                isEpicsThread;
     int                isRealTimeScheduled;
     int                isOnThreadList;
+    int                isRunning;
     unsigned int       osiPriority;
     int                joinable;
     char               name[1];     /* actually larger */

--- a/modules/libcom/src/osi/os/Linux/osdThreadExtra.c
+++ b/modules/libcom/src/osi/os/Linux/osdThreadExtra.c
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <sys/prctl.h>
 
+#include "epicsAtomic.h"
 #include "epicsStdio.h"
 #include "ellLib.h"
 #include "epicsEvent.h"
@@ -45,11 +46,12 @@ void epicsThreadShowInfo(epicsThreadId pthreadInfo, unsigned int level)
             if (!status)
                 priority = param.sched_priority;
         }
-        fprintf(epicsGetStdout(),"%16.16s %14p %8lu    %3d%8d %8.8s\n",
+        fprintf(epicsGetStdout(),"%16.16s %14p %8lu    %3d%8d %8.8s%s\n",
              pthreadInfo->name,(void *)
              pthreadInfo,(unsigned long)pthreadInfo->lwpId,
              pthreadInfo->osiPriority,priority,
-             pthreadInfo->isSuspended ? "SUSPEND" : "OK");
+             pthreadInfo->isSuspended ? "SUSPEND" : "OK",
+             epicsAtomicGetIntT(&pthreadInfo->isRunning) ? "" : " ZOMBIE");
     }
 }
 

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -173,6 +173,7 @@ static epicsThreadOSD * create_threadInfo(const char *name)
     pthreadInfo = calloc(1,sizeof(*pthreadInfo) + strlen(name));
     if(!pthreadInfo)
         return NULL;
+    pthreadInfo->isRunning = 1;
     pthreadInfo->suspendEvent = epicsEventCreate(epicsEventEmpty);
     if(!pthreadInfo->suspendEvent){
         free(pthreadInfo);
@@ -441,6 +442,8 @@ static void * start_routine(void *arg)
     (*pthreadInfo->createFunc)(pthreadInfo->createArg);
 
     epicsExitCallAtThreadExits ();
+
+    epicsAtomicSetIntT(&pthreadInfo->isRunning, 0);
     return(0);
 }
 

--- a/modules/libcom/src/osi/os/posix/osdThread.h
+++ b/modules/libcom/src/osi/os/posix/osdThread.h
@@ -34,6 +34,7 @@ typedef struct epicsThreadOSD {
     int                isEpicsThread;
     int                isRealTimeScheduled;
     int                isOnThreadList;
+    int                isRunning;
     unsigned int       osiPriority;
     int                joinable;
     char               name[1];     /* actually larger */

--- a/modules/libcom/src/osi/os/posix/osdThreadExtra.c
+++ b/modules/libcom/src/osi/os/posix/osdThreadExtra.c
@@ -12,6 +12,7 @@
 
 /* This is part of the posix implementation of epicsThread */
 
+#include "epicsAtomic.h"
 #include "epicsStdio.h"
 #include "ellLib.h"
 #include "epicsEvent.h"
@@ -35,11 +36,12 @@ void epicsThreadShowInfo(epicsThreadOSD *pthreadInfo, unsigned int level)
             status = pthread_getschedparam(pthreadInfo->tid,&policy,&param);
             if(!status) priority = param.sched_priority;
         }
-        fprintf(epicsGetStdout(),"%16.16s %14p %12lu    %3d%8d %8.8s\n",
+        fprintf(epicsGetStdout(),"%16.16s %14p %12lu    %3d%8d %8.8s%s\n",
              pthreadInfo->name,(void *)
              pthreadInfo,(unsigned long)pthreadInfo->tid,
              pthreadInfo->osiPriority,priority,
-             pthreadInfo->isSuspended?"SUSPEND":"OK");
+             pthreadInfo->isSuspended?"SUSPEND":"OK",
+             epicsAtomicGetIntT(&pthreadInfo->isRunning) ? "" : " ZOMBIE");
     }
 }
 


### PR DESCRIPTION
Flag when a thread has returned, but its tracking struct is still around.  eg. in need of joining.

This change effects all targets except vxWorks.

In response to https://github.com/epics-base/pvAccessCPP/issues/190

On Linux, output looks like:

```
epics> epicsThreadShowAll 
            NAME       EPICS ID   LWP ID   OSIPRI  OSSPRI  STATE
          _main_ 0x55e771cb0050   399465      0       0       OK
...
UDP-rx 224.0.0.1 0x55e771f1b420   399502     50       0       OK
          TCP-tx 0x7f6eb42d95a0   400851     20       0       OK ZOMBIE
          TCP-rx 0x7f6eb42d91b0   400850     20       0       OK ZOMBIE
```
