### PR TITLE
DB parser hint for unknown field name

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -637,7 +637,7 @@ void dbFinishEntry(DBENTRY *pdbentry)
     }
 }
 
-DBENTRY * dbCopyEntry(DBENTRY *pdbentry)
+DBENTRY * dbCopyEntry(const DBENTRY *pdbentry)
 {
     DBENTRY *pnew;
 
@@ -647,7 +647,7 @@ DBENTRY * dbCopyEntry(DBENTRY *pdbentry)
     return(pnew);
 }
 
-void dbCopyEntryContents(DBENTRY *pfrom,DBENTRY *pto)
+void dbCopyEntryContents(const DBENTRY *pfrom,DBENTRY *pto)
 {
     *pto = *pfrom;
     pto->message = NULL;

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.h
@@ -51,9 +51,9 @@ DBCORE_API void dbInitEntry(DBBASE *pdbbase,
     DBENTRY *pdbentry);
 
 DBCORE_API void dbFinishEntry(DBENTRY *pdbentry);
-DBCORE_API DBENTRY * dbCopyEntry(DBENTRY *pdbentry);
-DBCORE_API void dbCopyEntryContents(DBENTRY *pfrom,
-    DBENTRY *pto);
+DBCORE_API DBENTRY * dbCopyEntry(const DBENTRY *pdbentry);
+DBCORE_API void dbCopyEntryContents(const DBENTRY *pfrom,
+                                    DBENTRY *pto);
 
 DBCORE_API extern int dbBptNotMonotonic;
 


### PR DESCRIPTION
Adds a "did you mean" hint when an unknown field name is encountered.  Prints the name and prompt string of the best match.

```
$ softIoc -d badfield.db 
Error: Failed to load: badfield.db
ai Record "foo" does not have a field "DYTP"
    Did you mean "DTYP"?  (Device Type)
Error at or before ')' in path "."  file "badfield.db" line 2
dbLoadRecords: failed to load 'badfield.db'
```