### PR TITLE
feat: menuEpicsTypeSizes added and compatible to pRec->ftx.

### DIFF
--- a/modules/database/src/ioc/db/Makefile
+++ b/modules/database/src/ioc/db/Makefile
@@ -42,6 +42,7 @@ INC += dbState.h
 INC += db_access_routines.h
 INC += db_convert.h
 INC += dbUnitTest.h
+INC += menu.h
 
 # Generate menuGlobal.dbd, not really by concatenation, see RULES
 DBDCAT += menuGlobal.dbd

--- a/modules/database/src/ioc/db/menu.h
+++ b/modules/database/src/ioc/db/menu.h
@@ -1,0 +1,52 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+ \*************************************************************************/
+
+/** @file menu.h
+ * @brief Adds db menu capabilities
+ * @see @ref menu
+ */
+
+#ifndef INCmenuH
+#define INCmenuH
+
+#include "menuFtype.h"
+#include "epicsTypes.h"
+
+/*Returns the variable size of the menuFtype*/
+epicsEnum16 menuEpicsTypeSizes(menuFtype type)
+{
+	switch (type)
+	{
+	case menuFtypeSTRING:
+		return sizeof(epicsString);
+	case menuFtypeCHAR:
+		return sizeof(epicsInt8);
+	case menuFtypeUCHAR:
+		return sizeof(epicsUInt8);
+	case menuFtypeSHORT:
+		return sizeof(epicsInt16);
+	case menuFtypeUSHORT:
+		return sizeof(epicsUInt16);
+	case menuFtypeLONG:
+		return sizeof(epicsInt32);
+	case menuFtypeULONG:
+		return sizeof(epicsUInt32);
+	case menuFtypeINT64:
+		return sizeof(epicsInt64);
+	case menuFtypeUINT64:
+		return sizeof(epicsUInt64);
+	case menuFtypeFLOAT:
+		return sizeof(epicsFloat32);
+	case menuFtypeDOUBLE:
+		return sizeof(epicsFloat64);
+	case menuFtypeENUM:
+		return sizeof(epicsEnum16);
+	default:
+		return 0;
+	}
+}
+
+#endif


### PR DESCRIPTION
I am considering the implementation of the function (menuEpicsTypeSizes) that returns the size of all the type possibilities of the record (I use it in another project).
Please, review it and let me know if it is already implemented or not and if it is useful in general. If yes, then what would be the best location for this implementation? I wrote it in this way to show the idea and I am considering refining it after your answer (or cancel).