### PR TITLE
db: lock record for db_create_read_log() and dbChannelGetField()

### DIFF
--- a/modules/database/src/ioc/db/dbChannel.h
+++ b/modules/database/src/ioc/db/dbChannel.h
@@ -511,6 +511,10 @@ DBCORE_API long dbChannelGet(dbChannel *chan, short type,
  * \param[in,out] nRequest Pointer to the element count.
  * \param[in] pfl Pointer to a db_field_log or NULL.
  * \returns 0, or an error status value.
+ *
+ * \since UNRELEASED If pfl is NULL and chan has filters, db_create_read_log() will be called
+ *        internally to create a temporary db_field_log which is passed to dbChannelGet()
+ *        then deallocated.
  */
 DBCORE_API long dbChannelGetField(dbChannel *chan, short type,
         void *pbuffer, long *options, long *nRequest, void *pfl);

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -493,7 +493,6 @@ static void read_reply ( void *pArg, struct dbChannel *dbch,
     const int readAccess = asCheckGet ( pciu->asClientPVT );
     int status;
     int autosize;
-    int local_fl = 0;
     long item_count;
     ca_uint32_t payload_size;
     dbAddr *paddr=&dbch->addr;
@@ -535,20 +534,8 @@ static void read_reply ( void *pArg, struct dbChannel *dbch,
         return;
     }
 
-    /* If filters are involved in a read, create field log and run filters */
-    if (!pfl && (ellCount(&dbch->pre_chain) || ellCount(&dbch->post_chain))) {
-        pfl = db_create_read_log(dbch);
-        if (pfl) {
-            local_fl = 1;
-            pfl = dbChannelRunPreChain(dbch, pfl);
-            pfl = dbChannelRunPostChain(dbch, pfl);
-        }
-    }
-
     status = dbChannel_get_count ( dbch, pevext->msg.m_dataType,
                   pPayload, &item_count, pfl);
-
-    if (local_fl) db_delete_field_log(pfl);
 
     if ( status < 0 ) {
         /* Clients recv the status of the operation directly to the
@@ -616,7 +603,6 @@ static int read_action ( caHdrLargeArray *mp, void *pPayloadIn, struct client *p
     ca_uint32_t payloadSize;
     void *pPayload;
     int status;
-    int local_fl = 0;
     db_field_log *pfl = NULL;
 
     if ( ! pciu ) {
@@ -655,20 +641,8 @@ static int read_action ( caHdrLargeArray *mp, void *pPayloadIn, struct client *p
         return RSRV_OK;
     }
 
-    /* If filters are involved in a read, create field log and run filters */
-    if (ellCount(&pciu->dbch->pre_chain) || ellCount(&pciu->dbch->post_chain)) {
-        pfl = db_create_read_log(pciu->dbch);
-        if (pfl) {
-            local_fl = 1;
-            pfl = dbChannelRunPreChain(pciu->dbch, pfl);
-            pfl = dbChannelRunPostChain(pciu->dbch, pfl);
-        }
-    }
-
     status = dbChannel_get ( pciu->dbch, mp->m_dataType,
                   pPayload, mp->m_count, pfl );
-
-    if (local_fl) db_delete_field_log(pfl);
 
     if ( status < 0 ) {
         send_err ( mp, ECA_GETFAIL, pClient, RECORD_NAME ( pciu->dbch ) );

--- a/modules/database/test/ioc/db/dbChArrTest.cpp
+++ b/modules/database/test/ioc/db/dbChArrTest.cpp
@@ -130,9 +130,11 @@ static void check(short dbr_type) {
     off = Offset; req = 10; \
     memset(buf, 0, sizeof(buf)); \
     (void) dbPutField(&offaddr, DBR_LONG, &off, 1); \
+    dbScanLock(dbChannelRecord(pch)); \
     pfl = db_create_read_log(pch); \
     testOk(pfl && pfl->type == dbfl_type_ref, "Valid pfl, type = ref"); \
-    testOk(!dbChannelGetField(pch, DBR_LONG, buf, NULL, &req, pfl), "Got Field value"); \
+    testOk(!dbChannelGet(pch, DBR_LONG, buf, NULL, &req, pfl), "Got Field value"); \
+    dbScanUnlock(dbChannelRecord(pch)); \
     testOk(req == Size, "Got %ld elements (expected %d)", req, Size); \
     if (!testOk(!memcmp(buf, Expected, sizeof(Expected)), "Data correct")) \
         for (i=0; i<Size; i++) \
@@ -174,6 +176,7 @@ static void check(short dbr_type) {
     off = Offset; req = 15; \
     memset(buf, 0, sizeof(buf)); \
     (void) dbPutField(&offaddr, DBR_LONG, &off, 1); \
+    dbScanLock(dbChannelRecord(pch)); \
     pfl = db_create_read_log(pch); \
     pfl->type = dbfl_type_ref; \
     pfl->field_type = DBF_CHAR; \
@@ -181,7 +184,8 @@ static void check(short dbr_type) {
     pfl->no_elements = 26; \
     pfl->dtor = freeArray; \
     pfl->u.r.field = epicsStrDup("abcdefghijklmnopqrsstuvwxyz"); \
-    testOk(!dbChannelGetField(pch, DBR_LONG, buf, NULL, &req, pfl), "Got Field value"); \
+    testOk(!dbChannelGet(pch, DBR_LONG, buf, NULL, &req, pfl), "Got Field value"); \
+    dbScanUnlock(dbChannelRecord(pch)); \
     testOk(req == Size, "Got %ld elements (expected %d)", req, Size); \
     if (!testOk(!memcmp(buf, Expected, sizeof(Expected)), "Data correct")) \
         for (i=0; i<Size; i++) \


### PR DESCRIPTION
Resolve a data race of time/alarm meta-data during CA GET with server side filter.

Since 27fe3e4468ec62d4d17f775c4aced939a666ba36 db_create_read_log() accesses record fields, so callers must hold the record lock.  However, it is impossible for callers of `dbGetField()` to do so atomically.  So change `dbGetField()` and `dbChannel_get_count()` to create a local `db_field_log*` when useful.