### PR TITLE
Add newline to help text

### DIFF
--- a/modules/database/src/ioc/as/asIocRegister.c
+++ b/modules/database/src/ioc/as/asIocRegister.c
@@ -90,7 +90,7 @@ static const iocshFuncDef asprulesFuncDef = {
     "asprules",1,asprulesArgs,
     "List rules of an Access Security Group.\n"
     "If no Group is speciﬁed then list the rules for all groups\n"
-    "Example: asprules mygroup"
+    "Example: asprules mygroup\n"
 };
 static void asprulesCallFunc(const iocshArgBuf *args)
 {

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -193,7 +193,7 @@ static const iocshFuncDef epicsEnvShowFuncDef = {"epicsEnvShow",1,epicsEnvShowAr
                                                  "  (default) - show all environment variables\n"
                                                  "   name     - show value of specific environment variable\n"
                                                  "Example: epicsEnvShow\n"
-                                                 "Example: epicsEnvShow PATH"};
+                                                 "Example: epicsEnvShow PATH\n"};
 static void epicsEnvShowCallFunc(const iocshArgBuf *args)
 {
     epicsEnvShow (args[0].sval);


### PR DESCRIPTION
Extremely minor fix. Noticed that `help a*` had a broken newline between this command and the next.