### PR TITLE
Rationalize osdMutex

### DIFF
--- a/modules/libcom/src/misc/epicsExit.c
+++ b/modules/libcom/src/misc/epicsExit.c
@@ -35,8 +35,6 @@
 #include "cantProceed.h"
 #include "epicsExit.h"
 
-void epicsMutexCleanup(void);
-
 typedef struct exitNode {
     ELLNODE         node;
     epicsExitFunc   func;
@@ -115,8 +113,6 @@ LIBCOM_API void epicsExitCallAtExits(void)
         epicsExitCallAtExitsPvt ( pep );
         destroyExitPvt ( pep );
     }
-    /* Handle specially to avoid circular reference */
-    epicsMutexCleanup();
 }
 
 LIBCOM_API void epicsExitCallAtThreadExits(void)

--- a/modules/libcom/src/osi/epicsMutex.h
+++ b/modules/libcom/src/osi/epicsMutex.h
@@ -247,21 +247,6 @@ LIBCOM_API void epicsStdCall epicsMutexShow(
 LIBCOM_API void epicsStdCall epicsMutexShowAll(
     int onlyLocked,unsigned  int level);
 
-/**@privatesection
- * The following are interfaces to the OS dependent
- * implementation and should NOT be called directly by
- * user code.
- */
-struct epicsMutexOSD * epicsMutexOsdCreate(void);
-void epicsMutexOsdDestroy(struct epicsMutexOSD *);
-void epicsMutexOsdUnlock(struct epicsMutexOSD *);
-epicsMutexLockStatus epicsMutexOsdLock(struct epicsMutexOSD *);
-epicsMutexLockStatus epicsMutexOsdTryLock(struct epicsMutexOSD *);
-void epicsMutexOsdShow(struct epicsMutexOSD *,unsigned  int level);
-#ifdef EPICS_PRIVATE_API
-void epicsMutexOsdShowAll(void);
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/modules/libcom/src/osi/epicsMutexImpl.h
+++ b/modules/libcom/src/osi/epicsMutexImpl.h
@@ -1,0 +1,66 @@
+/*************************************************************************\
+* Copyright (c) 2002 The University of Chicago, as Operator of Argonne
+*     National Laboratory.
+* Copyright (c) 2002 The Regents of the University of California, as
+*     Operator of Los Alamos National Laboratory.
+* Copyright (c) 2023 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+/* Only include from osdMutex.c */
+
+#ifndef epicsMutexImpl_H
+#define epicsMutexImpl_H
+
+#if defined(vxWorks)
+#  include <vxWorks.h>
+#  include <semLib.h>
+#elif defined(_WIN32)
+#  define VC_EXTRALEAN
+#  define WIN32_LEAN_AND_MEAN
+#  include <windows.h>
+#elif defined(__rtems__)
+#  include <rtems.h>
+#  include <rtems/score/cpuopts.h>
+#else
+#  include <pthread.h>
+#endif
+
+#include "ellLib.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct epicsMutexParm {
+    /* global list of mutex */
+    ELLNODE node;
+    /* location where mutex was allocated */
+    const char *pFileName;
+    int lineno;
+#if defined(vxWorks)
+    SEM_ID osd;
+#elif defined(_WIN32)
+    CRITICAL_SECTION osd;
+#elif defined(__RTEMS_MAJOR__) && __RTEMS_MAJOR__<5
+    Semaphore_Control *osd;
+#else
+    pthread_mutex_t osd;
+#endif
+};
+
+void epicsMutexOsdSetup(void);
+long epicsMutexOsdPrepare(struct epicsMutexParm *);
+void epicsMutexOsdCleanup(struct epicsMutexParm *);
+void epicsMutexOsdShow(struct epicsMutexParm *,unsigned  int level);
+void epicsMutexOsdShowAll(void);
+
+extern struct epicsMutexParm epicsMutexGlobalLock;
+
+#ifdef __cplusplus
+} // extern "C
+#endif
+
+#endif // epicsMutexImpl_H

--- a/modules/libcom/src/osi/os/RTEMS-score/osdEvent.c
+++ b/modules/libcom/src/osi/os/RTEMS-score/osdEvent.c
@@ -26,6 +26,7 @@
 
 #include "epicsEvent.h"
 #include "epicsThread.h"
+#include "rtemsNamePvt.h"
 #include "errlog.h"
 
 /* #define EPICS_RTEMS_SEMAPHORE_STATS */
