### PR TITLE
Fix Clang-15 warnings

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -237,10 +237,10 @@ jobs:
       matrix:
         # Job names also name artifacts, character limitations apply
         include:
-          - name: "CentOS-7"
-            image: centos:7
-            cmp: gcc
-            configuration: default
+          #- name: "CentOS-7"
+          #  image: centos:7
+          #  cmp: gcc
+          #  configuration: default
 
           - name: "Fedora-33"
             image: fedora:33

--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -118,7 +118,6 @@ EXPAND_VARS = INSTALL_BIN=$(FINAL_LOCATION)/bin/$(T_A)
 SRC_DIRS += $(CURDIR)/test
 PROD_HOST += ca_test
 ca_test_SRCS = ca_test_main.c ca_test.c
-ca_test_LIBS  = ca Com
 ca_test_SYS_LIBS_WIN32 = ws2_32 advapi32 user32
 
 OBJS_vxWorks += ca_test

--- a/modules/database/src/ioc/as/Makefile
+++ b/modules/database/src/ioc/as/Makefile
@@ -23,4 +23,4 @@ dbCore_SRCS += asIocRegister.c
 
 PROD_HOST += ascheck
 ascheck_SRCS = ascheck.c
-ascheck_LIBS = dbCore ca Com
+ascheck_LIBS = dbCore ca

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -112,7 +112,7 @@ void dbSpcAsRegisterCallback(SPC_ASCALLBACK func)
 
 long dbPutSpecial(DBADDR *paddr,int pass)
 {
-    long int    (*pspecial)()=NULL;
+    long int    (*pspecial)(struct dbAddr *, int)=NULL;
     rset        *prset;
     dbCommon    *precord = paddr->precord;
     long        status=0;

--- a/modules/database/src/ioc/db/dbConvertFast.h
+++ b/modules/database/src/ioc/db/dbConvertFast.h
@@ -14,13 +14,16 @@
 
 #include "dbFldTypes.h"
 #include "dbCoreAPI.h"
+#include "link.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-DBCORE_API extern long (*dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1])();
-DBCORE_API extern long (*dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1])();
+/* typedef FASTCONVERTFUNC is now defined in link.h */
+
+DBCORE_API extern FASTCONVERTFUNC dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1];
+DBCORE_API extern FASTCONVERTFUNC dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1];
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbConvertFast.h
+++ b/modules/database/src/ioc/db/dbConvertFast.h
@@ -7,7 +7,20 @@
 * EPICS Base is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
-/* dbConvertFast.h */
+/** @file dbConvertFast.h
+ *  @brief Data conversion for scalar values
+ *
+ * The typedef FASTCONVERTFUNC is defined in link.h as:
+ * @code
+ *   long convert(const void *from, void *to, const struct dbAddr *paddr);
+ * @endcode
+ *
+ * The arrays declared here provide pointers to the fast conversion
+ * routine where the first array index is the data type for the first
+ * "from" pointer arg, and the second array index is the data type for
+ * the second "to" pointer arg. The array index values are a subset of
+ * the DBF_ enum values defined in dbFldTypes.h
+ */
 
 #ifndef INCdbConvertFasth
 #define INCdbConvertFasth
@@ -20,10 +33,12 @@
 extern "C" {
 #endif
 
-/* typedef FASTCONVERTFUNC is now defined in link.h */
-
-DBCORE_API extern FASTCONVERTFUNC dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1];
-DBCORE_API extern FASTCONVERTFUNC dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1];
+/** Function pointers for get conversions */
+DBCORE_API extern const FASTCONVERTFUNC
+    dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1];
+/** Function pointers for put conversions */
+DBCORE_API extern const FASTCONVERTFUNC
+    dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1];
 
 #ifdef __cplusplus
 }

--- a/modules/database/src/ioc/db/dbConvertJSON.c
+++ b/modules/database/src/ioc/db/dbConvertJSON.c
@@ -19,8 +19,6 @@
 #include "dbConvertFast.h"
 #include "dbConvertJSON.h"
 
