### PR TITLE
Don't include linux/ header in osdSockUnsentCount.

### DIFF
--- a/modules/libcom/src/osi/os/Linux/osdSockUnsentCount.c
+++ b/modules/libcom/src/osi/os/Linux/osdSockUnsentCount.c
@@ -4,7 +4,6 @@
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 
-#include <linux/sockios.h>
 #define EPICS_PRIVATE_API
 #include "osiSock.h"
 
@@ -14,7 +13,7 @@
  */
 int epicsSocketUnsentCount(SOCKET sock) {
     int unsent;
-    if (ioctl(sock, SIOCOUTQ, &unsent) == 0)
+    if (ioctl(sock, TIOCOUTQ, &unsent) == 0)
         return unsent;
     return -1;
 }


### PR DESCRIPTION
Per the manpage in the file's comment, SIOCOUTQ is equivalent to the TIOCOUTQ ioctl, whose value can be obtained by including <sys/ioctl.h>, which allows us to avoid including system-specific headers.

---

The `epicsSocketUnsentCount` function seems to only be used in logClient code (at least as far as epics-base goes). Is it critical that a working version be defined for as many platforms as possible?

I'm asking because, while investigating this ioctl, I came across the `FIONWRITE` one from the BSDs, which seems to be supported at least by [FreeBSD](https://man.freebsd.org/cgi/man.cgi?query=ioctl&apropos=0&sektion=0&manpath=FreeBSD+14.0-RELEASE+and+Ports&arch=default&format=html), [NetBSD](https://man.netbsd.org/ioctl.2) and [vxWorks](https://www.ecb.torontomu.ca/~courses/ee8205/Data-Sheets/Tornado-VxWorks/vxworks/ref/tyLib.html), which might have made it a candidate for the `posix` implementation? (I don't fully understand EPICS's policy for the osi code). However, [zOS](https://www.ibm.com/docs/en/zos/3.1.0?topic=functions-ioctl-control-device), for example, has a different meaning for it.