### PR TITLE
Add `pushd`, `popd` and `dirs` commands for iocsh

### DIFF
--- a/modules/database/src/ioc/db/dbUnitTest.c
+++ b/modules/database/src/ioc/db/dbUnitTest.c
@@ -62,12 +62,10 @@ void testdbReadDatabase(const char* file,
         path = "." OSI_PATH_LIST_SEPARATOR ".." OSI_PATH_LIST_SEPARATOR
                 "../O.Common" OSI_PATH_LIST_SEPARATOR "O.Common";
     if(dbReadDatabase(&pdbbase, file, path, substitutions)) {
-        char buf[100];
-        const char *cwd = getcwd(buf, sizeof(buf));
-        if(!cwd)
-            cwd = "<directory too long>";
+        char *cwd = epicsGetCwd();
         testAbort("Failed to load test database\ndbReadDatabase(%s,%s,%s)\n from: \"%s\"",
-                  file, path, substitutions, cwd);
+                  file, path, substitutions, cwd ? cwd : "<directory too long>");
+        free(cwd);
     }
 }
 

--- a/modules/libcom/RTEMS/epicsMemFs.c
+++ b/modules/libcom/RTEMS/epicsMemFs.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <fcntl.h>
 
+#include "osiFileName.h"
 #include "epicsMemFs.h"
 
 #ifndef PATH_MAX
@@ -22,14 +23,13 @@
 
 int epicsMemFsLoad(const epicsMemFS *fs)
 {
-    char initdir[PATH_MAX];
+    char *startDir = NULL;
     const epicsMemFile * const *fileptr = fs->files;
 
-    if(getcwd(initdir, sizeof(initdir)-1)==NULL) {
-        perror("getcwd");
+    if((startDir = epicsGetCwd())==NULL) {
+        perror("epicsGetCwd");
         return errno;
     }
-    initdir[sizeof(initdir)-1] = '\0';
 
     for(;*fileptr; fileptr++) {
         const epicsMemFile *curfile = *fileptr;
@@ -40,9 +40,10 @@ int epicsMemFsLoad(const epicsMemFS *fs)
         /* jump back to the root each time,
          * slow but simple.
          */
-        if(chdir(initdir)) {
+        if(chdir(startDir)) {
             perror("chdir");
-            return errno;
+            free(startDir);
+            goto error;
         }
 
         printf("-> /");
@@ -58,17 +59,17 @@ int epicsMemFsLoad(const epicsMemFS *fs)
                 if(mkdir(*dir,0744)==-1) {
                     printf("\n");
                     perror("mkdir");
-                    return errno;
+                    goto error;
                 }
                 if(chdir(*dir)==-1) {
                     printf("\n");
                     perror("chdir2");
-                    return errno;
+                    goto error;
                 }
             } else if(ret==-1) {
                 printf("\n");
                 perror("chdir1");
-                return errno;
+                goto error;
             }
         }
 
@@ -85,7 +86,7 @@ int epicsMemFsLoad(const epicsMemFS *fs)
         if(fd==-1) {
             printf("\n");
             perror("open");
-            return errno;
+            goto error;
         }
 
         sofar = 0;
@@ -95,7 +96,7 @@ int epicsMemFsLoad(const epicsMemFS *fs)
             if(ret<=0) {
                 printf("\n");
                 perror("write");
-                return errno;
+                goto error;
             }
             sofar += ret;
         }
@@ -104,8 +105,11 @@ int epicsMemFsLoad(const epicsMemFS *fs)
         printf(" - ok\n");
     }
 
-    if(chdir(initdir))
+    if(chdir(startDir))
         perror("chdir");
 
     return 0;
+error:
+    free(startDir);
+    return errno;
 }

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -17,6 +17,8 @@
 #include <map>
 #include <string>
 #include <sstream>
+#include <list>
+#include <string>
 
 #include <stddef.h>
 #include <string.h>
@@ -38,6 +40,8 @@
 #include "registry.h"
 #include "epicsReadline.h"
 #include "cantProceed.h"
+#include "osiFileName.h"
+#include "osiUnistd.h"
 #include "iocsh.h"
 
 #include "epicsReadlinePvt.h"
