### PR TITLE
Memory leaks

### DIFF
--- a/modules/database/src/ioc/as/asCa.c
+++ b/modules/database/src/ioc/as/asCa.c
@@ -225,6 +225,11 @@ static void asCaTask(void)
         if(asCaDebug) printf("asCaTask has cleared all channels\n");
         epicsEventSignal(asCaTaskWait);
     }
+
+    /* ATM never reached, just a placeholder */
+    cantProceed("Unreachable.  Perpetual thread.");
+
+    taskwdRemove(0);
 }
 
 void asCaStart(void)

--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -748,6 +748,7 @@ void rsrv_init (void)
         if(!havesometcp)
             cantProceed("CAS: No TCP server started\n");
     }
+    free(socks);
 
     /* servers list is considered read-only from this point */
 

--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -120,6 +120,11 @@ static void req_server (void *pParm)
             }
         }
     }
+
+    /* ATM never reached, just a placeholder */
+    cantProceed("Unreachable.  Perpetual thread.");
+
+    taskwdRemove(0);
 }
 
 static

--- a/modules/database/src/ioc/rsrv/online_notify.c
+++ b/modules/database/src/ioc/rsrv/online_notify.c
@@ -129,7 +129,11 @@ void rsrv_online_notify_task(void *pParm)
         }
     }
 
+    /* ATM never reached, just a placeholder */
+    cantProceed("Unreachable.  Perpetual thread.");
+
     free(lastError);
+    taskwdRemove(0);
 }
 
 


### PR DESCRIPTION
While running valgrind, we saw reports of a few memory leaks. One of these is real, the other ones are somewhat fictitious. However, the allocation and cleanup of tasks on threads that have no exit condition is somewhat inconsistent, so this is an attempt to make it more future-proof and consistent.