### PR TITLE
feat: Allowing rw to UTAG within db implementation.

### DIFF
--- a/modules/database/src/ioc/db/dbCommon.dbd.pod
+++ b/modules/database/src/ioc/db/dbCommon.dbd.pod
@@ -558,9 +558,8 @@ provide the time stamp as described above.
 		interest(2)
 		extra("epicsTimeStamp      time")
 	}
-        field(UTAG,DBF_UINT64) {
+	field(UTAG,DBF_UINT64) {
 		prompt("Time Tag")
-		special(SPC_NOMOD)
 		interest(3)
 	}
 	field(FLNK,DBF_FWDLINK) {


### PR DESCRIPTION
I propose that UTAG has RW capabilities.
In my test app, I feed directly the CycleId into the UTAG of the timestamping PV which is then used as a TIME reference for other PVs. It might happen that we will include more info (like BeamPresent etc.) into UTAG as well, and it will be easily done with e.g. calc record, etc.  Also, I think, if a user IOC has a reason to modify UTAG provided by the timing system based on their local PVs (e.g. for their local GUI application, etc. ) then this capability would be useful as everything can be done without writing excessive C code. Let me know your opinion.