### PR TITLE
Split up dbcar so that it can use a callback function

### DIFF
--- a/modules/database/src/ioc/db/dbCaTest.h
+++ b/modules/database/src/ioc/db/dbCaTest.h
@@ -12,12 +12,15 @@
 #define INC_dbCaTest_H
 
 #include "dbCoreAPI.h"
+#include "dbCommon.h"
+#include "dbStaticLib.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-DBCORE_API long dbcar(char *recordname,int level);
+DBCORE_API long process_ca_record_links(DBENTRY *pdbentry, void *pvt, long (*callback)(dbCommon *, dbFldDes *, DBLINK *, void *));
+DBCORE_API long dbcar(char *recordname, int level);
 DBCORE_API void dbcaStats(int *pchans, int *pdiscon);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This should have no functional changes, but it allows other utilities to read CA link data from an IOC. For example, recsync could export the CA links for given records which could be useful.