### PR TITLE
Fix MAKEFLAGS parsing with Make 4.4+

### DIFF
--- a/configure/CONFIG_COMMON
+++ b/configure/CONFIG_COMMON
@@ -83,8 +83,9 @@ IOCS_APPL_TOP               = $(INSTALL_ABSOLUTE)
 
 #-------------------------------------------------------
 # How to portably check the flags to make
+makeflags := $(firstword $(filter-out -,$(filter-out --%,$(MAKEFLAGS))))
 define checkflags
-  make-$1 = $(findstring $1,$(filter-out --%,$(MAKEFLAGS)))
+  make-$1 := $(findstring $1,$(makeflags))
 endef
 # This is extensible to most single letter flags:
 $(foreach flag,s q, $(eval $(call checkflags,$(flag))))


### PR DESCRIPTION
Since Make version 4.4, `MAKEFLAGS` also contains long options and overridden variables on the command-line ([source][1]).

[1]: https://git.savannah.gnu.org/cgit/make.git/tree/NEWS?h=4.4#n67

This means that parsing by filtering out `--%` doesn't work reliably anymore, since it doesn't remove overrides:

Running `make VAR=quacks` gives `MAKEFLAGS=" -- VAR=quacks"`, and `checkflags` would understand that flags `-q`, `-s`, ... were set.

This would get transmitted below into `QUIET_FLAGS` and `QUESTION_FLAG`, then passed to the `genVersionHeader.pl` as `-i` and `-q`.

The result would be that `genVersionHeader.pl` would never create the version header (only check for its up-to-date status), leading to confusing errors:

```
  ../misc/epicsRelease.c:25:32: error: expected ')' before 'EPICS_VCS_VERSION'
     25 |     printf ( "## %s\n", "Rev. " EPICS_VCS_VERSION );
        |            ~                   ^~~~~~~~~~~~~~~~~~
```

The [NEWS file][1] recommends using `firstword`, so we can use just that.