### PR TITLE
centralize -g flag for gnu targets

### DIFF
--- a/configure/CONFIG.gnuCommon
+++ b/configure/CONFIG.gnuCommon
@@ -27,13 +27,17 @@ RANLIB = $(GNU_BIN)/$(CMPLR_PREFIX)ranlib$(CMPLR_SUFFIX)
 ASAN_FLAGS_YES = -fsanitize=address
 ASAN_LDFLAGS_YES = $(ASAN_FLAGS_YES)
 
+# It makes sense to include debugging symbols even in optimized builds
+# in case you want to attach gdb to the process or examine a core-dump.
+# This does cost disk space, but not memory as debug symbols are not
+# loaded into RAM when the binary is loaded.
 PROF_CFLAGS_YES = -p
 GPROF_CFLAGS_YES = -pg
 CODE_CFLAGS = $(PROF_CFLAGS_$(PROFILE)) $(GPROF_CFLAGS_$(GPROF))
 CODE_CFLAGS += $(ASAN_FLAGS_$(ENABLE_ASAN))
 WARN_CFLAGS_YES = -Wall -Werror-implicit-function-declaration
 WARN_CFLAGS_NO = -w
-OPT_CFLAGS_YES = -O3
+OPT_CFLAGS_YES = -O3 -g
 OPT_CFLAGS_NO = -g
 
 PROF_CXXFLAGS_YES = -p
@@ -42,7 +46,7 @@ CODE_CXXFLAGS = $(PROF_CXXFLAGS_$(PROFILE)) $(GPROF_CXXFLAGS_$(GPROF))
 CODE_CXXFLAGS += $(ASAN_FLAGS_$(ENABLE_ASAN))
 WARN_CXXFLAGS_YES = -Wall
 WARN_CXXFLAGS_NO = -w
-OPT_CXXFLAGS_YES = -O3
+OPT_CXXFLAGS_YES = -O3 -g
 OPT_CXXFLAGS_NO = -g
 
 CODE_LDFLAGS = $(PROF_CXXFLAGS_$(PROFILE)) $(GPROF_CXXFLAGS_$(GPROF))

--- a/configure/os/CONFIG.Common.iosCommon
+++ b/configure/os/CONFIG.Common.iosCommon
@@ -42,12 +42,6 @@ ARCH_DEP_LDFLAGS += $(ARCH_DEP_FLAGS)
 OP_SYS_CFLAGS += -isysroot $(SDK_DIR)
 OP_SYS_LDFLAGS += -isysroot $(SDK_DIR)
 
-#--------------------------------------------------
-# Always compile in debugging symbol table information
-#
-OPT_CFLAGS_YES += -g
-OPT_CXXFLAGS_YES += -g
-
 #-------------------------------------------------------
 # Compiler definitions:
 

--- a/configure/os/CONFIG.darwinCommon.darwinCommon
+++ b/configure/os/CONFIG.darwinCommon.darwinCommon
@@ -40,12 +40,6 @@ OP_SYS_CFLAGS += -fno-common
 OP_SYS_CPPFLAGS += -Ddarwin
 
 #
-# Always compile in debugging symbol table information
-#
-OPT_CFLAGS_YES += -g
-OPT_CXXFLAGS_YES += -g
-
-#
 # Libraries for command-line editing.
 #
 LDLIBS_READLINE = -lreadline

--- a/configure/os/CONFIG_SITE.cygwin-x86.cygwin-x86
+++ b/configure/os/CONFIG_SITE.cygwin-x86.cygwin-x86
@@ -6,11 +6,3 @@
 #  GNU_DIR used when COMMANDLINE_LIBRARY is READLINE
 #GNU_DIR=C:/cygwin
 
-
-# It makes sense to include debugging symbols even in optimized builds
-# in case you want to attach gdb to the process or examine a core-dump.
-# This does cost disk space, but not memory as debug symbols are not
-# loaded into RAM when the binary is loaded.
-OPT_CFLAGS_YES += -g
-OPT_CXXFLAGS_YES += -g
-

--- a/configure/os/CONFIG_SITE.linux-aarch64.linux-aarch64
+++ b/configure/os/CONFIG_SITE.linux-aarch64.linux-aarch64
@@ -3,10 +3,3 @@
 # Site specific definitions for native linux-aarch64 builds
 #-------------------------------------------------------
 
-# It makes sense to include debugging symbols even in optimized builds
-# in case you want to attach gdb to the process or examine a core-dump.
-# This does cost disk space, but not memory as debug symbols are not
-# loaded into RAM when the binary is loaded.
-OPT_CFLAGS_YES += -g
-OPT_CXXFLAGS_YES += -g
-

--- a/configure/os/CONFIG_SITE.linux-x86.linux-x86
+++ b/configure/os/CONFIG_SITE.linux-x86.linux-x86
@@ -3,13 +3,6 @@
 # Site specific definitions for linux-x86 host - linux-x86 target builds
 #-------------------------------------------------------
 
-# It makes sense to include debugging symbols even in optimized builds
-# in case you want to attach gdb to the process or examine a core-dump.
-# This does cost disk space, but not memory as debug symbols are not
-# loaded into RAM when the binary is loaded.
-OPT_CFLAGS_YES += -g
-OPT_CXXFLAGS_YES += -g
-
 # Uncomment the followings lines to build with CLANG instead of GCC.
 #
 #GNU         = NO

--- a/configure/os/CONFIG_SITE.linux-x86_64.linux-x86_64
+++ b/configure/os/CONFIG_SITE.linux-x86_64.linux-x86_64
@@ -3,13 +3,6 @@
 # Site specific definitions for linux-x86_64 host - linux-x86_64 target builds
 #-------------------------------------------------------
 
-# It makes sense to include debugging symbols even in optimized builds
-# in case you want to attach gdb to the process or examine a core-dump.
-# This does cost disk space, but not memory as debug symbols are not
-# loaded into RAM when the binary is loaded.
-OPT_CFLAGS_YES += -g
-OPT_CXXFLAGS_YES += -g
-
 # Uncomment the followings lines to build with CLANG instead of GCC.
 #
 #GNU         = NO


### PR DESCRIPTION
Instead of adding `-g` to `OPT_CFLAGS_YES` and `OPT_CXXFLAGS_YES` for each architecture separately, it can be done once for all in CONFIG.gnuCommon.