-typedef long (*FASTCONVERT)();
-
 typedef struct parseContext {
     int depth;
     short dbrType;
@@ -42,7 +40,7 @@ static int dbcj_boolean(void *ctx, int val) {
 static int dbcj_integer(void *ctx, long long num) {
     parseContext *parser = (parseContext *) ctx;
     epicsInt64 val64 = num;
-    FASTCONVERT conv = dbFastPutConvertRoutine[DBF_INT64][parser->dbrType];
+    FASTCONVERTFUNC conv = dbFastPutConvertRoutine[DBF_INT64][parser->dbrType];
 
     if (parser->elems > 0) {
         conv(&val64, parser->pdest, NULL);
@@ -54,7 +52,7 @@ static int dbcj_integer(void *ctx, long long num) {
 
 static int dbcj_double(void *ctx, double num) {
     parseContext *parser = (parseContext *) ctx;
-    FASTCONVERT conv = dbFastPutConvertRoutine[DBF_DOUBLE][parser->dbrType];
+    FASTCONVERTFUNC conv = dbFastPutConvertRoutine[DBF_DOUBLE][parser->dbrType];
 
     if (parser->elems > 0) {
         conv(&num, parser->pdest, NULL);

--- a/modules/database/src/ioc/db/dbEvent.c
+++ b/modules/database/src/ioc/db/dbEvent.c
@@ -98,8 +98,8 @@ struct event_user {
     unsigned char       extra_labor;    /* if set call extra labor func */
     unsigned char       flowCtrlMode;   /* replace existing monitor */
     unsigned char       extraLaborBusy;
-    void                (*init_func)();
-    epicsThreadId       init_func_arg;
+    void                (*init_func)(void *);
+    void                *init_func_arg;
 };
 
 typedef struct {

--- a/modules/database/src/ioc/db/dbFastLinkConv.c
+++ b/modules/database/src/ioc/db/dbFastLinkConv.c
@@ -1639,7 +1639,7 @@ static long cvt_device_st(const void *f, void *t, const dbAddr *paddr)
  *  NULL implies the conversion is not supported.
  */
 
-FASTCONVERTFUNC dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1] = {
+FASTCONVERTFUNC const dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1] = {
 
  /* Convert DBF_STRING to ... */
 { cvt_st_st, cvt_st_c, cvt_st_uc, cvt_st_s, cvt_st_us, cvt_st_l, cvt_st_ul, cvt_st_q, cvt_st_uq, cvt_st_f, cvt_st_d, cvt_st_e },
@@ -1695,7 +1695,7 @@ FASTCONVERTFUNC dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1] = {
  *  NULL implies the conversion is not supported.
  */
 
-FASTCONVERTFUNC dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1] = {
+FASTCONVERTFUNC const dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1] = {
 
  /* Convert DBR_STRING to ... */
 { cvt_st_st, cvt_st_c, cvt_st_uc, cvt_st_s, cvt_st_us, cvt_st_l, cvt_st_ul, cvt_st_q, cvt_st_uq, cvt_st_f, cvt_st_d, cvt_st_e, cvt_st_menu, cvt_st_device},

--- a/modules/database/src/ioc/db/dbFastLinkConv.c
+++ b/modules/database/src/ioc/db/dbFastLinkConv.c
@@ -1399,7 +1399,7 @@ static long cvt_device_st(
  *  NULL implies the conversion is not supported.
  */
 
-long (*dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1])() = {
+FASTCONVERTFUNC dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1] = {
 
  /* Convert DBF_STRING to ... */
 { cvt_st_st, cvt_st_c, cvt_st_uc, cvt_st_s, cvt_st_us, cvt_st_l, cvt_st_ul, cvt_st_q, cvt_st_uq, cvt_st_f, cvt_st_d, cvt_st_e },
@@ -1455,7 +1455,7 @@ long (*dbFastGetConvertRoutine[DBF_DEVICE+1][DBR_ENUM+1])() = {
  *  NULL implies the conversion is not supported.
  */
 
-long (*dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1])() = {
+FASTCONVERTFUNC dbFastPutConvertRoutine[DBR_ENUM+1][DBF_DEVICE+1] = {
 
  /* Convert DBR_STRING to ... */
 { cvt_st_st, cvt_st_c, cvt_st_uc, cvt_st_s, cvt_st_us, cvt_st_l, cvt_st_ul, cvt_st_q, cvt_st_uq, cvt_st_f, cvt_st_d, cvt_st_e, cvt_st_menu, cvt_st_device},

--- a/modules/database/src/ioc/db/dbFastLinkConv.c
+++ b/modules/database/src/ioc/db/dbFastLinkConv.c
@@ -71,11 +71,10 @@
  */
 
 /* Convert String to String */
-static long cvt_st_st(
-     char *from,
-     char *to,
-     const dbAddr *paddr)
+static long cvt_st_st(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    char *to = (char *) t;
     size_t size;
 
     if (paddr && paddr->field_size < MAX_STRING_SIZE) {
@@ -89,11 +88,10 @@ static long cvt_st_st(
 }
 
 /* Convert String to Char */
-static long cvt_st_c(
-     char *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
+static long cvt_st_c(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
     char *end;
 
     if (*from == 0) {
@@ -104,11 +102,10 @@ static long cvt_st_c(
 }
 
 /* Convert String to Unsigned Char */
-static long cvt_st_uc(
-    char *from,
-    epicsUInt8 *to,
-    const dbAddr *paddr)
+static long cvt_st_uc(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
     char *end;
 
     if (*from == 0) {
@@ -119,11 +116,10 @@ static long cvt_st_uc(
 }
 
 /* Convert String to Short */
-static long cvt_st_s(
-    char *from,
-    epicsInt16 *to,
-    const dbAddr *paddr)
+static long cvt_st_s(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
     char *end;
 
     if (*from == 0) {
@@ -134,11 +130,10 @@ static long cvt_st_s(
 }
 
 /* Convert String to Unsigned Short */
-static long cvt_st_us(
-    char *from,
-    epicsUInt16 *to,
-    const dbAddr *paddr)
+static long cvt_st_us(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
     char *end;
 
     if (*from == 0) {
@@ -149,11 +144,10 @@ static long cvt_st_us(
 }
 
 /* Convert String to Long */
-static long cvt_st_l(
-    char *from,
-    epicsInt32 *to,
-    const dbAddr *paddr)
+static long cvt_st_l(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
     char *end;
 
     if (*from == 0) {
@@ -164,11 +158,10 @@ static long cvt_st_l(
 }
 
 /* Convert String to Unsigned Long */
-static long cvt_st_ul(
-     char *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
+static long cvt_st_ul(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
     char *end;
     long status;
 
@@ -195,11 +188,10 @@ static long cvt_st_ul(
 }
 
 /* Convert String to Int64 */
-static long cvt_st_q(
-    char *from,
-    epicsInt64 *to,
-    const dbAddr *paddr)
+static long cvt_st_q(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
     char *end;
 
     if (*from == 0) {
@@ -210,11 +202,10 @@ static long cvt_st_q(
 }
 
 /* Convert String to UInt64 */
-static long cvt_st_uq(
-     char *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
+static long cvt_st_uq(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
     char *end;
 
     if (*from == 0) {
@@ -225,41 +216,38 @@ static long cvt_st_uq(
 }
 
 /* Convert String to Float */
-static long cvt_st_f(
-     char *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
+static long cvt_st_f(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
     char *end;
 
-   if (*from == 0) {
-      *to = 0;
-      return 0;
-   }
-   return epicsParseFloat32(from, to, &end);
+    if (*from == 0) {
+        *to = 0;
+        return 0;
+    }
+    return epicsParseFloat32(from, to, &end);
 }
 
 /* Convert String to Double */
-static long cvt_st_d(
-     char *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
+static long cvt_st_d(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
     char *end;
 
-   if (*from == 0) {
-      *to = 0.0;
-      return 0;
-   }
-   return epicsParseFloat64(from, to, &end);
+    if (*from == 0) {
+        *to = 0.0;
+        return 0;
+    }
+    return epicsParseFloat64(from, to, &end);
 }
 
 /* Convert String to Enumerated */
-static long cvt_st_e(
-    char *from,
-    epicsEnum16 *to,
-    const dbAddr *paddr)
+static long cvt_st_e(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
     rset *prset = dbGetRset(paddr);
     long status = S_db_noRSET;
     struct dbr_enumStrs enumStrs;
@@ -294,11 +282,10 @@ static long cvt_st_e(
 }
 
 /* Convert String to Menu */
-static long cvt_st_menu(
-    char *from,
-    epicsEnum16 *to,
-    const dbAddr *paddr)
+static long cvt_st_menu(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
     dbFldDes *pdbFldDes = paddr->pfldDes;
     dbMenu *pdbMenu;
     char **pchoices;
@@ -325,15 +312,14 @@ static long cvt_st_menu(
         }
     }
     recGblDbaddrError(S_db_badChoice, paddr, "dbFastLinkConv(cvt_st_menu)");
-    return(S_db_badChoice);
+    return S_db_badChoice;
 }
 
 /* Convert String to Device */
-static long cvt_st_device(
-    char *from,
-    epicsEnum16 *to,
-    const dbAddr *paddr)
+static long cvt_st_device(const void *f, void *t, const dbAddr *paddr)
 {
+    const char *from = (const char *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
     dbFldDes *pdbFldDes = paddr->pfldDes;
     dbDeviceMenu *pdbDeviceMenu = pdbFldDes->ftPvt;
     char **pchoices, *pchoice;
@@ -363,979 +349,1234 @@ static long cvt_st_device(
 }
 
 /* Convert Char to String */
-static long cvt_c_st(
-     epicsInt8 *from,
-     char *to,
-     const dbAddr *paddr)
-{ cvtCharToString(*from, to); return(0); }
+static long cvt_c_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    char *to = (char *) t;
+    cvtCharToString(*from, to);
+    return 0;
+}
 
 /* Convert Char to Char */
-static long cvt_c_c(
-     epicsInt8 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to Unsigned Char */
-static long cvt_c_uc(
-     epicsInt8 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to Short */
-static long cvt_c_s(
-     epicsInt8 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to Unsigned Short */
-static long cvt_c_us(
-     epicsInt8 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to Long */
-static long cvt_c_l(
-     epicsInt8 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to Unsigned Long */
-static long cvt_c_ul(
-     epicsInt8 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to Int64 */
-static long cvt_c_q(
-     epicsInt8 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to UInt64 */
-static long cvt_c_uq(
-     epicsInt8 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to Float */
-static long cvt_c_f(
-     epicsInt8 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to Double */
-static long cvt_c_d(
-     epicsInt8 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Char to Enumerated */
-static long cvt_c_e(
-     epicsInt8 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_c_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt8 *from = (const epicsInt8 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to String */
-static long cvt_uc_st(
-     epicsUInt8 *from,
-     char *to,
-     const dbAddr *paddr)
-{ cvtUcharToString(*from, to); return(0); }
+static long cvt_uc_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    char *to = (char *) t;
+    cvtUcharToString(*from, to);
+    return 0;
+}
 
 /* Convert Unsigned Char to Char */
-static long cvt_uc_c(
-     epicsUInt8 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to Unsigned Char */
-static long cvt_uc_uc(
-     epicsUInt8 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to Short */
-static long cvt_uc_s(
-     epicsUInt8 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to Unsigned Short */
-static long cvt_uc_us(
-     epicsUInt8 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to Long */
-static long cvt_uc_l(
-     epicsUInt8 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to Unsigned Long */
-static long cvt_uc_ul(
-     epicsUInt8 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to Int64 */
-static long cvt_uc_q(
-     epicsUInt8 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to UInt64 */
-static long cvt_uc_uq(
-     epicsUInt8 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to Float */
-static long cvt_uc_f(
-     epicsUInt8 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to Double */
-static long cvt_uc_d(
-     epicsUInt8 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Char to Enumerated */
-static long cvt_uc_e(
-     epicsUInt8 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uc_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt8 *from = (const epicsUInt8 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Short to String */
-static long cvt_s_st(
-     epicsInt16 *from,
-     char *to,
-     const dbAddr *paddr)
-{ cvtShortToString(*from, to); return(0); }
+static long cvt_s_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    char *to = (char *) t;
+    cvtShortToString(*from, to);
+    return 0;
+}
 
 /* Convert Short to Char */
-static long cvt_s_c(
-     epicsInt16 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsInt8)*from; return(0); }
+static long cvt_s_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=(epicsInt8)*from;
+    return 0;
+}
 
 /* Convert Short to Unsigned Char */
-static long cvt_s_uc(
-     epicsInt16 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsUInt8)*from; return(0); }
+static long cvt_s_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=(epicsUInt8)*from;
+    return 0;
+}
 
 /* Convert Short to Short */
-static long cvt_s_s(
-     epicsInt16 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_s_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Short to Unsigned Short */
-static long cvt_s_us(
-     epicsInt16 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_s_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Short to Long */
-static long cvt_s_l(
-     epicsInt16 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_s_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Short to Unsigned Long */
-static long cvt_s_ul(
-     epicsInt16 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_s_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Short to Int64 */
-static long cvt_s_q(
-     epicsInt16 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_s_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Short to UInt64 */
-static long cvt_s_uq(
-     epicsInt16 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_s_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Short to Float */
-static long cvt_s_f(
-     epicsInt16 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_s_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Short to Double */
-static long cvt_s_d(
-     epicsInt16 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_s_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Short to Enumerated */
-static long cvt_s_e(
-     epicsInt16 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_s_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt16 *from = (const epicsInt16 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to String */
-static long cvt_us_st(
-     epicsUInt16 *from,
-     char *to,
-     const dbAddr *paddr)
-{ cvtUshortToString(*from, to); return(0); }
+static long cvt_us_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    char *to = (char *) t;
+    cvtUshortToString(*from, to);
+    return 0;
+}
 
 /* Convert Unsigned Short to Char */
-static long cvt_us_c(
-     epicsUInt16 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsInt8)*from; return(0); }
+static long cvt_us_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=(epicsInt8)*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to Unsigned Char */
-static long cvt_us_uc(
-     epicsUInt16 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsUInt8)*from; return(0); }
+static long cvt_us_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=(epicsUInt8)*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to Short */
-static long cvt_us_s(
-     epicsUInt16 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_us_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to Unsigned Short */
-static long cvt_us_us(
-     epicsUInt16 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_us_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to Long */
-static long cvt_us_l(
-     epicsUInt16 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_us_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to Unsigned Long */
-static long cvt_us_ul(
-     epicsUInt16 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_us_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to Int64 */
-static long cvt_us_q(
-     epicsUInt16 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_us_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to UInt64 */
-static long cvt_us_uq(
-     epicsUInt16 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_us_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to Float */
-static long cvt_us_f(
-     epicsUInt16 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_us_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to Double */
-static long cvt_us_d(
-     epicsUInt16 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_us_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Short to Enumerated */
-static long cvt_us_e(
-     epicsUInt16 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_us_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt16 *from = (const epicsUInt16 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to String */
-static long cvt_l_st(
-     epicsInt32 *from,
-     char *to,
-     const dbAddr *paddr)
-{ cvtLongToString(*from, to); return(0); }
+static long cvt_l_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    char *to = (char *) t;
+    cvtLongToString(*from, to);
+    return 0;
+}
 
 /* Convert Long to Char */
-static long cvt_l_c(
-     epicsInt32 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to Unsigned Char */
-static long cvt_l_uc(
-     epicsInt32 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to Short */
-static long cvt_l_s(
-     epicsInt32 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to Unsigned Short */
-static long cvt_l_us(
-     epicsInt32 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to Long */
-static long cvt_l_l(
-     epicsInt32 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to Unsigned Long */
-static long cvt_l_ul(
-     epicsInt32 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to Int64 */
-static long cvt_l_q(
-     epicsInt32 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to UInt64 */
-static long cvt_l_uq(
-     epicsInt32 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to Float */
-static long cvt_l_f(
-     epicsInt32 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=(epicsFloat32)*from; return(0); }
+static long cvt_l_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=(epicsFloat32)*from;
+    return 0;
+}
 
 /* Convert Long to Double */
-static long cvt_l_d(
-     epicsInt32 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Long to Enumerated */
-static long cvt_l_e(
-     epicsInt32 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_l_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt32 *from = (const epicsInt32 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to String */
-static long cvt_ul_st(
-     epicsUInt32 *from,
-     char *to,
-     const dbAddr *paddr)
-{ cvtUlongToString(*from, to); return(0); }
+static long cvt_ul_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    char *to = (char *) t;
+    cvtUlongToString(*from, to);
+    return 0;
+}
 
 /* Convert Unsigned Long to Char */
-static long cvt_ul_c(
-     epicsUInt32 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to Unsigned Char */
-static long cvt_ul_uc(
-     epicsUInt32 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to Short */
-static long cvt_ul_s(
-     epicsUInt32 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to Unsigned Short */
-static long cvt_ul_us(
-     epicsUInt32 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to Long */
-static long cvt_ul_l(
-     epicsUInt32 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to Unsigned Long */
-static long cvt_ul_ul(
-     epicsUInt32 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to Int64 */
-static long cvt_ul_q(
-     epicsUInt32 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to UInt64 */
-static long cvt_ul_uq(
-     epicsUInt32 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to Float */
-static long cvt_ul_f(
-     epicsUInt32 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=(epicsFloat32)*from; return(0); }
+static long cvt_ul_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=(epicsFloat32)*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to Double */
-static long cvt_ul_d(
-     epicsUInt32 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Unsigned Long to Enumerated */
-static long cvt_ul_e(
-     epicsUInt32 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_ul_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt32 *from = (const epicsUInt32 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to String */
-static long cvt_q_st(
-     epicsInt64 *from,
-     char *to,
-     const dbAddr *paddr)
-{ cvtInt64ToString(*from, to); return(0); }
+static long cvt_q_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    char *to = (char *) t;
+    cvtInt64ToString(*from, to);
+    return 0;
+}
 
 /* Convert Int64 to Char */
-static long cvt_q_c(
-     epicsInt64 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to Unsigned Char */
-static long cvt_q_uc(
-     epicsInt64 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to Short */
-static long cvt_q_s(
-     epicsInt64 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to Unsigned Short */
-static long cvt_q_us(
-     epicsInt64 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to Long */
-static long cvt_q_l(
-     epicsInt64 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to Unsigned Long */
-static long cvt_q_ul(
-     epicsInt64 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to Int64 */
-static long cvt_q_q(
-     epicsInt64 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to UInt64 */
-static long cvt_q_uq(
-     epicsInt64 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to Float */
-static long cvt_q_f(
-     epicsInt64 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to Double */
-static long cvt_q_d(
-     epicsInt64 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Int64 to Enumerated */
-static long cvt_q_e(
-     epicsInt64 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_q_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsInt64 *from = (const epicsInt64 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to String */
-static long cvt_uq_st(
-     epicsUInt64 *from,
-     char *to,
-     const dbAddr *paddr)
-{ cvtUInt64ToString(*from, to); return(0); }
+static long cvt_uq_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    char *to = (char *) t;
+    cvtUInt64ToString(*from, to);
+    return 0;
+}
 
 /* Convert UInt64 to Char */
-static long cvt_uq_c(
-     epicsUInt64 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to Unsigned Char */
-static long cvt_uq_uc(
-     epicsUInt64 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to Short */
-static long cvt_uq_s(
-     epicsUInt64 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to Unsigned Short */
-static long cvt_uq_us(
-     epicsUInt64 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to Long */
-static long cvt_uq_l(
-     epicsUInt64 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to Unsigned Long */
-static long cvt_uq_ul(
-     epicsUInt64 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to Int64 */
-static long cvt_uq_q(
-     epicsUInt64 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to UInt64 */
-static long cvt_uq_uq(
-     epicsUInt64 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to Float */
-static long cvt_uq_f(
-     epicsUInt64 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to Double */
-static long cvt_uq_d(
-     epicsUInt64 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert UInt64 to Enumerated */
-static long cvt_uq_e(
-     epicsUInt64 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_uq_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsUInt64 *from = (const epicsUInt64 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Float to String */
-static long cvt_f_st(
-     epicsFloat32 *from,
-     char *to,
-     const dbAddr *paddr)
- {
-   rset *prset = 0;
-   long status = 0;
-   long precision = 6;
+static long cvt_f_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    char *to = (char *) t;
+    
+    rset *prset = 0;
+    long status = 0;
+    long precision = 6;
 
-   if(paddr) prset = dbGetRset(paddr);
+    if (paddr) prset = dbGetRset(paddr);
 
-   if (prset && prset->get_precision)
-     status = (*prset->get_precision)(paddr, &precision);
-   cvtFloatToString(*from, to, (unsigned short)precision);
-   return(status);
+    if (prset && prset->get_precision)
+        status = (*prset->get_precision)(paddr, &precision);
+    cvtFloatToString(*from, to, (unsigned short)precision);
+    return status;
  }
 
 /* Convert Float to Char */
-static long cvt_f_c(
-     epicsFloat32 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsInt8)*from; return(0); }
+static long cvt_f_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=(epicsInt8)*from;
+    return 0;
+}
 
 /* Convert Float to Unsigned Char */
-static long cvt_f_uc(
-     epicsFloat32 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsUInt8)*from; return(0); }
+static long cvt_f_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=(epicsUInt8)*from;
+    return 0;
+}
 
 /* Convert Float to Short */
-static long cvt_f_s(
-     epicsFloat32 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=(epicsInt16)*from; return(0); }
+static long cvt_f_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=(epicsInt16)*from;
+    return 0;
+}
 
 /* Convert Float to Unsigned Short */
-static long cvt_f_us(
-     epicsFloat32 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=(epicsUInt16)*from; return(0); }
+static long cvt_f_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=(epicsUInt16)*from;
+    return 0;
+}
 
 /* Convert Float to Long */
-static long cvt_f_l(
-     epicsFloat32 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=(epicsInt32)*from; return(0); }
+static long cvt_f_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=(epicsInt32)*from;
+    return 0;
+}
 
 /* Convert Float to Unsigned Long */
-static long cvt_f_ul(
-     epicsFloat32 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=(epicsUInt32)*from; return(0); }
+static long cvt_f_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=(epicsUInt32)*from;
+    return 0;
+}
 
 /* Convert Float to Int64 */
-static long cvt_f_q(
-     epicsFloat32 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_f_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Float to UInt64 */
-static long cvt_f_uq(
-     epicsFloat32 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_f_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Float to Float */
-static long cvt_f_f(
-     epicsFloat32 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_f_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Float to Double */
-static long cvt_f_d(
-     epicsFloat32 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_f_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Float to Enumerated */
-static long cvt_f_e(
-     epicsFloat32 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=(epicsEnum16)*from; return(0); }
+static long cvt_f_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat32 *from = (const epicsFloat32 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=(epicsEnum16)*from;
+    return 0;
+}
 
 /* Convert Double to String */
-static long cvt_d_st(
-     epicsFloat64 *from,
-     char *to,
-     const dbAddr *paddr)
- {
-   rset *prset = 0;
-   long status = 0;
-   long precision = 6;
+static long cvt_d_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    char *to = (char *) t;
+    rset *prset = 0;
+    long status = 0;
+    long precision = 6;
 
-   if(paddr) prset = dbGetRset(paddr);
+    if (paddr) prset = dbGetRset(paddr);
 
-   if (prset && prset->get_precision)
-     status = (*prset->get_precision)(paddr, &precision);
-   cvtDoubleToString(*from, to, (unsigned short)precision);
-   return(status);
+    if (prset && prset->get_precision)
+        status = (*prset->get_precision)(paddr, &precision);
+    cvtDoubleToString(*from, to, (unsigned short)precision);
+    return status;
  }
 
 /* Convert Double to Char */
-static long cvt_d_c(
-     epicsFloat64 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsInt8)*from; return(0); }
+static long cvt_d_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=(epicsInt8)*from;
+    return 0;
+}
 
 /* Convert Double to Unsigned Char */
-static long cvt_d_uc(
-     epicsFloat64 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsUInt8)*from; return(0); }
+static long cvt_d_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=(epicsUInt8)*from;
+    return 0;
+}
 
 /* Convert Double to Short */
-static long cvt_d_s(
-     epicsFloat64 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=(epicsInt16)*from; return(0); }
+static long cvt_d_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=(epicsInt16)*from;
+    return 0;
+}
 
 /* Convert Double to Unsigned Short */
-static long cvt_d_us(
-     epicsFloat64 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=(epicsUInt16)*from; return(0); }
+static long cvt_d_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=(epicsUInt16)*from;
+    return 0;
+}
 
 /* Convert Double to Long */
-static long cvt_d_l(
-     epicsFloat64 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_d_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Double to Unsigned Long */
-static long cvt_d_ul(
-     epicsFloat64 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_d_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Double to Int64 */
-static long cvt_d_q(
-     epicsFloat64 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_d_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Double to UInt64 */
-static long cvt_d_uq(
-     epicsFloat64 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_d_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Double to Float */
-static long cvt_d_f(
-     epicsFloat64 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
-{ *to = epicsConvertDoubleToFloat(*from); return 0;}
+static long cvt_d_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to = epicsConvertDoubleToFloat(*from); return 0;}
 
 /* Convert Double to Double */
-static long cvt_d_d(
-     epicsFloat64 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_d_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Double to Enumerated */
-static long cvt_d_e(
-     epicsFloat64 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=(epicsEnum16)*from; return(0); }
+static long cvt_d_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsFloat64 *from = (const epicsFloat64 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=(epicsEnum16)*from;
+    return 0;
+}
 
 /* Convert Enumerated to Char */
-static long cvt_e_c(
-     epicsEnum16 *from,
-     epicsInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsInt8)*from; return(0); }
+static long cvt_e_c(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsInt8 *to = (epicsInt8 *) t;
+    *to=(epicsInt8)*from;
+    return 0;
+}
 
 /* Convert Enumerated to Unsigned Char */
-static long cvt_e_uc(
-     epicsEnum16 *from,
-     epicsUInt8 *to,
-     const dbAddr *paddr)
- { *to=(epicsUInt8)*from; return(0); }
+static long cvt_e_uc(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsUInt8 *to = (epicsUInt8 *) t;
+    *to=(epicsUInt8)*from;
+    return 0;
+}
 
 /* Convert Enumerated to Short */
-static long cvt_e_s(
-     epicsEnum16 *from,
-     epicsInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_e_s(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsInt16 *to = (epicsInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Enumerated to Unsigned Short */
-static long cvt_e_us(
-     epicsEnum16 *from,
-     epicsUInt16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_e_us(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsUInt16 *to = (epicsUInt16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Enumerated to Long */
-static long cvt_e_l(
-     epicsEnum16 *from,
-     epicsInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_e_l(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsInt32 *to = (epicsInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Enumerated to Unsigned Long */
-static long cvt_e_ul(
-     epicsEnum16 *from,
-     epicsUInt32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_e_ul(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsUInt32 *to = (epicsUInt32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Enumerated to Int64 */
-static long cvt_e_q(
-     epicsEnum16 *from,
-     epicsInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_e_q(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsInt64 *to = (epicsInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Enumerated to UInt64 */
-static long cvt_e_uq(
-     epicsEnum16 *from,
-     epicsUInt64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_e_uq(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsUInt64 *to = (epicsUInt64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Enumerated to Float */
-static long cvt_e_f(
-     epicsEnum16 *from,
-     epicsFloat32 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_e_f(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsFloat32 *to = (epicsFloat32 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Enumerated to Double */
-static long cvt_e_d(
-     epicsEnum16 *from,
-     epicsFloat64 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_e_d(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsFloat64 *to = (epicsFloat64 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Enumerated to Enumerated */
-static long cvt_e_e(
-     epicsEnum16 *from,
-     epicsEnum16 *to,
-     const dbAddr *paddr)
- { *to=*from; return(0); }
+static long cvt_e_e(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    epicsEnum16 *to = (epicsEnum16 *) t;
+    *to=*from;
+    return 0;
+}
 
 /* Convert Choices And Enumerated Types To String ... */
 
 /* Get Enumerated to String */
-static long cvt_e_st_get(
-     epicsEnum16 *from,
-     char *to,
-     const dbAddr *paddr)
- {
-   rset *prset = 0;
-   long status;
+static long cvt_e_st_get(const void *f, void *t, const dbAddr *paddr)
+{
+    char *to = (char *) t;
+    rset *prset = 0;
+    long status;
 
-   if(paddr) prset = dbGetRset(paddr);
+    if(paddr) prset = dbGetRset(paddr);
 
-   if (prset && prset->get_enum_str)
-       return (*prset->get_enum_str)(paddr, to);
+    if (prset && prset->get_enum_str)
+        return (*prset->get_enum_str)(paddr, to);
 
-   status = S_db_noRSET;
-   recGblRecSupError(status, paddr, "dbGetField", "get_enum_str");
+    status = S_db_noRSET;
+    recGblRecSupError(status, paddr, "dbGetField", "get_enum_str");
 
-   return(S_db_badDbrtype);
- }
+    return S_db_badDbrtype;
+}
 
 /* Put Enumerated to String */
-static long cvt_e_st_put(
-     epicsEnum16 *from,
-     char *to,
-     const dbAddr *paddr)
- { cvtUshortToString(*from, to); return(0); }
+static long cvt_e_st_put(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    char *to = (char *) t;
+
+    cvtUshortToString(*from, to);
+    return 0;
+}
 
 /* Get Menu to String */
-static long cvt_menu_st(
-     epicsEnum16 *from,
-     char *to,
-     const dbAddr *paddr)
+static long cvt_menu_st(const void *f, void *t, const dbAddr *paddr)
 {
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    char *to = (char *) t;
     dbFldDes *pdbFldDes;
     dbMenu *pdbMenu;
 
@@ -1358,15 +1599,14 @@ static long cvt_menu_st(
 
 
 /* Get Device to String */
-static long cvt_device_st(
-     epicsEnum16 *from,
-     char *to,
-     const dbAddr *paddr)
- {
-   dbFldDes             *pdbFldDes;
-   dbDeviceMenu         *pdbDeviceMenu;
-   char                 **papChoice;
-   char                 *pchoice;
+static long cvt_device_st(const void *f, void *t, const dbAddr *paddr)
+{
+    const epicsEnum16 *from = (const epicsEnum16 *) f;
+    char *to = (char *) t;
+    dbFldDes             *pdbFldDes;
+    dbDeviceMenu         *pdbDeviceMenu;
+    char                 **papChoice;
+    char                 *pchoice;
 
     if (!paddr
     || !(pdbFldDes = paddr->pfldDes)) {
@@ -1382,11 +1622,11 @@ static long cvt_device_st(
     || !(papChoice= pdbDeviceMenu->papChoice)
     || !(pchoice=papChoice[*from])) {
         recGblDbaddrError(S_db_badChoice,paddr,"dbFastLinkConv(cvt_device_st)");
-        return(S_db_badChoice);
+        return S_db_badChoice;
     }
     strncpy(to,pchoice,MAX_STRING_SIZE);
-    return(0);
- }
+    return 0;
+}
 
 /*
  *  Get conversion routine lookup table

--- a/modules/database/src/ioc/db/dbLink.h
+++ b/modules/database/src/ioc/db/dbLink.h
@@ -307,7 +307,7 @@ typedef struct lset {
      *
      * @param   plink       the link
      * @param   dbrType     data type code
-     * @param   pbuffer     where to put the value
+     * @param   pbuffer     where the data is
      * @param   nRequest    number of elements to send
      * @returns status value
      */
@@ -324,7 +324,7 @@ typedef struct lset {
      *
      * @param   plink       the link
      * @param   dbrType     data type code
-     * @param   pbuffer     where to put the value
+     * @param   pbuffer     where the data is
      * @param   nRequest    number of elements to send
      * @returns status value
      */

--- a/modules/database/src/ioc/db/dbScan.c
+++ b/modules/database/src/ioc/db/dbScan.c
@@ -264,7 +264,7 @@ void scanAdd(struct dbCommon *precord)
     } else if (scan == menuScanI_O_Intr) {
         ioscan_head *piosh = NULL;
         int prio;
-        DEVSUPFUN get_ioint_info;
+        long (*get_ioint_info)(int, struct dbCommon *, IOSCANPVT*);
 
         if (precord->dset == NULL){
             recGblRecordError(-1, (void *)precord,
@@ -332,7 +332,7 @@ void scanDelete(struct dbCommon *precord)
     } else if (scan == menuScanI_O_Intr) {
         ioscan_head *piosh = NULL;
         int prio;
-        DEVSUPFUN get_ioint_info;
+        long (*get_ioint_info)(int, struct dbCommon *, IOSCANPVT*);
 
         if (precord->dset==NULL) {
             recGblRecordError(-1, (void *)precord,

--- a/modules/database/src/ioc/db/dbTest.c
+++ b/modules/database/src/ioc/db/dbTest.c
@@ -680,7 +680,7 @@ long dbtpf(const char *pname, const char *pvalue)
 long dbior(const char *pdrvName,int interest_level)
 {
     drvSup *pdrvSup;
-    struct drvet *pdrvet;
+    drvet *pdrvet;
     dbRecordType *pdbRecordType;
 
     if (!pdbbase) {

--- a/modules/database/src/ioc/dbStatic/Makefile
+++ b/modules/database/src/ioc/dbStatic/Makefile
@@ -11,6 +11,8 @@
 
 SRC_DIRS += $(IOCDIR)/dbStatic
 
+USR_CFLAGS += -DUSE_TYPED_DRVET
+
 INC += dbBase.h
 INC += dbFldTypes.h
 INC += dbStaticLib.h

--- a/modules/database/src/ioc/dbStatic/dbBase.h
+++ b/modules/database/src/ioc/dbStatic/dbBase.h
@@ -21,6 +21,7 @@
 #include "dbDefs.h"
 #include "recSup.h"
 #include "devSup.h"
+#include "drvSup.h"
 
 typedef struct dbMenu {
     ELLNODE         node;
@@ -33,7 +34,7 @@ typedef struct dbMenu {
 typedef struct drvSup {
     ELLNODE         node;
     char            *name;
-    struct drvet    *pdrvet;
+    drvet           *pdrvet;
 }drvSup;
 
 typedef struct devSup {

--- a/modules/database/src/ioc/dbStatic/dbYacc.y
+++ b/modules/database/src/ioc/dbStatic/dbYacc.y
@@ -8,7 +8,7 @@
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
 %{
-static int yyerror();
+static int yyerror(char *str);
 static int yy_start;
 static long pvt_yy_parse(void);
 static int yyFailed = 0;

--- a/modules/database/src/ioc/dbStatic/link.h
+++ b/modules/database/src/ioc/dbStatic/link.h
@@ -188,8 +188,8 @@ union value {
     struct vxiio        vxiio;          /* vxi io */
 };
 
+struct dbCommon;
 struct lset;
-
 struct link {
     struct dbCommon *precord;   /* Pointer to record owning link */
     short type;

--- a/modules/database/src/ioc/dbStatic/link.h
+++ b/modules/database/src/ioc/dbStatic/link.h
@@ -77,14 +77,14 @@ struct macro_link {
     char *macroStr;
 };
 
-struct dbCommon;
-typedef long (*LINKCVT)();
+struct dbAddr;
+typedef long (*FASTCONVERTFUNC)(const void *from, void *to, const struct dbAddr *paddr);
 
 struct pv_link {
     ELLNODE     backlinknode;
     char        *pvname;        /* pvname link points to */
     void        *pvt;           /* CA or DB private */
-    LINKCVT     getCvt;         /* input conversion function */
+    FASTCONVERTFUNC getCvt;     /* input conversion function */
     short       pvlMask;        /* Options mask */
     short       lastGetdbrType; /* last dbrType for DB or CA get */
 };

--- a/modules/database/src/ioc/dbtemplate/Makefile
+++ b/modules/database/src/ioc/dbtemplate/Makefile
@@ -14,7 +14,6 @@ SRC_DIRS += $(IOCDIR)/dbtemplate
 PROD_HOST += msi
 
 msi_SRCS = msi.cpp
-msi_LIBS += Com
 HTMLS += msi.html
 
 INC += dbLoadTemplate.h

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -388,7 +388,7 @@ static void initDrvSup(void) /* Locate all driver support entry tables */
 
     for (pdrvSup = (drvSup *)ellFirst(&pdbbase->drvList); pdrvSup;
          pdrvSup = (drvSup *)ellNext(&pdrvSup->node)) {
-        struct drvet *pdrvet = registryDriverSupportFind(pdrvSup->name);
+        drvet *pdrvet = registryDriverSupportFind(pdrvSup->name);
 
         if (!pdrvet) {
             errlogPrintf("iocInit: driver %s not found\n", pdrvSup->name);

--- a/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
+++ b/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
@@ -32,11 +32,12 @@ namespace {
 struct compareLoc {
     bool operator()(const recordTypeLocation& lhs, const recordTypeLocation& rhs) const
     {
-        if(lhs.prset<rhs.prset)
+        if (lhs.prset < rhs.prset)
             return true;
-        else if(lhs.prset>rhs.prset)
+        if (lhs.prset > rhs.prset)
             return false;
-        return (char *)lhs.sizeOffset < (char *)rhs.sizeOffset;
+        return reinterpret_cast<char *>(lhs.sizeOffset)
+             < reinterpret_cast<char *>(rhs.sizeOffset);
     }
 };
 

--- a/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
+++ b/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
@@ -36,7 +36,7 @@ struct compareLoc {
             return true;
         else if(lhs.prset>rhs.prset)
             return false;
-        return lhs.sizeOffset<rhs.sizeOffset;
+        return (char *)lhs.sizeOffset < (char *)rhs.sizeOffset;
     }
 };
 

--- a/modules/database/src/ioc/registry/registryCommon.c
+++ b/modules/database/src/ioc/registry/registryCommon.c
@@ -65,7 +65,7 @@ void registerDevices(DBBASE *pbase, int nDevices,
 }
 
 void registerDrivers(DBBASE *pbase, int nDrivers,
-    const char * const * driverSupportNames, struct drvet * const *drvsl)
+    const char * const * driverSupportNames, drvet * const *drvsl)
 {
     int i;
     for (i = 0; i < nDrivers; i++) {

--- a/modules/database/src/ioc/registry/registryCommon.h
+++ b/modules/database/src/ioc/registry/registryCommon.h
@@ -29,7 +29,7 @@ DBCORE_API void registerDevices(
     const char * const *deviceSupportNames, const dset * const *devsl);
 DBCORE_API void registerDrivers(
     DBBASE *pbase, int nDrivers,
-    const char * const *driverSupportNames, struct drvet * const *drvsl);
+    const char * const *driverSupportNames, drvet * const *drvsl);
 DBCORE_API void registerJLinks(
     DBBASE *pbase, int nDrivers, jlif * const *jlifsl);
 

--- a/modules/database/src/ioc/registry/registryDriverSupport.c
+++ b/modules/database/src/ioc/registry/registryDriverSupport.c
@@ -18,12 +18,12 @@ static void *registryID = "driver support";
 
 
 DBCORE_API int registryDriverSupportAdd(
-    const char *name, struct drvet *pdrvet)
+    const char *name, drvet *pdrvet)
 {
     return registryAdd(registryID, name, pdrvet);
 }
 
-DBCORE_API struct drvet * registryDriverSupportFind(
+DBCORE_API drvet * registryDriverSupportFind(
     const char *name)
 {
     return registryFind(registryID, name);

--- a/modules/database/src/ioc/registry/registryDriverSupport.h
+++ b/modules/database/src/ioc/registry/registryDriverSupport.h
@@ -19,8 +19,8 @@ extern "C" {
 #endif
 
 DBCORE_API int registryDriverSupportAdd(
-    const char *name, struct drvet *pdrvet);
-DBCORE_API struct drvet * registryDriverSupportFind(
+    const char *name, drvet *pdrvet);
+DBCORE_API drvet * registryDriverSupportFind(
     const char *name);
 
 #ifdef __cplusplus

--- a/modules/database/src/ioc/rsrv/cast_server.c
+++ b/modules/database/src/ioc/rsrv/cast_server.c
@@ -98,13 +98,10 @@ static void clean_addrq(struct client *client)
     }
     epicsMutexUnlock ( client->chanListLock );
 
-#   ifdef DEBUG
-    if(ndelete){
+    if (CASDEBUG>1 && ndelete){
         epicsPrintf ("CAS: %d CA channels have expired after %f sec\n",
             ndelete, maxdelay);
     }
-#   endif
-
 }
 
 /*

--- a/modules/database/src/std/link/lnkCalc.c
+++ b/modules/database/src/std/link/lnkCalc.c
@@ -36,8 +36,6 @@
 #include "epicsExport.h"
 
 
-typedef long (*FASTCONVERT)();
-
 typedef struct calc_link {
     jlink jlink;        /* embedded object */
     int nArgs;
@@ -558,7 +556,7 @@ static long lnkCalc_getValue(struct link *plink, short dbrType, void *pbuffer,
     dbCommon *prec = plink->precord;
     int i;
     long status;
-    FASTCONVERT conv;
+    FASTCONVERTFUNC conv;
 
     if(INVALID_DB_REQ(dbrType))
         return S_db_badDbrtype;
@@ -638,7 +636,7 @@ static long lnkCalc_putValue(struct link *plink, short dbrType,
     dbCommon *prec = plink->precord;
     int i;
     long status;
-    FASTCONVERT conv;
+    FASTCONVERTFUNC conv;
 
     if(INVALID_DB_REQ(dbrType))
         return S_db_badDbrtype;

--- a/modules/database/src/std/link/lnkConst.c
+++ b/modules/database/src/std/link/lnkConst.c
@@ -23,8 +23,6 @@
 #include "epicsExport.h"
 
 
-typedef long (*FASTCONVERT)();
-
 typedef struct const_link {
     jlink jlink;        /* embedded object */
     int nElems;
@@ -458,7 +456,7 @@ static long lnkConst_loadArray(struct link *plink, short dbrType, void *pbuffer,
     short dbrSize;
     char *pdest = pbuffer;
     int nElems = clink->nElems;
-    FASTCONVERT conv;
+    FASTCONVERTFUNC conv;
     long status;
 
     if(INVALID_DB_REQ(dbrType))

--- a/modules/database/src/std/link/lnkState.c
+++ b/modules/database/src/std/link/lnkState.c
@@ -34,8 +34,6 @@
 #include "epicsExport.h"
 
 
-typedef long (*FASTCONVERT)();
-
 typedef struct state_link {
     jlink jlink;        /* embedded object */
     char *name;
@@ -143,7 +141,7 @@ static long lnkState_getValue(struct link *plink, short dbrType, void *pbuffer,
 {
     state_link *slink = CONTAINER(plink->value.json.jlink,
         struct state_link, jlink);
-    FASTCONVERT conv;
+    FASTCONVERTFUNC conv;
 
     if(INVALID_DB_REQ(dbrType))
         return S_db_badDbrtype;

--- a/modules/database/test/ioc/db/dbPutLinkTest.c
+++ b/modules/database/test/ioc/db/dbPutLinkTest.c
@@ -597,8 +597,12 @@ void testJLink(void)
     testNumZ(6);
 
     testdbPutFieldOk("j1.INP", DBF_STRING, "{\"z\":{\"good\":4}}");
+    testdbPutFieldOk("j1.PHAS", DBF_LONG, 0);
+    testdbPutFieldOk("j1.OUTP", DBF_STRING, "{z:{good:99}}");
     testdbPutFieldOk("j1.PROC", DBF_LONG, 1);
     testdbGetFieldEqual("j1.VAL", DBF_LONG, 4);
+    testdbGetFieldEqual("j1.PHAS", DBF_LONG, 4);
+    testdbPutFieldOk("j1.OUTP", DBF_STRING, "");
 
     testdbPutFieldOk("j2.TSEL", DBF_STRING, "{'z':{good:0}}");
     testdbPutFieldOk("j2.PROC", DBF_LONG, 1);
@@ -701,7 +705,7 @@ void testTSEL(void)
 
 MAIN(dbPutLinkTest)
 {
-    testPlan(348);
+    testPlan(352);
     testLinkParse();
     testLinkFailParse();
     testCADBSet();

--- a/modules/database/test/ioc/db/dbStressLock.c
+++ b/modules/database/test/ioc/db/dbStressLock.c
@@ -59,6 +59,9 @@ static unsigned int nrecords;
 
 #define MAXLOCK 20
 
+/* Verbose output from test if you set this to 1 */
+#define MULTI_DIAG 0
+
 static dbCommon **precords;
 
 typedef struct {
@@ -120,7 +123,7 @@ void doMulti(workerPriv *p)
     }
     dbScanUnlockMany(locker);
 
-    if (0)
+    if (MULTI_DIAG)
         testDiag("sum = %d", sum);
 
     dbLockerFree(locker);

--- a/modules/database/test/ioc/db/dbStressLock.c
+++ b/modules/database/test/ioc/db/dbStressLock.c
@@ -120,6 +120,9 @@ void doMulti(workerPriv *p)
     }
     dbScanUnlockMany(locker);
 
+    if (0)
+        testDiag("sum = %d", sum);
+
     dbLockerFree(locker);
 }
 

--- a/modules/database/test/ioc/db/jlinkz.c
+++ b/modules/database/test/ioc/db/jlinkz.c
@@ -119,11 +119,12 @@ long z_putval(struct link *plink, short dbrType,
 {
     long ret;
     zpriv *priv = CONTAINER(plink->value.json.jlink, zpriv, base);
+    FASTCONVERTFUNC pconv;
 
     if(INVALID_DB_REQ(dbrType))
         return S_db_badDbrtype;
 
-    FASTCONVERTFUNC pconv = dbFastPutConvertRoutine[DBF_LONG][dbrType];
+    pconv = dbFastPutConvertRoutine[DBF_LONG][dbrType];
 
     if(nRequest==0) return 0;
 

--- a/modules/database/test/ioc/db/jlinkz.c
+++ b/modules/database/test/ioc/db/jlinkz.c
@@ -35,7 +35,6 @@ void z_open(struct link *plink)
     if(priv->isopen)
         testDiag("lsetZ re-open");
     priv->isopen = 1;
-    testDiag("Open jlinkz %p", priv);
 }
 
 static
@@ -49,8 +48,6 @@ void z_remove(struct dbLocker *locker, struct link *plink)
         testDiag("lsetZ remove without open");
 
     epicsMutexUnlock(priv->lock);
-
-    testDiag("Remove/free jlinkz %p", priv);
 
     epicsAtomicDecrIntT(&numzalloc);
 
@@ -169,8 +166,6 @@ jlink* z_alloc(short dbfType)
 
     epicsAtomicIncrIntT(&numzalloc);
 
-    testDiag("Alloc jlinkz %p", priv);
-
     return &priv->base;
 fail:
     if(priv && priv->lock) epicsMutexDestroy(priv->lock);
@@ -185,8 +180,6 @@ void z_free(jlink *pj)
 
     if(priv->isopen)
         testDiag("lsetZ jlink free after open()");
-
-    testDiag("Free jlinkz %p", priv);
 
     epicsAtomicDecrIntT(&numzalloc);
 

--- a/modules/database/test/ioc/db/jlinkz.c
+++ b/modules/database/test/ioc/db/jlinkz.c
@@ -83,13 +83,13 @@ long z_getval(struct link *plink, short dbrType, void *pbuffer,
         long *pnRequest)
 {
     long ret;
-    long (*pconv)(const epicsInt32 *, void *, const dbAddr *) = dbFastGetConvertRoutine[DBF_LONG][dbrType];
+    FASTCONVERTFUNC pconv = dbFastGetConvertRoutine[DBF_LONG][dbrType];
     zpriv *priv = CONTAINER(plink->value.json.jlink, zpriv, base);
 
     if(pnRequest && *pnRequest==0) return 0;
 
     epicsMutexLock(priv->lock);
-    ret = (*pconv)(&priv->value, pbuffer, NULL);
+    ret = pconv(&priv->value, pbuffer, NULL);
     epicsMutexUnlock(priv->lock);
     if(ret==0 && pnRequest) *pnRequest = 1;
     return ret;
@@ -118,18 +118,17 @@ long z_putval(struct link *plink, short dbrType,
         const void *pbuffer, long nRequest)
 {
     long ret;
-    long (*pconv)(epicsInt32 *, const void *, const dbAddr *);
     zpriv *priv = CONTAINER(plink->value.json.jlink, zpriv, base);
 
     if(INVALID_DB_REQ(dbrType))
         return S_db_badDbrtype;
 
-    pconv = dbFastPutConvertRoutine[DBF_LONG][dbrType];
+    FASTCONVERTFUNC pconv = dbFastPutConvertRoutine[DBF_LONG][dbrType];
 
     if(nRequest==0) return 0;
 
     epicsMutexLock(priv->lock);
-    ret = (*pconv)(&priv->value, pbuffer, NULL);
+    ret = pconv(pbuffer, &priv->value, NULL);
     epicsMutexUnlock(priv->lock);
     return ret;
 }

--- a/modules/database/test/ioc/db/jlinkz.c
+++ b/modules/database/test/ioc/db/jlinkz.c
@@ -124,13 +124,14 @@ long z_putval(struct link *plink, short dbrType,
     if(INVALID_DB_REQ(dbrType))
         return S_db_badDbrtype;
 
-    pconv = dbFastPutConvertRoutine[DBF_LONG][dbrType];
+    pconv = dbFastPutConvertRoutine[dbrType][DBF_LONG];
 
     if(nRequest==0) return 0;
 
     epicsMutexLock(priv->lock);
     ret = pconv(pbuffer, &priv->value, NULL);
     epicsMutexUnlock(priv->lock);
+    plink->precord->phas = priv->value;
     return ret;
 }
 

--- a/modules/database/test/ioc/db/xRecord.c
+++ b/modules/database/test/ioc/db/xRecord.c
@@ -71,6 +71,7 @@ static long process(struct dbCommon *pcommon)
         ret = (*xset->process)(prec);
     monitor(prec);
     recGblGetTimeStamp(prec);
+    dbPutLink(&prec->outp, DBR_LONG, &prec->val, 1);
     recGblFwdLink(prec);
     prec->pact = FALSE;
     return ret;

--- a/modules/database/test/ioc/db/xRecord.dbd
+++ b/modules/database/test/ioc/db/xRecord.dbd
@@ -49,6 +49,9 @@ recordtype(x) {
     prompt("Input Link")
     special(SPC_MOD)
   }
+  field(OUTP, DBF_OUTLINK) {
+    prompt("Output Link")
+  }
   field(CLBK, DBF_NOACCESS) {
     prompt("Processing callback")
     special(SPC_NOMOD)


### PR DESCRIPTION
These commits clean up compiler warnings from Clang-15 when building the built-in modules. I developed and tested this on macOS, both Intel and ARM; I didn't check for warning reductions on gcc though.