### PR TITLE
Improve error message for mingw64 architecture

### DIFF
--- a/src/tools/EpicsHostArch.pl
+++ b/src/tools/EpicsHostArch.pl
@@ -53,11 +53,11 @@ sub HostArch {
             die "$0: macOS CPU type '$cpu' not recognized\n";
         }
         # mingw64 has 32bit and 64bit build shells which give same arch result
-        if (m/^x86_64-msys/ or m/^i686-msys/) {
-            die "$0: Architecture '$arch' ambiguous.\n".
-                "Rerun after typing one of the following:\n".
-                "    export EPICS_HOST_ARCH=windows-x64-mingw   # for 64bit build\n".
-                "    export EPICS_HOST_ARCH=win32-x86-mingw     # for 32bit build\n";
+        if (m/^(x86_64|i686)-msys/) {
+            die "$0: Architecture '$arch' is unclear,\n".
+                "try again after explicitly setting the EPICS_HOST_ARCH environment variable.\n".
+                "Use  EPICS_HOST_ARCH=windows-x64-mingw  for a 64bit MinGW build, or\n".
+                "EPICS_HOST_ARCH=win32-x86-mingw  for a 32bit MinGW build.\n"
         }
         die "$0: Architecture '$arch' not recognized\n";
     }

--- a/src/tools/EpicsHostArch.pl
+++ b/src/tools/EpicsHostArch.pl
@@ -52,7 +52,13 @@ sub HostArch {
             }
             die "$0: macOS CPU type '$cpu' not recognized\n";
         }
-
+        # mingw64 has 32bit and 64bit build shells which give same arch result
+        if (m/^x86_64-msys/ or m/^i686-msys/) {
+            die "$0: Architecture '$arch' ambiguous.\n".
+                "Rerun after typing one of the following:\n".
+                "    export EPICS_HOST_ARCH=windows-x64-mingw   # for 64bit build\n".
+                "    export EPICS_HOST_ARCH=win32-x86-mingw     # for 32bit build\n";
+        }
         die "$0: Architecture '$arch' not recognized\n";
     }
 }


### PR DESCRIPTION
As described in https://bugs.launchpad.net/epics-base/+bug/1873406 guessing the correct EPICS architecture for a MinGW system is not straightforward. Some suggestions are made there, it may also be possible to look at e.g. `gcc -v` to guess this based on its default target as to the best EPICS target. However in the meantime we will just print a better hint to the user as to how to resolve the situation.      