### PR TITLE
Incompatible changes to asLib to fix type safety

### DIFF
--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -88,7 +88,7 @@ typedef struct rsrv_put_notify {
     long nRequest;
     short dbrType;
     /* end arguments for db_put_field */
-    void            * asWritePvt;
+    asTrapWrite     * asWritePvt;
     unsigned        valueSize; /* size of block pointed to by pbuffer */
     char            busy; /* put notify in progress */
     char            onExtraLaborQueue;
@@ -756,7 +756,7 @@ static int write_action ( caHdrLargeArray *mp,
     struct channel_in_use   *pciu;
     int                     status;
     long                    dbStatus;
-    void                    *asWritePvt;
+    asTrapWrite             *asWritePvt;
 
     pciu = MPTOPCIU(mp);
     if(!pciu){

--- a/modules/libcom/src/as/asLib.h
+++ b/modules/libcom/src/as/asLib.h
@@ -22,6 +22,8 @@
 extern "C" {
 #endif
 
+struct dbChannel;
+
 /* 0 - Use (unverified) client provided host name string.
  * 1 - Use actual client IP address.  HAG() are resolved to IPs at ACF load time.
  */
@@ -121,7 +123,7 @@ LIBCOM_API int epicsStdCall asDumpHash(void);
 LIBCOM_API int epicsStdCall asDumpHashFP(FILE *fp);
 
 LIBCOM_API void * epicsStdCall asTrapWriteBeforeWithData(
-    const char *userid, const char *hostid, void *addr,
+    const char *userid, const char *hostid, struct dbChannel *addr,
     int dbrType, int no_elements, void *data);
 
 LIBCOM_API void epicsStdCall asTrapWriteAfterWrite(void *pvt);

--- a/modules/libcom/src/as/asLib.h
+++ b/modules/libcom/src/as/asLib.h
@@ -122,11 +122,19 @@ LIBCOM_API int epicsStdCall asDumpMemFP(FILE *fp,const char *asgname,
 LIBCOM_API int epicsStdCall asDumpHash(void);
 LIBCOM_API int epicsStdCall asDumpHashFP(FILE *fp);
 
-LIBCOM_API void * epicsStdCall asTrapWriteBeforeWithData(
+/** \brief Handle for in progress asTrapWrite
+ *
+ * Returned by asTrapWriteBeforeWithData(), must be passed to asTrapWriteAfterWrite()
+ *
+ * \since UNRELEASED Previously was void
+ */
+typedef struct asTrapWrite asTrapWrite;
+
+LIBCOM_API struct asTrapWrite * epicsStdCall asTrapWriteBeforeWithData(
     const char *userid, const char *hostid, struct dbChannel *addr,
     int dbrType, int no_elements, void *data);
 
-LIBCOM_API void epicsStdCall asTrapWriteAfterWrite(void *pvt);
+LIBCOM_API void epicsStdCall asTrapWriteAfterWrite(struct asTrapWrite *pvt);
 
 #define S_asLib_clientsExist    (M_asLib| 1) /*Client Exists*/
 #define S_asLib_noUag           (M_asLib| 2) /*User Access Group does not exist*/

--- a/modules/libcom/src/as/asTrapWrite.c
+++ b/modules/libcom/src/as/asTrapWrite.c
@@ -44,7 +44,7 @@ typedef struct asTrapListener{
     void *pvt2;
 }listener;
 
-typedef struct writeMessage {
+typedef struct asTrapWrite {
     ELLNODE node;
     asTrapWriteMessage message;
     ELLLIST listenerPvtList;
@@ -141,7 +141,7 @@ void asTrapCallListener(const listener *plistener, asTrapWriteMessage* msg, int 
         (*plistener->func2)(plistener->pvt2, msg, after);
 }
 
-void * epicsStdCall asTrapWriteBeforeWithData(
+struct asTrapWrite * epicsStdCall asTrapWriteBeforeWithData(
     const char *userid, const char *hostid, struct dbChannel *addr,
     int dbrType, int no_elements, void *data)
 {
@@ -179,9 +179,8 @@ void * epicsStdCall asTrapWriteBeforeWithData(
     return pwriteMessage;
 }
 
-void epicsStdCall asTrapWriteAfterWrite(void *pvt)
+void epicsStdCall asTrapWriteAfterWrite(writeMessage *pwriteMessage)
 {
-    writeMessage *pwriteMessage = (writeMessage *)pvt;
     listenerPvt *plistenerPvt;
 
     if (pwriteMessage == 0 ||

--- a/modules/libcom/src/as/asTrapWrite.c
+++ b/modules/libcom/src/as/asTrapWrite.c
@@ -33,11 +33,11 @@
 
 typedef struct listenerPvt {
     ELLNODE node;
-    struct listener *plistener;
+    struct asTrapListener *plistener;
     void *userPvt;
 }listenerPvt;
 
-typedef struct listener{
+typedef struct asTrapListener{
     ELLNODE node;
     asTrapWriteListener func;
 }listener;
@@ -114,7 +114,7 @@ void epicsStdCall asTrapWriteUnregisterListener(asTrapWriteId id)
 }
 
 void * epicsStdCall asTrapWriteBeforeWithData(
-    const char *userid, const char *hostid, void *addr,
+    const char *userid, const char *hostid, struct dbChannel *addr,
     int dbrType, int no_elements, void *data)
 {
     writeMessage *pwriteMessage;

--- a/modules/libcom/src/as/asTrapWrite.h
+++ b/modules/libcom/src/as/asTrapWrite.h
@@ -26,6 +26,8 @@
 extern "C" {
 #endif
 
+struct dbChannel;
+
 /**
  * \brief The message passed to registered listeners.
  */
@@ -38,8 +40,13 @@ typedef struct asTrapWriteMessage {
      * server is forwarding the put requests. This pointer holds
      * the value the server provides to asTrapWriteWithData(), which
      * for RSRV is the dbChannel pointer for the target field.
+     *
+     * Valid during callback only.  Must not be access afterwards.
+     *
+     * \since UNRELEASED type changed from void* to dbChannel*
+     * \since 3.15.0.1 Storage pointed to changed from dbAddr to dbChannel
      */
-    void *serverSpecific;
+    struct dbChannel *serverSpecific;
     /** \brief A field for use by the \ref asTrapWriteListener.
      *
      * When the listener is called before the write, this has the
@@ -50,13 +57,18 @@ typedef struct asTrapWriteMessage {
     void *userPvt;
     int dbrType; /**< \brief Data type from ca/db_access.h, NOT dbFldTypes.h */
     int no_elements; /**< \brief Array length  */
-    void *data;     /**< \brief Might be NULL if no data is available */
+    const void *data;     /**< \brief Might be NULL if no data is available */
 } asTrapWriteMessage;
 
+/** \brief Type of identifier needed to unregister an listener.
+ * \since UNRELEASED Added
+ */
+struct asTrapListener;
 /**
  * \brief An identifier needed to unregister an listener.
+ * \since UNRELEASED Changed from void* to asTrapListener*
  */
-typedef void *asTrapWriteId;
+typedef struct asTrapListener *asTrapWriteId;
 
 /**
  * \brief Pointer to a listener function.

--- a/modules/libcom/src/as/asTrapWrite.h
+++ b/modules/libcom/src/as/asTrapWrite.h
@@ -85,6 +85,7 @@ typedef struct asTrapListener *asTrapWriteId;
  * or do anything that causes a delay.
 */
 typedef void(*asTrapWriteListener)(asTrapWriteMessage *pmessage,int after);
+typedef void(*asTrapWriteListener2)(void *pvt, const asTrapWriteMessage *pmessage,int after);
 
 /**
  * \brief Register function to be called on asTrapWriteListener.
@@ -93,6 +94,9 @@ typedef void(*asTrapWriteListener)(asTrapWriteMessage *pmessage,int after);
  */
 LIBCOM_API asTrapWriteId epicsStdCall asTrapWriteRegisterListener(
     asTrapWriteListener func);
+
+LIBCOM_API asTrapWriteId epicsStdCall asTrapWriteRegisterListener2(
+    asTrapWriteListener2 func, void *pvt);
 /**
  * \brief Unregister asTrapWriteListener.
  * \param id Listener identifier from asTrapWriteRegisterListener().


### PR DESCRIPTION
See #474.  A set of changes, some incompatible.  Grouped in rough order of increasing intrusiveness.

- `asTrapWriteRegisterListener()` safe lazy init with `epicsThreadOnce()`
- `asTrapWriteRegisterListener2()` constifed alternate version
- Typing
  - `dbChannel* asTrapWriteMessage::serverSpecific`.
  - `typedef struct asTrapListener *asTrapWriteId;`
  - `asTrapWriteBeforeWithData(..., dbChannel* addr, ...)`
  - `const void* asTrapWriteMessage::data`
    - Breaks caputLogger build.
- `asTrapWriteBeforeWithData()` and `asTrapWriteAfterWrite()` return `asTrapWrite*` instead of `void*`.
  - Breaks PVXS build
