### PR TITLE
libCom: detect support for backtrace() with __has_include.

### DIFF
--- a/modules/libcom/src/osi/os/posix/osdExecinfoBackTrace.cpp
+++ b/modules/libcom/src/osi/os/posix/osdExecinfoBackTrace.cpp
@@ -12,10 +12,13 @@
 #include <stdlib.h>
 
 // execinfo.h may not be present if uclibc is configured to omit backtrace()
-#if !defined(__UCLIBC_MAJOR__) || defined(__UCLIBC_HAS_EXECINFO__)
+// some C libraries, such as musl, don't have execinfo.h at all
+#if defined(__has_include)
+#  if __has_include(<execinfo.h>)
+#    define HAS_EXECINFO 1
+#  endif
+#elif !defined(__UCLIBC_MAJOR__) || defined(__UCLIBC_HAS_EXECINFO__)
 #  define HAS_EXECINFO 1
-#else
-#  define HAS_EXECINFO 0
 #endif
 
 #if HAS_EXECINFO


### PR DESCRIPTION
This is necessary in order to build epics-base with musl libc, for example, and any other C libraries which don't include this functionality. In order to not regress builds with older compilers, we still support the uclibc check.