### PR TITLE
Accept should return SOCKET rather than int

### DIFF
--- a/modules/libcom/src/log/iocLogServer.c
+++ b/modules/libcom/src/log/iocLogServer.c
@@ -43,7 +43,7 @@ static char ioc_log_file_command[256];
 
 
 struct iocLogClient {
-    int insock;
+    SOCKET insock;
     struct ioc_log_server *pserver;
     size_t nChar;
     char recvbuf[1024];

--- a/modules/libcom/src/osi/os/WIN32/osdSock.c
+++ b/modules/libcom/src/osi/os/WIN32/osdSock.c
@@ -119,8 +119,8 @@ LIBCOM_API SOCKET epicsStdCall epicsSocketCreate (
     return socket ( domain, type, protocol );
 }
 
-LIBCOM_API int epicsStdCall epicsSocketAccept ( 
-    int sock, struct sockaddr * pAddr, osiSocklen_t * addrlen )
+LIBCOM_API SOCKET epicsStdCall epicsSocketAccept (
+    SOCKET sock, struct sockaddr * pAddr, osiSocklen_t * addrlen )
 {
     return accept ( sock, pAddr, addrlen );
 }

--- a/modules/libcom/src/osi/os/posix/osdSock.c
+++ b/modules/libcom/src/osi/os/posix/osdSock.c
@@ -124,8 +124,8 @@ LIBCOM_API SOCKET epicsStdCall epicsSocketCreate (
     return sock;
 }
 
-LIBCOM_API int epicsStdCall epicsSocketAccept ( 
-    int sock, struct sockaddr * pAddr, osiSocklen_t * addrlen )
+LIBCOM_API SOCKET epicsStdCall epicsSocketAccept (
+    SOCKET sock, struct sockaddr * pAddr, osiSocklen_t * addrlen )
 {
 #ifndef HAVE_SOCK_CLOEXEC
     int newSock = accept ( sock, pAddr, addrlen );

--- a/modules/libcom/src/osi/os/vxWorks/osdSock.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdSock.c
@@ -44,8 +44,8 @@ LIBCOM_API SOCKET epicsStdCall epicsSocketCreate (
     return sock;
 }
 
-LIBCOM_API int epicsStdCall epicsSocketAccept ( 
-    int sock, struct sockaddr * pAddr, osiSocklen_t * addrlen )
+LIBCOM_API SOCKET epicsStdCall epicsSocketAccept (
+    SOCKET sock, struct sockaddr * pAddr, osiSocklen_t * addrlen )
 {
     int newSock = accept ( sock, pAddr, addrlen );
     if ( newSock < 0 ) {

--- a/modules/libcom/src/osi/osiSock.h
+++ b/modules/libcom/src/osi/osiSock.h
@@ -63,8 +63,8 @@ LIBCOM_API SOCKET epicsStdCall epicsSocketCreate (
  * peer address.
  * \return A new socket used for communicating with the peer just accepted, or -1 on error.
  */
-LIBCOM_API int epicsStdCall epicsSocketAccept ( 
-    int sock, struct sockaddr * pAddr, osiSocklen_t * addrlen );
+LIBCOM_API SOCKET epicsStdCall epicsSocketAccept (
+    SOCKET sock, struct sockaddr * pAddr, osiSocklen_t * addrlen );
 /*!
  * \brief Close and free resources held by a SOCKET object.
  *


### PR DESCRIPTION
Change return type and first parameter of `epicsSocketAccept()` from `int` to `SOCKET` to match its real data type - this removes a compiler warning on WIN32
