### PR TITLE
Fix issues detected by cppcheck / sonarqube

### DIFF
--- a/modules/ca/src/client/catime.c
+++ b/modules/ca/src/client/catime.c
@@ -450,7 +450,7 @@ void timeIt ( tf *pfunc, ti *pItems, unsigned iterations,
     epicsTimeStamp      end_time;
     epicsTimeStamp      start_time;
     double              delay;
-    unsigned            inlineIter;
+    unsigned            inlineIter = 0;
 
     epicsTimeGetCurrent ( &start_time );
     (*pfunc) ( pItems, iterations, &inlineIter );

--- a/modules/database/src/ioc/db/dbChannel.c
+++ b/modules/database/src/ioc/db/dbChannel.c
@@ -575,18 +575,10 @@ long dbChannelOpen(dbChannel *chan)
     }
 
     /* Set up type probe */
-    probe.type = dbfl_type_val;
-    probe.ctx = dbfl_context_read;
-    probe.mask = 0;
+    memset(&probe, 0, sizeof(probe));
     probe.field_type  = dbChannelExportType(chan);
     probe.no_elements = dbChannelElements(chan);
     probe.field_size  = dbChannelFieldSize(chan);
-    probe.utag = 0;
-    probe.sevr = NO_ALARM;
-    probe.stat = NO_ALARM;
-    probe.time.secPastEpoch = 0;
-    probe.time.nsec = 0;
-    probe.dtor = NULL;
 
     p = probe;
 

--- a/modules/database/src/ioc/db/dbChannel.c
+++ b/modules/database/src/ioc/db/dbChannel.c
@@ -577,13 +577,16 @@ long dbChannelOpen(dbChannel *chan)
     /* Set up type probe */
     probe.type = dbfl_type_val;
     probe.ctx = dbfl_context_read;
+    probe.mask = 0;
     probe.field_type  = dbChannelExportType(chan);
     probe.no_elements = dbChannelElements(chan);
     probe.field_size  = dbChannelFieldSize(chan);
+    probe.utag = 0;
     probe.sevr = NO_ALARM;
     probe.stat = NO_ALARM;
     probe.time.secPastEpoch = 0;
     probe.time.nsec = 0;
+    probe.dtor = NULL;
 
     p = probe;
 

--- a/modules/libcom/src/log/iocLogServer.c
+++ b/modules/libcom/src/log/iocLogServer.c
@@ -193,6 +193,7 @@ int main(void)
             "File access problems to `%s' because `%s'\n",
             ioc_log_file_name,
             strerror(errno));
+        free(pserver);
         return IOCLS_ERROR;
     }
 
@@ -205,6 +206,7 @@ int main(void)
     if (status < 0) {
         fprintf(stderr,
             "iocLogServer: failed to add read callback\n");
+        free(pserver);
         return IOCLS_ERROR;
     }
 

--- a/modules/libcom/src/log/iocLogServer.c
+++ b/modules/libcom/src/log/iocLogServer.c
@@ -113,8 +113,8 @@ int main(void)
 
     pserver->pfdctx = (void *) fdmgr_init();
     if (!pserver->pfdctx) {
-        free(pserver);
         fprintf(stderr, "iocLogServer: %s\n", strerror(errno));
+        free(pserver);
         return IOCLS_ERROR;
     }
 
@@ -149,6 +149,7 @@ int main(void)
         fprintf (stderr,
             "iocLogServer: a server is already installed on port %u?\n",
             (unsigned)ioc_log_port);
+        free(pserver);
         return IOCLS_ERROR;
     }
 
@@ -158,6 +159,7 @@ int main(void)
         char sockErrBuf[64];
         epicsSocketConvertErrnoToString ( sockErrBuf, sizeof ( sockErrBuf ) );
         fprintf(stderr, "iocLogServer: listen err %s\n", sockErrBuf);
+        free(pserver);
         return IOCLS_ERROR;
     }
 
@@ -174,6 +176,7 @@ int main(void)
         char sockErrBuf[64];
         epicsSocketConvertErrnoToString ( sockErrBuf, sizeof ( sockErrBuf ) );
         fprintf(stderr, "iocLogServer: ioctl FIONBIO err %s\n", sockErrBuf);
+        free(pserver);
         return IOCLS_ERROR;
     }
 

--- a/modules/libcom/src/macLib/macEnv.c
+++ b/modules/libcom/src/macLib/macEnv.c
@@ -30,6 +30,7 @@ macDefExpand(const char *str, MAC_HANDLE *macros)
     static const char * pairs[] = { "", "environ", NULL, NULL };
     long destCapacity = 128;
     char *dest = NULL;
+    char *newdest = NULL;
     int n;
 
     if (macros) {
@@ -61,8 +62,11 @@ macDefExpand(const char *str, MAC_HANDLE *macros)
     } else {
         size_t unused = destCapacity - ++n;
 
-        if (unused >= 20)
-            dest = realloc(dest, n);
+        if (unused >= 20) {
+            newdest = realloc(dest, n);
+            if (newdest)
+                dest = newdest;
+        }
     }
 
 done:

--- a/modules/libcom/src/osi/os/RTEMS-posix/osdMessageQueue.c
+++ b/modules/libcom/src/osi/os/RTEMS-posix/osdMessageQueue.c
@@ -41,6 +41,10 @@ epicsMessageQueueCreate(unsigned int capacity, unsigned int maximumMessageSize)
 {
     struct mq_attr the_attr;
     epicsMessageQueueId id = (epicsMessageQueueId)calloc(1, sizeof(*id));
+    if (!id) {
+        fprintf (stderr, "Can't allocate message queue: %s\n", strerror(errno));
+        return NULL;
+    }
     sprintf(id->name, "MQ_%0d", epicsAtomicIncrIntT(&idCnt));
     the_attr.mq_maxmsg = capacity;
     the_attr.mq_msgsize = maximumMessageSize;

--- a/modules/libcom/src/osi/os/RTEMS-posix/osdMessageQueue.c
+++ b/modules/libcom/src/osi/os/RTEMS-posix/osdMessageQueue.c
@@ -47,6 +47,7 @@ epicsMessageQueueCreate(unsigned int capacity, unsigned int maximumMessageSize)
     id->id = mq_open(id->name, O_RDWR | O_CREAT | O_EXCL, 0644, &the_attr);
     if (id->id <0) {
         fprintf (stderr, "Can't create message queue: %s\n", strerror (errno));
+        free(id);
         return NULL;
     }
     return id;


### PR DESCRIPTION
A set of (non-functional) changes that fix a few issues found by cppcheck / sonar. Intended to make EPICS Base pass the ITER quality gates again.

- zero-initialization of local variables and structure members
- missing `free()` of allocated memory when returning an error
- memory leaks when `realloc()` returns an error