### PR TITLE
WIN32: Move call to setThreadName()

### DIFF
--- a/modules/libcom/src/osi/os/WIN32/osdThread.c
+++ b/modules/libcom/src/osi/os/WIN32/osdThread.c
@@ -500,8 +500,6 @@ static unsigned WINAPI epicsWin32ThreadEntry ( LPVOID lpParameter )
     BOOL success;
 
     if ( pGbl )  {
-        setThreadName ( pParm->id, pParm->pName );
-
         success = FlsSetValue ( pGbl->flsIndexThreadLibraryEPICS, pParm );
         if ( success ) {
             osdThreadHooksRun ( ( epicsThreadId ) pParm );
@@ -659,6 +657,7 @@ epicsThreadId epicsThreadCreateOpt (
         pParmWIN32->id = ( DWORD ) threadId ;
     }
 
+    setThreadName ( pParmWIN32->id, pParmWIN32->pName );
     osdPriority = epicsThreadGetOsdPriorityValue (opts->priority);
     bstat = SetThreadPriority ( pParmWIN32->handle, osdPriority );
     if (!bstat) {

--- a/modules/libcom/src/osi/os/WIN32/osdTime.cpp
+++ b/modules/libcom/src/osi/os/WIN32/osdTime.cpp
@@ -215,6 +215,7 @@ void currentTime :: startPLL ()
                 CREATE_SUSPENDED | STACK_SIZE_PARAM_IS_A_RESERVATION,
                 & this->threadId );
         assert ( this->threadHandle );
+        setThreadName ( this->threadId, "EPICS Time PLL" );
         BOOL bstat = SetThreadPriority (
             this->threadHandle, THREAD_PRIORITY_HIGHEST );
         assert ( bstat );
@@ -496,7 +497,6 @@ static unsigned __stdcall _pllThreadEntry ( void * pCurrentTimeIn )
 {
     currentTime * pCT =
         reinterpret_cast < currentTime * > ( pCurrentTimeIn );
-    setThreadName ( pCT->threadId, "EPICS Time PLL" );
     while ( ! pCT->threadShutdownCmd ) {
         Sleep ( currentTime :: pllDelay * 1000 /* mS */ );
         pCT->updatePLL ();


### PR DESCRIPTION
The call to `setThreadName()` is moved to avoid a race condition that can happen with very short lived processes. If the process terminates very quickly e.g. is a google test runner or the `msi.exe` command called from a Makefile during a build, then very occasionally a crash can occur during process termination in `setThreadName()` when called from the newly created thread. This looks to be because the DLL it is trying to call gets unloaded between it getting a handle to the DLL and making the call. Moving the `setThreadName()` call to the creating thread avoids this problem, which probably stemmed from the delay between the thread being created and it subsequently running `setThreadName()`.  The issue was only ever seen with statically linked epics executables, I am unsure if the way a DLL based epics program unloads might avoid this, or just make it less likely but still possible. As mentioned above, the issue would only ever have occurred to threads that are created during process termination and so would not affect running IOCs