### PR TITLE
Fix issue with compress record

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -22,6 +22,11 @@ should also be read to understand what has changed since earlier releases:
 
 ## Changes made on the 7.0 branch since 7.0.8
 
+### Fix issue with compress record
+
+In Base 7.0.8, an update to the compress record was added to allow for certain
+algorithms to use partially filled buffers in their computations. Unfortunately,
+this broke the behaviour of the records in certain cases. This has been fixed.
 
 -----
 


### PR DESCRIPTION
The handling of N-to-M array compression was broken with the addition of the partial buffer option, which broke the bounds check that was being used.

Note that this also makes the partial buffer option more consistent; if, for example, you have
```
record(compress, foo) {
  field(ALG, "N to 1 Average")
  field(INP, "bar NPP")
  field(NSAM, 2)
  field(N, 2)
  field(PBUF, YES)
}
```
(with bar having, e.g., length 3) then this will now behave as expected on both of the samples.