### PR TITLE
allow macros with defaults in dbLoadRecords without substitutions

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -247,23 +247,23 @@ static long dbReadCOM(DBBASE **ppdbbase,const char *filename, FILE *fp,
     }
     my_buffer = dbCalloc(MY_BUFFER_SIZE,sizeof(char));
     freeListInitPvt(&freeListPvt,sizeof(tempListNode),100);
-    if(substitutions) {
-        if(macCreateHandle(&macHandle,NULL)) {
-            epicsPrintf("macCreateHandle error\n");
-            status = -1;
-            goto cleanup;
-        }
-        macParseDefns(macHandle,(char *)substitutions,&macPairs);
-        if(macPairs ==NULL) {
-            macDeleteHandle(macHandle);
-            macHandle = NULL;
-        } else {
-            macInstallMacros(macHandle,macPairs);
-            free((void *)macPairs);
-            mac_input_buffer = dbCalloc(MY_BUFFER_SIZE,sizeof(char));
-        }
-        macSuppressWarning(macHandle,dbQuietMacroWarnings);
+    if (substitutions == NULL)
+        substitutions = "";
+    if(macCreateHandle(&macHandle,NULL)) {
+        epicsPrintf("macCreateHandle error\n");
+        status = -1;
+        goto cleanup;
     }
+    macParseDefns(macHandle,substitutions,&macPairs);
+    if(macPairs == NULL) {
+        macDeleteHandle(macHandle);
+        macHandle = NULL;
+    } else {
+        macInstallMacros(macHandle,macPairs);
+        free(macPairs);
+        mac_input_buffer = dbCalloc(MY_BUFFER_SIZE,sizeof(char));
+    }
+    macSuppressWarning(macHandle,dbQuietMacroWarnings);
     pinputFile = dbCalloc(1,sizeof(inputFile));
     if (filename) {
         pinputFile->filename = macEnvExpand(filename);


### PR DESCRIPTION
A template file that only contains macros with default values can be loaded with `dbLoadRecords("file.db","")` but not with `dbLoadRecords("file.db",NULL)`. In particular, in the startup script, it cannot be loaded with `dbLoadRecords "file.db"` but only with `dbLoadRecords "file.db",""`. (VxWorks shell as well as iocsh.)

Using such a macro in a record name results in the error message:
```
ERROR: Bad character '$' in Record/Alias name "$(P=)Name"
```

Using macros with defaults in fields shows error messages like this:
```
ERRORName.PREC Has unexpanded macro
Can't set "Name.PREC" to "$(PREC=3)" : Bad Field value
ERRORERROR failed to load 'file.db'
```

(Unrelated: Someone please fix the missing blanks after ERROR and the ERRORERROR.)

The reason is that `dbReadCOM`, the function that does the real work, only creates a `macHandle` when `substitutions` is not `NULL`. Not having a `macHandle` prevents any macro substitution from working, even those which provide a default value.

In the old times, when macros could not have defaults, this was fine, but not any more. A macro handle should always be created, even if it stays empty when `substitutions` is `NULL`.

This PR fixes the problem by setting `substitutions` to `""` if it was `NULL`.