### PR TITLE
Print link types as text instead of numbers

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -2206,12 +2206,12 @@ long dbInitRecordLinks(dbRecordType *rtyp, struct dbCommon *prec)
              */
 
         } else if(dbCanSetLink(plink, &link_info, devsup)!=0) {
-            errlogPrintf(ERL_ERROR ": %s.%s: can't initialize link type %d with \"%s\" (type %d)\n",
-                         prec->name, pflddes->name, plink->type, plink->text, link_info.ltype);
+            errlogPrintf(ERL_ERROR ": %s.%s: can't initialize link type %s with \"%s\" (type %s)\n",
+                         prec->name, pflddes->name, pamaplinkType[plink->type].strvalue, plink->text, pamaplinkType[link_info.ltype].strvalue);
 
         } else if(dbSetLink(plink, &link_info, devsup)) {
-            errlogPrintf(ERL_ERROR ": %s.%s: failed to initialize link type %d with \"%s\" (type %d)\n",
-                         prec->name, pflddes->name, plink->type, plink->text, link_info.ltype);
+            errlogPrintf(ERL_ERROR ": %s.%s: failed to initialize link type %s with \"%s\" (type %s)\n",
+                         prec->name, pflddes->name, pamaplinkType[plink->type].strvalue, plink->text, pamaplinkType[link_info.ltype].strvalue);
         }
         free(plink->text);
         plink->text = NULL;


### PR DESCRIPTION
Improve error message when using wrong link format.
Old: `ERROR: RECORD.INP: can't initialize link type 12 with "#C1 S2@SOME_TEXT" (type 2)`
New: `ERROR: RECORD.INP: can't initialize link type INST_IO with "#C1 S2@SOME_TEXT" (type VME_IO)`
