### PR TITLE
Colorize stderr

### DIFF
--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -549,7 +549,7 @@ void epicsStdCall caRepeaterRegistrationMessage (
             char sockErrBuf[64];
             epicsSocketConvertErrnoToString (
                 sockErrBuf, sizeof ( sockErrBuf ) );
-            fprintf ( stderr, "error sending registration message to CA repeater daemon was \"%s\"\n",
+            fprintf ( stderr, ERL_ERROR " sending registration message to CA repeater daemon was \"%s\"\n",
                 sockErrBuf );
         }
     }
@@ -813,13 +813,13 @@ bool udpiiu::exceptionRespAction (
 
     if ( msg.m_postsize > sizeof ( caHdr ) ){
         errlogPrintf (
-            "error condition \"%s\" detected by %s with context \"%s\" at %s\n",
+            ERL_ERROR " condition \"%s\" detected by %s with context \"%s\" at %s\n",
             ca_message ( msg.m_available ),
             name, reinterpret_cast <const char *> ( &reqMsg + 1 ), date );
     }
     else{
         errlogPrintf (
-            "error condition \"%s\" detected by %s at %s\n",
+            ERL_ERROR " condition \"%s\" detected by %s at %s\n",
             ca_message ( msg.m_available ), name, date );
     }
 

--- a/modules/ca/src/tools/caput.c
+++ b/modules/ca/src/tools/caput.c
@@ -35,6 +35,7 @@
 #include <epicsStdlib.h>
 
 #include <cadef.h>
+#include <errlog.h>
 #include <epicsGetopt.h>
 #include <epicsEvent.h>
 #include <epicsString.h>
@@ -549,7 +550,7 @@ int main (int argc, char *argv[])
         result = ca_array_put (dbrType, count, pvs[0].chid, pbuf);
     }
     if (result != ECA_NORMAL) {
-        fprintf(stderr, "Error from put operation: %s\n", ca_message(result));
+        fprintf(stderr, ERL_ERROR " from put operation: %s\n", ca_message(result));
         free(sbuf); free(dbuf); free(ebuf);
         return 1;
     }
@@ -570,7 +571,7 @@ int main (int argc, char *argv[])
     }
 
     if (result != ECA_NORMAL) {
-        fprintf(stderr, "Error occured writing data: %s\n", ca_message(result));
+        fprintf(stderr, ERL_ERROR " occured writing data: %s\n", ca_message(result));
         free(sbuf); free(dbuf); free(ebuf);
         return 1;
     }

--- a/modules/database/src/ioc/bpt/makeBpt.c
+++ b/modules/database/src/ioc/bpt/makeBpt.c
@@ -21,6 +21,7 @@
 #include <ctype.h>
 
 #include "dbDefs.h"
+#include "errlog.h"
 #include "ellLib.h"
 #include "cvtTable.h"
 
