### PR TITLE
Add makeBaseApp templateApp for instantiating site templates

### DIFF
--- a/src/template/base/Makefile
+++ b/src/template/base/Makefile
@@ -15,6 +15,22 @@ TEMPLATES += top/configure/RULES.ioc
 TEMPLATES += top/configure/RULES_DIRS
 TEMPLATES += top/configure/RULES_TOP
 
+# This is a template for a module that provides local templates.
+# It needs to install the TEMPLATES files named above into the
+# templateApp/top/... tree.
+SUBTEMPL := $(TEMPLATES)
+T_APP = top/templateApp
+SUBFILES = $(addprefix $(T_APP)/,$(SUBTEMPL))
+
+TEMPLATES += $(T_APP)/Makefile
+TEMPLATES += $(T_APP)/makeSiteApp@
+TEMPLATES += $(SUBFILES)
+
 SCRIPTS_HOST += makeBaseApp.pl
 
 include $(TOP)/configure/RULES
+
+$(addprefix $(INSTALL_TEMPLATES_SUBDIR)/,$(SUBFILES)): \
+    $(INSTALL_TEMPLATES_SUBDIR)/$(T_APP)/%: ../%
+	$(ECHO) "Installing $@"
+	@$(INSTALL) -d -m $(INSTALL_PERMISSIONS) $< $(@D)

--- a/src/template/base/top/templateApp/Makefile
+++ b/src/template/base/top/templateApp/Makefile
@@ -1,0 +1,30 @@
+TOP=..
+include $(TOP)/configure/CONFIG
+
+# Install the makeSiteApp script
+SCRIPTS_HOST += makeSiteApp
+EXPAND += makeSiteApp
+EXPAND_ME += EPICS_BASE
+EXPAND_VARS += MYTOP=$(abspath $(TOP))
+
+# Standard EPICS build files
+TEMPLATES_DIR = makeBaseApp
+
+TEMPLATES += top/Makefile
+TEMPLATES += top/.gitignore
+TEMPLATES += top/configure/CONFIG
+TEMPLATES += top/configure/CONFIG_SITE
+TEMPLATES += top/configure/Makefile
+TEMPLATES += top/configure/RELEASE
+TEMPLATES += top/configure/RULES
+TEMPLATES += top/configure/RULES.ioc
+TEMPLATES += top/configure/RULES_DIRS
+TEMPLATES += top/configure/RULES_TOP
+
+# Add your template files here like this:
+# TEMPLATES += top/xxxApp/Makefile
+# TEMPLATES += top/xxxApp/...
+
+
+include $(TOP)/configure/RULES
+

--- a/src/template/base/top/templateApp/makeSiteApp@
+++ b/src/template/base/top/templateApp/makeSiteApp@
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+#
+# Short-cut script to run makeBaseApp.pl with these local templates.
+# The installed version of this script can be put anywhere, it knows
+# the absolute paths to the modules it was configured with, i.e.:
+#   EPICS_BASE: @EPICS_BASE@
+#       MYTOP: @MYTOP@
+
+use strict;
+use File::Basename 'basename';
+
+my $tool = basename($0);
+my $mba = '@EPICS_BASE@/bin/@ARCH@/makeBaseApp.pl';
+my $templates = '@MYTOP@/templates/makeBaseApp/top';
+
+die "$tool: Can't find makeBaseApp.pl\n"
+    unless -x $mba;
+die "$tool: Can't find iocStd templates\n"
+    unless -d $templates;
+
+exec $mba, '-T', $templates, @ARGV;


### PR DESCRIPTION
This adds a new makeBaseApp template which when instantiated gives you an application to which you can add your own (or your site's) EPICS application templates. It installs a Perl script `makeSiteApp` into its own `bin/$EPICS_HOST_ARCH` directory which calls the `makeBaseApp.pl` script, but offering its own templates for instantiation instead of those from Base itself. Thus after instatiating this template you can add your own `*App` and `*Boot` template directories under the `src/template/base/top` directory, and edit the `src/template/base/top/templateApp/Makefile` and list the files to be copied.

Don't try to use this particular application to try and understand how to create templates, it's likely to be confusing since it's fairly self-referential; look at the other templates which come with Base and can be found in the `$EPICS_BASE/templates/makeBaseApp/top` directory.