@@ -988,9 +992,24 @@ struct iocshScope {
 
 // per thread executing iocshBody()
 struct iocshContext {
+    iocshContext() :
+        handle(NULL),
+        scope(NULL)
+    {
+    }
+
     MAC_HANDLE *handle;
     iocshScope *scope;
+    std::list<std::string> dirStack;
 };
+
+static iocshContext* iocshContextGet()
+{
+    iocshContext* ctxt = NULL;
+    if (iocshContextId)
+        ctxt = (iocshContext *) epicsThreadPrivateGet(iocshContextId);
+    return ctxt;
+}
 
 int iocshSetError(int err)
 {
@@ -1084,10 +1103,10 @@ iocshBody (const char *pathname, const char *commandLine, const char *macros)
     context = (iocshContext *) epicsThreadPrivateGet(iocshContextId);
 
     if (!context) {
-        context = (iocshContext*)calloc(1, sizeof(*context));
+        context = new (std::nothrow) iocshContext;
         if (!context || macCreateHandle(&context->handle, pairs)) {
             errlogMessage("iocsh: macCreateHandle failed.");
-            free(context);
+            delete context;
             return -1;
         }
 
@@ -1294,7 +1313,7 @@ iocshBody (const char *pathname, const char *commandLine, const char *macros)
 
     if (!scope.outer) {
         macDeleteHandle(handle);
-        free(context);
+        delete context;
         epicsThreadPrivateSet(iocshContextId, NULL);
     } else {
         context->scope = scope.outer;
@@ -1545,6 +1564,96 @@ static void onCallFunc(const iocshArgBuf *args)
 #undef USAGE
 }
 
+/* pushd */
+static const iocshArg pushdArg0 = {"dir", iocshArgString};
+static const iocshArg* const pushdArgs[1] = {&pushdArg0};
+static const iocshFuncDef pushdFuncDef = {"pushd", 1, pushdArgs,
+                                         "Pushes the current directory to the directory stack and changes to the specified directory"};
+
+static void pushdCallFunc(const iocshArgBuf* args)
+{
+    if (!args[0].sval) {
+        iocshSetError(-1);
+        fprintf(stderr, "Missing required argument: dir\n");
+        return;
+    }
+
+    iocshContext* ctxt = iocshContextGet();
+    if (!ctxt) {
+        iocshSetError(-1);
+        return;
+    }
+
+    char* cwd = epicsGetCwd();
+    if (!cwd) {
+        iocshSetError(-1);
+        fprintf(stderr, "epicsGetCwd() failed\n");
+        return;
+    }
+
+    if (iocshSetError(chdir(args[0].sval)) != 0) {
+        fprintf(stderr, "Invalid directory path\n");
+        iocshSetError(-1);
+    }
+    else {
+        ctxt->dirStack.push_front(cwd);
+    }
+
+    free(cwd);
+}
+
+/* popd */
+static const iocshFuncDef popdFuncDef = {"popd", 0, NULL,
+                                         "Pops the top off of the directory stack and changes to that directory"};
+
+static void popdCallFunc(const iocshArgBuf* args)
+{
+    iocshContext* ctxt = iocshContextGet();
+    if (!ctxt) {
+        iocshSetError(-1);
+        return;
+    }
+
+    if (ctxt->dirStack.size() <= 0) {
+        fprintf(stderr, "Directory stack is empty.\n");
+        return;
+    }
+
+    if (iocshSetError(chdir(ctxt->dirStack.front().c_str())) != 0) {
+        fprintf(stderr, "Invalid directory path\n");
+        iocshSetError(-1);
+    }
+    ctxt->dirStack.pop_front();
+}
+
+/* dirs */
+static const iocshFuncDef dirsFuncDef = {"dirs", 0, NULL,
+                                         "Displays the contents of the directory stack, including current directory on top"};
+
+static void dirsCallFunc(const iocshArgBuf* args)
+{
+    iocshContext* ctxt = iocshContextGet();
+    if (!ctxt) {
+        iocshSetError(-1);
+        return;
+    }
+
+    char* cwd = epicsGetCwd();
+    if (!cwd) {
+        fprintf(stderr, "epicsGetCwd() failed\n");
+        iocshSetError(-1);
+        return;
+    }
+
+    puts(cwd);
+
+    for (std::list<std::string>::iterator it = ctxt->dirStack.begin(); it != ctxt->dirStack.end(); ++it) {
+        puts(it->c_str());
+    }
+
+    free(cwd);
+}
+
 /*
  * Dummy internal commands -- register and install in command table
  * so they show up in the help display
@@ -1579,6 +1688,9 @@ static void iocshOnce (void *)
     iocshRegisterImpl(&iocshLoadFuncDef,iocshLoadCallFunc);
     iocshRegisterImpl(&iocshRunFuncDef,iocshRunCallFunc);
     iocshRegisterImpl(&onFuncDef, onCallFunc);
+    iocshRegisterImpl(&pushdFuncDef, pushdCallFunc);
+    iocshRegisterImpl(&popdFuncDef, popdCallFunc);
+    iocshRegisterImpl(&dirsFuncDef, dirsCallFunc);
     iocshTableUnlock();
 }
 

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -27,27 +27,21 @@
 #include "epicsGeneralTime.h"
 #include "freeList.h"
 #include "libComRegister.h"
+#include "osiFileName.h"
 
 /* Register the PWD environment variable when the cd IOC shell function is
  * registered. This variable contains the current directory path.
  */
 static void updatePWD() {
     static int lasterror;
-    char buf[1024];
-    char *pwd = getcwd(buf, sizeof(buf));
+    char *pwd = epicsGetCwd();
     if (pwd) {
-        pwd[sizeof(buf) - 1] = '\0';
         lasterror = 0;
-        epicsEnvSet("PWD", buf);
+        epicsEnvSet("PWD", pwd);
     } else {
         if(lasterror!=errno) {
             lasterror = errno;
-            if (errno == ERANGE) {
-                fprintf(stderr, "Warning: Current path exceeds %u characters\n",
-                                                              (unsigned)sizeof(buf));
-            } else {
-                perror("getcwd");
-            }
+            perror("getcwd");
             fprintf(stderr, "Warning: Unable to update $PWD\n");
         }
     }
@@ -118,12 +112,10 @@ static const iocshFuncDef pwdFuncDef = {"pwd", 0, 0,
                                         "Print name of current/working directory\n"};
 static void pwdCallFunc (const iocshArgBuf *args)
 {
-    char buf[1024];
-    char *pwd = getcwd ( buf, sizeof(buf) );
-    if ( pwd ) {
-        buf[sizeof(buf)-1u] = '\0';
-        printf ( "%s\n", pwd );
-    }
+    char *pwd = epicsGetCwd();
+    if ( pwd )
+        puts(pwd);
+    free(pwd);
 }
 
 /* epicsEnvSet */

--- a/modules/libcom/src/osi/Makefile
+++ b/modules/libcom/src/osi/Makefile
@@ -130,6 +130,7 @@ Com_SRCS += osdProcess.c
 Com_SRCS += osdNetIntf.c
 Com_SRCS += osdMessageQueue.c
 Com_SRCS += osdgetexec.c
+Com_SRCS += osdgetcwd.c
 
 Com_SRCS += devLibVME.c
 Com_SRCS += devLibVMEOSD.c

--- a/modules/libcom/src/osi/os/WIN32/osdgetcwd.c
+++ b/modules/libcom/src/osi/os/WIN32/osdgetcwd.c
@@ -1,0 +1,14 @@
+/*************************************************************************\
+* Copyright (c) 2025 Stanford University / SLAC National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+#include "osiFileName.h"
+
+#include <direct.h>
+
+char *epicsGetCwd(void)
+{
+    return _getcwd(NULL, 0);
+}

--- a/modules/libcom/src/osi/os/default/osdgetcwd.c
+++ b/modules/libcom/src/osi/os/default/osdgetcwd.c
@@ -1,0 +1,14 @@
+/*************************************************************************\
+* Copyright (c) 2025 Stanford University / SLAC National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+#include "osiFileName.h"
+
+#include <unistd.h>
+
+char *epicsGetCwd(void)
+{
+    return getcwd(NULL, 0);
+}

--- a/modules/libcom/src/osi/os/vxWorks/osdgetcwd.c
+++ b/modules/libcom/src/osi/os/vxWorks/osdgetcwd.c
@@ -1,0 +1,21 @@
+/*************************************************************************\
+* Copyright (c) 2025 Stanford University / SLAC National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+#include "osiFileName.h"
+
+#include <stddef.h>
+#include <ioLib.h>
+
+char *epicsGetCwd(void)
+{
+    char *buf, *ret;
+    buf = malloc(MAX_FILENAME_LENGTH+1);
+    buf[MAX_FILENAME_LENGTH] = 0;
+    if ((ret = getcwd(buf)))
+        return ret;
+    free(buf);
+    return NULL;
+}

--- a/modules/libcom/src/osi/osiFileName.h
+++ b/modules/libcom/src/osi/osiFileName.h
@@ -40,6 +40,11 @@ char *epicsGetExecName(void);
 LIBCOM_API
 char *epicsGetExecDir(void);
 
+/** Return the absolute path of the current working directory
+ \return NULL or the path.  Caller must free(). May return NULL if out of memory  */
+LIBCOM_API
+char *epicsGetCwd(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
These are simplified versions of the bash equivalents detailed here: https://www.gnu.org/software/bash/manual/html_node/Directory-Stack-Builtins.html

`pushd` is used like `pushd path/to/my/directory`, and takes no other arguments or flags.

`popd` takes no arguments and removes the top item from the directory stack.

`dirs` shows the entire directory stack with the current working directory on top. Even if the stack is empty, `dirs` will still display the cwd.

I also used struct hack in the `dirStackEntry` structure. This is standard in C99, but was provided as a compiler extension prior to then. GCC as far back as 3.4.6 (at least) seems to [support this without issue](https://godbolt.org/z/94jEMTsd6). That being said, I don't know what support for these is like in Visual Studio. Everything that I can find seems to indicate that it's been supported since at least 2012. We'll see what Appveyor says :) 
According to the Microsoft docs, flexible arrays are available as long as Microsoft extensions are enabled (i.e. `/permissive-` and `/Za` are *not* set).

Closes #494 