### PR TITLE
Com: Make STATIC_ASSERT macro typedefs unique

### DIFF
--- a/modules/libcom/src/osi/epicsAssert.h
+++ b/modules/libcom/src/osi/epicsAssert.h
@@ -78,14 +78,22 @@ LIBCOM_API void epicsAssert (const char *pFile, const unsigned line,
 #if __cplusplus>=201103L
 #define STATIC_ASSERT(expr) static_assert(expr, #expr)
 #else
-#define STATIC_JOIN(x, y) STATIC_JOIN2(x, y)
-#define STATIC_JOIN2(x, y) x ## y
+
+#define STATIC_JOIN(x, y, z, w) STATIC_JOIN4(x, y, z, w)
+#define STATIC_JOIN4(x, y, z, w) x ## y ## z ## w
+
+/* Compilers that do not support __COUNTER__ (e.g. GCC 4.1) will not be able to use unique static assert typedefs */
+#ifdef __COUNTER__
+#   define STATIC_ASSERT_MSG(l) STATIC_JOIN(static_assert_, __COUNTER__, _failed_at_line_, l)
+#else
+#   define STATIC_ASSERT_MSG(l) STATIC_JOIN(static_assert_, 0, _failed_at_line_, l)
+#endif
 
 /**\brief Declare a condition that should be true at compile-time.
  * \param expr A C/C++ const-expression that should evaluate to True.
  */
 #define STATIC_ASSERT(expr) \
-    typedef int STATIC_JOIN(static_assert_failed_at_line_, __LINE__) \
+    typedef int STATIC_ASSERT_MSG(__LINE__) \
     [ (expr) ? 1 : -1 ] EPICS_UNUSED
 #endif
 


### PR DESCRIPTION
When building in C++03 mode, `STATIC_ASSERT` generates a typedef in the form `static_assert_failed_at_line_N` where `N` is the line number. This can trigger shadowing warnings if you have a `STATIC_ASSERT` in function scope on the same line as a global-scope `STATIC_ASSERT` in some included header. EPICS has some `STATIC_ASSERT`s in various header files, which ended up triggering a shadowing warning in some code I wrote.

Something like this would fail to compile with `-std=c++03 -Wshadow -Werror=shadow`
```
// myheader.h

STATIC_ASSERT(sizeof(int) == 4); // Line 3

// myfile.cpp
void test() {
    STATIC_ASSERT(sizeof(bool) == 1); // Line 3
}
```

To fix this, I just inserted `__COUNTER__` into the typedef. Sufficiently old compilers, like GCC 4.1 and earlier, don't support this macro and will have to eat the warning.


