### PR TITLE
Add typing to dbEvent.h opaque structs when -DUSE_TYPED_DBEVENT

### DIFF
--- a/modules/database/src/ioc/db/dbChannelIO.cpp
+++ b/modules/database/src/ioc/db/dbChannelIO.cpp
@@ -14,6 +14,8 @@
  *  505 665 1831
  */
 
+#define USE_TYPED_DBEVENT
+
 #include <string>
 #include <stdexcept>
 

--- a/modules/database/src/ioc/db/dbContext.cpp
+++ b/modules/database/src/ioc/db/dbContext.cpp
@@ -13,6 +13,8 @@
  *  505 665 1831
  */
 
+#define USE_TYPED_DBEVENT
+
 #include <limits.h>
 
 #include "epicsMutex.h"

--- a/modules/database/src/ioc/db/dbContextReadNotifyCache.cpp
+++ b/modules/database/src/ioc/db/dbContextReadNotifyCache.cpp
@@ -12,6 +12,8 @@
  * Author Jeff Hill
  */
 
+#define USE_TYPED_DBEVENT
+
 #include <stdlib.h>
 
 #include "epicsMutex.h"

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -19,6 +19,8 @@
  */
 
 #define EPICS_PRIVATE_API
+#define USE_TYPED_DBEVENT
+
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/modules/database/src/ioc/db/dbEvent.h
+++ b/modules/database/src/ioc/db/dbEvent.h
@@ -32,14 +32,21 @@ struct dbChannel;
 struct db_field_log;
 struct evSubscrip;
 
+#ifdef USE_TYPED_DBEVENT
+struct dbEventContext; // use dbEventCtx
+typedef struct evSubscrip* dbEventSubscription;
+typedef struct dbEventContext* dbEventCtx;
+#else
+typedef void * dbEventSubscription;
+typedef void * dbEventCtx;
+#endif
+
 DBCORE_API int db_event_list (
     const char *name, unsigned level);
 DBCORE_API int dbel (
     const char *name, unsigned level);
 DBCORE_API int db_post_events (
     void *pRecord, void *pField, unsigned caEventMask );
-
-typedef void * dbEventCtx;
 
 typedef void EXTRALABORFUNC (void *extralabor_arg);
 DBCORE_API dbEventCtx db_init_events (void);
@@ -63,7 +70,6 @@ DBCORE_API void db_init_event_freelists (void);
 typedef void EVENTFUNC (void *user_arg, struct dbChannel *chan,
     int eventsRemaining, struct db_field_log *pfl);
 
-typedef void * dbEventSubscription;
 DBCORE_API dbEventSubscription db_add_event (
     dbEventCtx ctx, struct dbChannel *chan,
     EVENTFUNC *user_sub, void *user_arg, unsigned select);

--- a/modules/database/src/ioc/db/dbPutNotifyBlocker.cpp
+++ b/modules/database/src/ioc/db/dbPutNotifyBlocker.cpp
@@ -15,6 +15,8 @@
  *  505 665 1831
  */
 
+#define USE_TYPED_DBEVENT
+
 #include <string>
 #include <stdexcept>
 

--- a/modules/database/src/ioc/db/dbSubscriptionIO.cpp
+++ b/modules/database/src/ioc/db/dbSubscriptionIO.cpp
@@ -14,6 +14,8 @@
  *  505 665 1831
  */
 
+#define USE_TYPED_DBEVENT
+
 #include <string>
 #include <stdexcept>
 

--- a/modules/database/src/ioc/db/dbUnitTest.c
+++ b/modules/database/src/ioc/db/dbUnitTest.c
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #define EPICS_PRIVATE_API
+#define USE_TYPED_DBEVENT
 
 #include "dbmf.h"
 #include "epicsUnitTest.h"


### PR DESCRIPTION
dbEvent.h avoid typedefs of `void*`.  Since this would be an incompatible API change, follow the pattern of device and driver support APIs with an opt-in macro `USE_TYPED_DBEVENT`.

This PR updates internal usages except `caservertask.c`, which is left as-is to "prove" backwards compatibility.

As an example of why this change could otherwise be backwards incompatible.  In PVXS I had to change:

```c++
std::shared_ptr<void> S(db_add_event(...));
// to
std::shared_ptr<std::remove_pointer<dbEventSubscription>::type> S(db_add_event(...));
```
