### PR TITLE
Fix off by one error in constant link fetch

### DIFF
--- a/modules/database/src/std/link/lnkConst.c
+++ b/modules/database/src/std/link/lnkConst.c
@@ -495,9 +495,11 @@ static long lnkConst_loadArray(struct link *plink, short dbrType, void *pbuffer,
         }
         else {
             /* Long string conversion */
-            strncpy(pbuffer, clink->value.scalar_string, *pnReq);
-            ((char *)pbuffer)[*pnReq] = 0;
-            nElems = strlen(pbuffer) + 1;
+            if (*pnReq > 0) {
+                strncpy(pbuffer, clink->value.scalar_string, *pnReq);
+                ((char *)pbuffer)[*pnReq - 1] = 0;
+                nElems = strlen(pbuffer) + 1;
+            }
             status = 0;
         }
         break;


### PR DESCRIPTION
For long string buffers, we currently write a null terminator one byte past the end of the buffer. This can be seen with a record of the type

```
record(aai, foo) {
  field(NELM, 1)
  field(FTVL, CHAR)
  field(INP, {const: "foo"})
}
```
where the buffer is only of size 1, but then we write at index 1 (aka past the end of the buffer).