### PR TITLE
solving (recGblRecordError prints "ugly" messages) issue

### DIFF
--- a/modules/database/src/ioc/db/recGbl.c
+++ b/modules/database/src/ioc/db/recGbl.c
@@ -62,7 +62,7 @@ void recGblRecordError(long status, void *pdbc,
     dbCommon *precord = pdbc;
     char errMsg[256] = "";
 
-    if (status)
+    if ( status>0 )
         errSymLookup(status, errMsg, sizeof(errMsg));
 
     errlogPrintf("recGblRecordError: %s %s PV: %s\n",


### PR DESCRIPTION
modifying the condition from (status!=0) to (status>0) to skip the block in case the status variable ==-1