### PR TITLE
rtems: Add AARCH64 support and xilinx_zynqmp_lp64_zu3eg BSP

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS-xilinx_zynqmp_lp64_zu3eg
+++ b/configure/os/CONFIG.Common.RTEMS-xilinx_zynqmp_lp64_zu3eg
@@ -1,0 +1,15 @@
+#
+# CONFIG.Common.RTEMS-xilinx_zynq_zedboard
+# Author: Chris Johns <chris@contemporary.software>
+#
+# All RTEMS targets use the same Makefile fragment
+#
+#EXE = .elf
+RTEMS_BSP = xilinx_zynqmp_lp64_zu3eg
+RTEMS_TARGET_CPU = aarch64
+GNU_TARGET = aarch64-rtems
+
+OP_SYS_LDLIBS += -Wl,--gc-sections
+ARCH_DEP_LDFLAGS = -L$(RTEMS_BASE)/$(GNU_TARGET)$(RTEMS_VERSION)/xilinx_zynqmp_lp64_zu3eg/lib/
+
+include $(CONFIG)/os/CONFIG.Common.RTEMS

--- a/modules/libcom/RTEMS/posix/rtems_config.c
+++ b/modules/libcom/RTEMS/posix/rtems_config.c
@@ -169,7 +169,8 @@ extern void *POSIX_Init(void *argument);
  * The new general time support makes including the RTC driver less important.
  */
 #if !defined(mpc604) && !defined(__mc68040__) && !defined(__mcf5200__) && \
-    !defined(mpc7455) && !defined(__arm__)  && !defined(__nios2__)
+    !defined(mpc7455) && !defined(__arm__)  && !defined(__aarch64__) && \
+    !defined(__nios2__)
     /* don't have RTC code */
 #define CONFIGURE_APPLICATION_NEEDS_RTC_DRIVER
 #endif

--- a/modules/libcom/src/osi/os/RTEMS/osdVME.h
+++ b/modules/libcom/src/osi/os/RTEMS/osdVME.h
@@ -11,12 +11,12 @@
 /*
  * OS-dependent VME support
  */
-#ifndef __i386__
-#ifndef __mc68000
-#ifndef __arm__
+/*
+ * ?? Is PowerPC the only EPICS arch to support VME?
+ */
+#if !defined(__i386__) && !defined(__mc68000) && \
+    !defined(__arm__) && !defined(__aarch64__)
 #include <bsp/VME.h>
-#endif
-#endif
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
I have built this BSP on the TRENZ TE0802 board. This is a ZynqMP processor so the patch adds `aarch64` support for RTEMS to EPICS.

Most tests run and I see no error but some seem to need system level support such as NFS are failing.

The build is the latest as of today and is RTEMS 6 (master), libbsd (6-freebsd-12) and the [Legacy Stack](https://github.com/epics-base/epics-base/pull/375) pull request. I use FreeBSD so I also had the (FreeBSD)[https://github.com/epics-base/epics-base/pull/393] pull request included.