@@ -47,12 +48,9 @@ epicsEventCreate(epicsEventInitialState initialState)
 {
     rtems_status_code sc;
     rtems_id sid;
-    rtems_interrupt_level level;
-    static char c1 = 'a';
-    static char c2 = 'a';
-    static char c3 = 'a';
+    static uint32_t name;
 
-    sc = rtems_semaphore_create (rtems_build_name ('B', c3, c2, c1),
+    sc = rtems_semaphore_create (next_rtems_name ('B', &name),
         initialState,
         RTEMS_FIFO | RTEMS_SIMPLE_BINARY_SEMAPHORE |
             RTEMS_NO_INHERIT_PRIORITY | RTEMS_NO_PRIORITY_CEILING | RTEMS_LOCAL,
@@ -62,26 +60,6 @@ epicsEventCreate(epicsEventInitialState initialState)
         errlogPrintf ("Can't create binary semaphore: %s\n", rtems_status_text (sc));
         return NULL;
     }
-    rtems_interrupt_disable (level);
-    if (c1 == 'z') {
-        if (c2 == 'z') {
-            if (c3 == 'z') {
-                c3 = 'a';
-            }
-            else {
-                c3++;
-            }
-            c2 = 'a';
-        }
-        else {
-            c2++;
-        }
-        c1 = 'a';
-    }
-    else {
-        c1++;
-    }
-    rtems_interrupt_enable (level);
     return (epicsEventId)sid;
 }
 

--- a/modules/libcom/src/osi/os/RTEMS-score/rtemsNamePvt.h
+++ b/modules/libcom/src/osi/os/RTEMS-score/rtemsNamePvt.h
@@ -1,0 +1,20 @@
+/*************************************************************************\
+* Copyright (c) 2023 Michael Davidsaver
+* SPDX-License-Identifier: EPICS
+* EPICS Base is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef RTEMSNAMEPVT_H
+#define RTEMSNAMEPVT_H
+
+#include <stdint.h>
+
+/* Compute rtems_build_name(prefix, A, B, C) where A, B, C are the letters a-z.
+ * eg. "Qaaa"
+ *
+ * 'counter' is incremented atomically during each call.
+ */
+uint32_t next_rtems_name(char prefix, uint32_t* counter);
+
+#endif // RTEMSNAMEPVT_H

--- a/modules/libcom/src/osi/os/vxWorks/osdMutex.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdMutex.c
@@ -13,6 +13,7 @@
 
 #include <vxWorks.h>
 #include <semLib.h>
+#include <errno.h>
 #include <time.h>
 #include <objLib.h>
 #include <sysLib.h>
@@ -23,30 +24,47 @@ int sysClkRateGet(void);
 #define EPICS_PRIVATE_API
 
 #include "epicsMutex.h"
-
-struct epicsMutexOSD * epicsMutexOsdCreate(void)
+#include "epicsMutexImpl.h"
+
+void epicsMutexOsdSetup(void)
 {
-    return((struct epicsMutexOSD *)
-        semMCreate(SEM_DELETE_SAFE|SEM_INVERSION_SAFE|SEM_Q_PRIORITY));
+    if(!epicsMutexGlobalLock.osd) {
+        epicsMutexOsdPrepare(&epicsMutexGlobalLock);
+    }
 }
 
-void epicsMutexOsdDestroy(struct epicsMutexOSD * id)
+long epicsMutexOsdPrepare(struct epicsMutexParm *mutex)
 {
-    semDelete((SEM_ID)id);
+    mutex->osd = semMCreate(SEM_DELETE_SAFE|SEM_INVERSION_SAFE|SEM_Q_PRIORITY);
+    return mutex->osd ? 0 : ENOMEM;
 }
 
-epicsMutexLockStatus epicsMutexOsdTryLock(struct epicsMutexOSD * id)
+void epicsMutexOsdCleanup(struct epicsMutexParm *mutex)
 {
-    int status;
-    status = semTake((SEM_ID)id,NO_WAIT);
+    semDelete(mutex->osd);
+}
+
+epicsMutexLockStatus epicsMutexLock(struct epicsMutexParm *mutex)
+{
+    return semTake(mutex->osd,WAIT_FOREVER)==OK ? epicsMutexLockOK : epicsMutexLockError;
+}
+
+epicsMutexLockStatus epicsMutexTryLock(struct epicsMutexParm *mutex)
+{
+    int status = semTake(mutex->osd,NO_WAIT);
     if(status==OK) return(epicsMutexLockOK);
     if(errno==S_objLib_OBJ_UNAVAILABLE) return(epicsMutexLockTimeout);
     return(epicsMutexLockError);
 }
 
-void epicsMutexOsdShow(struct epicsMutexOSD * id,unsigned int level)
+void epicsMutexUnlock(struct epicsMutexParm *mutex)
 {
-    semShow((SEM_ID)id,level);
+    semGive(mutex->osd);
+}
+
+void epicsMutexOsdShow(struct epicsMutexParm *mutex,unsigned int level)
+{
+    semShow(mutex->osd,level);
 }
 
 void epicsMutexOsdShowAll(void) {}

--- a/modules/libcom/src/osi/os/vxWorks/osdMutex.h
+++ b/modules/libcom/src/osi/os/vxWorks/osdMutex.h
@@ -13,13 +13,3 @@
 
 #include <vxWorks.h>
 #include <semLib.h>
-
-/* If the macro is replaced by inline it is necessary to say
-   static __inline__
-   but then a warning message appears everywhere osdMutex.h is included
-*/
-
-#define epicsMutexOsdUnlock(ID) semGive((SEM_ID)(ID))
-
-#define epicsMutexOsdLock(ID) \
-(semTake((SEM_ID)(ID),WAIT_FOREVER)==OK ? epicsMutexLockOK : epicsMutexLockError)


### PR DESCRIPTION
I see this mainly a "cleanup" change.  Although it does:

* Remove the (semi)public `epicsMutexOsd*()` functions.

My github/google searches do not turn up any external usage.

If there is significant concern, I could re-add these as wrappers around regular `epicsMutedId`, with some obnoxious deprecation warnings.

* Remove the free list in epicsMutex.cpp.

I don't think this special case free-list has much value for Linux, OSX, or Windows.  I could be persuaded to keep it for the RTOSs specifically.

* Eliminates the separate `epicsMutexOSD` struct.

Avoids allocation of a second struct on posix and windows.

* Consolidate OSD in private `epicsMutexImpl.h`.

Yes, I could have added 5 OSD headers instead of the `#ifdef`, but I don't think all of the extra boilerplate would clarify the situation.

* WIN32: eliminate pre-XP code

The current `_WIN32_WINNT < 0x0501` condition already prevents anyone from building with older windows.

* RTEMS-score: eliminate unused non-fast code.

Now that our use of RTEMS/score is solidly legacy, I don't think there is any benefit to preserving the untested non-fast version.  I didn't check if this "alternative" works currently.

* Eliminate unused `LOG_LAST_OWNER`.

Again, I didn't test to see if it works.

* vxworks...

untested.