@@ -125,12 +126,12 @@ int main(int argc, char **argv)
     }
     inFile = fopen(argv[1],"r");
     if(!inFile) {
-        fprintf(stderr,"Error opening %s\n",argv[1]);
+        fprintf(stderr,ERL_ERROR " opening %s\n",argv[1]);
         exit(-1);
     }
     outFile = fopen(outFilename,"w");
     if(!outFile) {
-        fprintf(stderr,"Error opening %s\n",outFilename);
+        fprintf(stderr,ERL_ERROR " opening %s\n",outFilename);
         exit(-1);
     }
     while(fgets(inbuf,MAX_LINE_SIZE,inFile)) {

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1068,7 +1068,7 @@ int dbRecordNameValidate(const char *name)
     const char *pos = name;
 
     if (!*name) {
-        yyerrorAbort("Error: Record/Alias name can't be empty");
+        yyerrorAbort(ERL_ERROR ": Record/Alias name can't be empty");
         return 1;
     }
 

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1086,7 +1086,7 @@ int dbRecordNameValidate(const char *name)
                          name, c);
 
         } else if(c==' ' || c=='\t' || c=='"' || c=='\'' || c=='.' || c=='$') {
-            epicsPrintf("Error: Bad character '%c' in Record/Alias name \"%s\"\n",
+            epicsPrintf(ERL_ERROR ": Bad character '%c' in Record/Alias name \"%s\"\n",
                 c, name);
             yyerrorAbort(NULL);
             return 1;

--- a/modules/database/src/ioc/dbStatic/dbStaticIocRegister.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticIocRegister.c
@@ -10,6 +10,7 @@
 
 #include "iocsh.h"
 #include "errSymTbl.h"
+#include "errlog.h"
 
 #include "dbStaticIocRegister.h"
 #include "dbStaticLib.h"
@@ -254,7 +255,7 @@ static void dbCreateAliasCallFunc(const iocshArgBuf *args)
     }
     dbFinishEntry(&ent);
     if(status) {
-        fprintf(stderr, "Error: %ld %s\n", status, errSymMsg(status));
+        fprintf(stderr, ERL_ERROR ": %ld %s\n", status, errSymMsg(status));
         iocshSetError(1);
     }
 }

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -89,7 +89,7 @@ static FILE *openOutstream(const char *filename)
     errno = 0;
     stream = fopen(filename,"w");
     if(!stream) {
-        fprintf(stderr,"error opening %s %s\n",filename,strerror(errno));
+        fprintf(stderr,ERL_ERROR " opening %s %s\n",filename,strerror(errno));
         return 0;
     }
     return stream;

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -2204,11 +2204,11 @@ long dbInitRecordLinks(dbRecordType *rtyp, struct dbCommon *prec)
              */
 
         } else if(dbCanSetLink(plink, &link_info, devsup)!=0) {
-            errlogPrintf("Error: %s.%s: can't initialize link type %d with \"%s\" (type %d)\n",
+            errlogPrintf(ERL_ERROR ": %s.%s: can't initialize link type %d with \"%s\" (type %d)\n",
                          prec->name, pflddes->name, plink->type, plink->text, link_info.ltype);
 
         } else if(dbSetLink(plink, &link_info, devsup)) {
-            errlogPrintf("Error: %s.%s: failed to initialize link type %d with \"%s\" (type %d)\n",
+            errlogPrintf(ERL_ERROR ": %s.%s: failed to initialize link type %d with \"%s\" (type %d)\n",
                          prec->name, pflddes->name, plink->type, plink->text, link_info.ltype);
         }
         free(plink->text);

--- a/modules/database/src/ioc/dbStatic/dbStaticRun.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticRun.c
@@ -143,7 +143,7 @@ long dbAllocRecord(DBENTRY *pdbentry,const char *precordName)
 
                 status = dbPutStringNum(pdbentry,pflddes->initial);
                 if(status)
-                    epicsPrintf("Error initializing %s.%s initial %s\n",
+                    epicsPrintf(ERL_ERROR " initializing %s.%s initial %s\n",
                                 pdbRecordType->name,pflddes->name,pflddes->initial);
             }
             break;

--- a/modules/database/src/ioc/dbStatic/dbYacc.y
+++ b/modules/database/src/ioc/dbStatic/dbYacc.y
@@ -370,9 +370,9 @@ json_value: jsonNULL    { $$ = dbmfStrdup("null"); }
 static int yyerror(char *str)
 {
     if (str)
-        epicsPrintf("Error: %s\n", str);
+        epicsPrintf(ERL_ERROR ": %s\n", str);
     else
-        epicsPrintf("Error");
+        epicsPrintf(ERL_ERROR "");
     if (!yyFailed) {    /* Only print this stuff once */
         epicsPrintf(" at or before '%s'", yytext);
         dbIncludePrint();

--- a/modules/database/src/ioc/dbtemplate/dbLoadTemplate.y
+++ b/modules/database/src/ioc/dbtemplate/dbLoadTemplate.y
@@ -16,6 +16,7 @@
 #include "osiUnistd.h"
 #include "macLib.h"
 #include "dbmf.h"
+#include "errlog.h"
 
 #include "epicsExport.h"
 #include "dbAccess.h"
@@ -337,7 +338,7 @@ int dbLoadTemplate(const char *sub_file, const char *cmd_collect)
 
     if (dbTemplateMaxVars < 1)
     {
-        fprintf(stderr,"Error: dbTemplateMaxVars = %d, must be +ve\n",
+        fprintf(stderr,ERL_ERROR ": dbTemplateMaxVars = %d, must be +ve\n",
                 dbTemplateMaxVars);
         return -1;
     }

--- a/modules/database/src/ioc/dbtemplate/msi.cpp
+++ b/modules/database/src/ioc/dbtemplate/msi.cpp
@@ -264,7 +264,7 @@ static void addMacroReplacements(MAC_HANDLE * const macPvt,
     if (status) {
         status = macInstallMacros(macPvt, pairs);
         if (!status) {
-            fprintf(stderr, "Error from macInstallMacros\n");
+            fprintf(stderr, ERL_ERROR " from macInstallMacros\n");
             usageExit(1);
         }
         free(pairs);

--- a/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
+++ b/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
@@ -17,6 +17,7 @@
 
 #include <epicsStdio.h>
 #include <epicsFindSymbol.h>
+#include <errlog.h>
 #include <registryRecordType.h>
 #include <registryDeviceSupport.h>
 #include <registryDriverSupport.h>
@@ -248,7 +249,7 @@ registerAllRecordDeviceDrivers(DBBASE *pdbbase)
 
     } catch(std::exception& e) {
         dbFinishEntry(&entry);
-        fprintf(stderr, "Error: %s\n", e.what());
+        fprintf(stderr, ERL_ERROR ": %s\n", e.what());
         return 2;
     }
 }

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -666,7 +666,7 @@ static void setlogmaskCallFunc(const iocshArgBuf *args)
 #endif
             return;
         }
-        printf("Error: unknown log level.\n");
+        printf(ERL_ERROR ": unknown log level.\n");
     }
 }
 static const iocshArg setlogmaskArg0 = {"level name", iocshArgString};

--- a/modules/libcom/src/as/asLib.y
+++ b/modules/libcom/src/as/asLib.y
@@ -209,7 +209,7 @@ static int yyerror(char *str)
     if (strlen(str))
         errlogPrintf("%s at line %d\n", str, line_num);
     else
-        errlogPrintf("Error at line %d\n", line_num);
+        errlogPrintf(ERL_ERROR " at line %d\n", line_num);
     yyFailed = TRUE;
     return 0;
 }

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -639,7 +639,7 @@ struct ReadlineContext {
             if(!hist_file.empty()) {
                 if(int err = read_history(hist_file.c_str())) {
                     if(err!=ENOENT)
-                        fprintf(stderr, "Error %s (%d) loading '%s'\n",
+                        fprintf(stderr, ERL_ERROR " %s (%d) loading '%s'\n",
                                 strerror(err), err, hist_file.c_str());
                 }
                 stifle_history(1024); // some limit...
@@ -654,7 +654,7 @@ struct ReadlineContext {
 #ifdef USE_READLINE
             if(!hist_file.empty()) {
                 if(int err = write_history(hist_file.c_str())) {
-                    fprintf(stderr, "Error %s (%d) writing '%s'\n",
+                    fprintf(stderr, ERL_ERROR " %s (%d) writing '%s'\n",
                             strerror(err), err, hist_file.c_str());
                 }
             }

--- a/modules/libcom/src/pool/threadPool.c
+++ b/modules/libcom/src/pool/threadPool.c
@@ -42,7 +42,7 @@ epicsThreadPool* epicsThreadPoolCreate(epicsThreadPoolConfig *opts)
 
     /* caller likely didn't initialize the options structure */
     if (opts && opts->maxThreads == 0) {
-        errlogMessage("Error: epicsThreadPoolCreate() options provided, but not initialized");
+        errlogMessage(ERL_ERROR ": epicsThreadPoolCreate() options provided, but not initialized");
         return NULL;
     }
 
@@ -78,7 +78,7 @@ epicsThreadPool* epicsThreadPoolCreate(epicsThreadPoolConfig *opts)
 
     if (pool->threadsRunning == 0 && pool->conf.initialThreads != 0) {
         epicsMutexUnlock(pool->guard);
-        errlogPrintf("Error: Unable to create any threads for thread pool\n");
+        errlogPrintf(ERL_ERROR ": Unable to create any threads for thread pool\n");
         goto cleanup;
 
     }


### PR DESCRIPTION
So far we have only included ANSI escape sequences through errlog, where they are filtered out when not supported.  This PR adds colorized errors to many `fprintf(stderr, ...`, where they would not be filtered out.

I think the benefit of colorized errors in eg. db file parse errors is obvious to anyone who has failed to notice such an error in the middle of the output of a long `st.cmd`.

Of course unconditionally printing ANSI escapes may annoy someone who is collecting stderr for viewing with a program which does not know about escapes.

I can think of several ways to avoid this, however these would introduce additional complexity and/or failure modes which I don't like.  eg. `epicsSnprintf()` into an allocated temporary buffer.

Some arguments in favor...

We could allow escapes in stderr, but not stdout.  imo. stdout is more likely to be redirected and consumed programmatically than stderr.

Captured stderr logs would be improved if also passed through tools which convert eg. [escapes to html](https://pypi.org/project/ansi2html/) tags.

So, would the extra overhead of striping escapes be worthwhile?