### PR TITLE
Fix issues detected by clang-tidy

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -856,7 +856,9 @@ static void dbDriver(char *name)
     if(!pgphentry) {
         yyerrorAbort("gphAdd failed");
     }
-    pgphentry->userPvt = pdrvSup;
+    else {
+        pgphentry->userPvt = pdrvSup;
+    }
     ellAdd(&savedPdbbase->drvList,&pdrvSup->node);
 }
 
@@ -876,7 +878,9 @@ static void dbLinkType(char *name, char *jlif_name)
     if (!pgphentry) {
         yyerrorAbort("gphAdd failed");
     }
-    pgphentry->userPvt = pLinkSup;
+    else {
+        pgphentry->userPvt = pLinkSup;
+    }
     ellAdd(&savedPdbbase->linkList, &pLinkSup->node);
 }
 
@@ -899,7 +903,9 @@ static void dbRegistrar(char *name)
     if(!pgphentry) {
         yyerrorAbort("gphAdd failed");
     }
-    pgphentry->userPvt = ptext;
+    else {
+        pgphentry->userPvt = ptext;
+    }
     ellAdd(&savedPdbbase->registrarList,&ptext->node);
 }
 
@@ -922,7 +928,9 @@ static void dbFunction(char *name)
     if(!pgphentry) {
        yyerrorAbort("gphAdd failed");
     }
-    pgphentry->userPvt = ptext;
+    else {
+        pgphentry->userPvt = ptext;
+    }
     ellAdd(&savedPdbbase->functionList,&ptext->node);
 }
 
@@ -946,7 +954,9 @@ static void dbVariable(char *name, char *type)
     if(!pgphentry) {
         yyerrorAbort("gphAdd failed");
     }
-    pgphentry->userPvt = pvar;
+    else {
+        pgphentry->userPvt = pvar;
+    }
     ellAdd(&savedPdbbase->variableList,&pvar->node);
 }
 

--- a/modules/database/src/std/link/lnkConst.c
+++ b/modules/database/src/std/link/lnkConst.c
@@ -225,8 +225,10 @@ static jlif_result lnkConst_string(jlink *pjlink, const char *val, size_t len)
         if (!vec)
             return jlif_stop;
         str = malloc(len+1);
-        if (!str)
+        if (!str) {
+            free(vec);
             return jlif_stop;
+        }
 
         strncpy(str, val, len);
         str[len] = '\0';

--- a/modules/libcom/src/calc/postfix.c
+++ b/modules/libcom/src/calc/postfix.c
@@ -335,6 +335,10 @@ LIBCOM_API long
             break;
 
         case SEPERATOR:
+            if (pstacktop == stack) {
+                *perror = CALC_ERR_BAD_SEPERATOR;
+                goto bad;
+            }
             /* Move operators to the output until open paren */
             while (pstacktop->name[0] != '(') {
                 if (pstacktop <= stack+1) {
@@ -353,6 +357,10 @@ LIBCOM_API long
             break;
 
         case CLOSE_PAREN:
+            if (pstacktop == stack) {
+                *perror = CALC_ERR_PAREN_NOT_OPEN;
+                goto bad;
+            }
             /* Move operators to the output until matching paren */
             while (pstacktop->name[0] != '(') {
                 if (pstacktop <= stack+1) {

--- a/modules/libcom/test/epicsCalcTest.cpp
+++ b/modules/libcom/test/epicsCalcTest.cpp
@@ -298,7 +298,7 @@ MAIN(epicsCalcTest)
     const double a=1.0, b=2.0, c=3.0, d=4.0, e=5.0, f=6.0,
                  g=7.0, h=8.0, i=9.0, j=10.0, k=11.0, l=12.0;
 
-    testPlan(635);
+    testPlan(637);
 
     /* LITERAL_OPERAND elements */
     testExpr(0);
@@ -953,6 +953,8 @@ MAIN(epicsCalcTest)
     testBadExpr("1?", CALC_ERR_CONDITIONAL);
     testBadExpr("1?1", CALC_ERR_CONDITIONAL);
     testBadExpr(":1", CALC_ERR_SYNTAX);
+    testBadExpr("0,", CALC_ERR_BAD_SEPERATOR);
+    testBadExpr("0)", CALC_ERR_PAREN_NOT_OPEN);
 
     // Bit manipulations wrt bit 31 (bug lp:1514520)
     //   using integer literals


### PR DESCRIPTION
Inspired by #392, I decided to run clang-tidy on epics-base and it pointed out these issues.

* Fix possible nullptr de-reference in `dbLexRoutines.c`. There was just a missing else block in some of these functions.
* Fix possible memory leak in `lnkConst.c`