### PR TITLE
Allow auto-declarations for dbdExpand.pl

### DIFF
--- a/modules/database/src/tools/dbdExpand.pl
+++ b/modules/database/src/tools/dbdExpand.pl
@@ -20,10 +20,14 @@ use EPICS::Getopts;
 use EPICS::Readfile;
 use EPICS::macLib;
 
-our ($opt_D, @opt_I, @opt_S, $opt_o);
+our ($opt_D, $opt_A, @opt_I, @opt_S, $opt_o);
 
-getopts('DI@S@o:') or
-    die "Usage: dbdExpand [-D] [-I dir] [-S macro=val] [-o out.dbd] in.dbd ...";
+getopts('DAI@S@o:') or
+    die "Usage: dbdExpand [-D] [-A] [-I dir] [-S macro=val] [-o out.dbd] in.dbd ...";
+
+if ($opt_A) {
+    $DBD::Parser::allowAutoDeclarations = 1;
+}
 
 my @path = map { split /[:;]/ } @opt_I; # FIXME: Broken on Win32?
 my $macros = EPICS::macLib->new(@opt_S);


### PR DESCRIPTION
At ESS we have a custom script (inherited from PSI) to combine .dbd files. The only thing that blocks us from using dbdExpand.pl from EPICS base is the fact that in its current setup, dbdExpand.pl gives errors such as
```
dbdExpand.pl: Device 'asynOctetCmdResponse' refers to unknown record type 'stringin'.
        DBD files must be combined in the correct order.
```
For us at ESS this isn't an issue since all of our IOCs use softIocPVA.dbd in combination with other .dbd files, which would thus be nice to have the option to either remove this error (as this PR does) or to reduce it to a warning.