### PR TITLE
change PROC to ASL0

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -22,6 +22,12 @@ should also be read to understand what has changed since earlier releases:
 
 ## Changes made on the 7.0 branch since 7.0.7
 
+### PROC field changed to ASL0
+
+The PROC field has been changed from access security level ASL1 to ASL0.
+This allows users to trigger processing a record without having the rights
+to reconfigure the records.
+
 ### bi "Raw Soft Channel" use MASK
 
 If MASK is non-zero, The raw device support will now apply MASK to the

--- a/modules/database/src/ioc/db/dbCommon.dbd.pod
+++ b/modules/database/src/ioc/db/dbCommon.dbd.pod
@@ -240,6 +240,7 @@ The B<SPVT> field is for internal use by the scanning system.
 	}
 	field(PROC,DBF_UCHAR) {
 		prompt("Force Processing")
+		asl(ASL0)
 		pp(TRUE)
 		interest(3)
 	}


### PR DESCRIPTION
The `PROC` field is a "user" field like `VAL`, not a "configuration" field like `DRVH`.
But since the `PROC` field has the default `ASG1`, a Channel Access who wants to process the record via `PROC` field needs configuration rights.
This PR changes the `PROC` to `ASG0`, the same as `VAL` typically has. This allows a user with only write access but without configuration access to process the record.