### PR TITLE
Fix issue where VSCode makefile extension can delete files

### DIFF
--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -532,11 +532,11 @@ endif # LOADABLE_SHRLIB_SUFFIX
 ifneq ($(INSTALL_CONFIGS),)
 $(INSTALL_CONFIG)/%: %
 	$(ECHO) "Installing config file $@"
-	@$(INSTALL) -d -m $(INSTALL_PERMISSIONS) $< $(@D)
+	@$(INSTALL) -d -m $(INSTALL_PERMISSIONS) $(abspath $< $(@D))
 
 $(INSTALL_CONFIG)/%: ../%
 	$(ECHO) "Installing config file $@"
-	@$(INSTALL) -d -m $(INSTALL_PERMISSIONS) $< $(@D)
+	@$(INSTALL) -d -m $(INSTALL_PERMISSIONS) $(abspath $< $(@D))
 endif
 
 $(INSTALL_INCLUDE)/%: $(COMMON_DIR)/%

--- a/src/tools/installEpics.pl
+++ b/src/tools/installEpics.pl
@@ -57,6 +57,9 @@ foreach my $source (@ARGV) {
     my $temp   = "$install_dir/TEMP.$name.$$";
     my $target = "$install_dir/$name";
 
+    # Don't try to install the file if it already exists
+    next if $source eq $target;
+
     if (-f $target) {
         next if -M $target < -M $source and -C $target < -C $source;
         # Remove old target, making sure it is deletable first


### PR DESCRIPTION
The problem is that VSCode's make extension, in order to determine some information about the project, runs
```
make --dry-run --always-make
```
which despite its name will actually try to remake the configure/* files. Running `installEpics.pl` on these will delete them first, then try copy them, resulting in an error.

Fixes #456 