### PR TITLE
iocsh: keep history file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ O.*/
 *.log
 .*.swp
 .DS_Store
+.iocsh_history

--- a/src/template/base/top/.gitignore
+++ b/src/template/base/top/.gitignore
@@ -17,6 +17,9 @@
 /iocBoot/*ioc*/envPaths
 /iocBoot/*ioc*/relPaths.sh
 
+# iocsh
+.iocsh_history
+
 # Build directories
 O.*/
 

--- a/src/template/ext/top/.gitignore
+++ b/src/template/ext/top/.gitignore
@@ -8,6 +8,9 @@
 # Local configuration files
 /configure/*.local
 
+# iocsh
+.iocsh_history
+
 # Build directories
 O.*/
 


### PR DESCRIPTION
It turns out to be easy to have readline read/write a command history file like eg. `~/.bash_history`.

What should the default history file name be?

I have initially picked a default of `.iocsh_history` (aka in the current directory) as I think a per-IOC history makes the most sense.

This default can be overridden by setting `$HISTFILE` (like bash and others).