### PR TITLE
caget now can bring values from multiple PVs even when some are disconnected

### DIFF
--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -37,8 +37,6 @@
 #include <epicsGetopt.h>
 #include "epicsVersion.h"
 #include "epicsMutex.h"
-#include "epicsExit.h"
-#include "epicsSpin.h"
 
 #include "tool_lib.h"
 

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -368,8 +368,7 @@ static int caget (pv pv_data, RequestT request, OutputT format,
     default :
         break;
     }
-    free(pvs_data.value);
-    }
+    free(pv_data.value);
 
     epicsMutexUnlock(printMutex);
 

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -24,6 +24,9 @@
  *     Added field separators
  *  2009/04/01 Ralph Lange (HZB/BESSY)
  *     Added support for long strings (array of char) and quoting of nonprintable characters
+ *  2026/02/26 Marcio Donadio (SLAC)
+ *     caget now operates wiht more threads and retrieves values or "PV not found" messages
+ *     for all PVs in the argument list instead of failing after the first PV is not found.
  *
  */
 
@@ -53,7 +56,8 @@ typedef enum { plain, terse, all, specifiedDbr } OutputT;
 /* Different request types */
 typedef enum { get, callback } RequestT;
 
-// Struct to hold data used by caget threads
+// Struct to hold data used by caget threads.
+// This is sent via the EPICS message queue mechanism.
 typedef struct
 {
     pv pv_data;
@@ -63,15 +67,24 @@ typedef struct
     unsigned long reqElems;
     epicsMutexId printMutex;
     epicsMutexId resultMutex;
-    epicsMessageQueueId queueId;
     int totalNumberOfPvs;
 } t_thread_data;
+
+// Struct to hold data used only during thread initialization
+typedef struct
+{
+    epicsMessageQueueId queueId;
+    struct ca_client_context* ca_context;
+
+} t_init_thread;
 
 static int nConn = 0;           /* Number of connected PVs */
 static int nRead = 0;           /* Number of channels that were read */
 static int floatAsString = 0;   /* Flag: fetch floats as string */
 static int pvs_with_trouble = 0; /* Counter for PVs with result not zero */
-static int completedPVs = 0;
+static int completedPVs = 0; /* Number of PVs already processed */
+static epicsMessageQueueId queueId; /* Transfers PV data from one producer to several consumer threads */
+static struct ca_client_context* ca_context; /* Unique CA context for all threads */
 
 static void usage (void)
 {
@@ -401,16 +414,27 @@ void thread_name (int index, char* th_name) {
 }
 
 // Function that runs inside each thread, calling the caget function
-void caget_caller (void* queueId_void)
+void caget_caller (void* init_thread_void)
 {
     int result;                 /* CA result */
     t_thread_data thread_data;
+    t_init_thread* init_thread = (t_init_thread*) init_thread_void;
 
-    epicsMessageQueueId queueId = (epicsMessageQueueId) queueId_void;
+    // Attach to the CA context created by the main thread
+    //struct ca_client_context* ca_context = malloc(sizeof(struct ca_client_context*)); 
+    //memcpy (ca_context, init_thread->ca_context, sizeof(struct ca_client_context));
+    //ca_context_status(ca_context, 1);
+    result = ca_attach_context(ca_context);
+    if (result != ECA_NORMAL) {
+        fprintf(stderr, "CA error %s occurred while trying "
+                "to attach to channel access context.\n", ca_message(result));
+        return;
+    }
+
+    //epicsMessageQueueId queueId = (epicsMessageQueueId) queueId_void;
 
     while(true) {
         if (epicsMessageQueueReceiveWithTimeout(queueId, &thread_data, sizeof(t_thread_data), 0.1) > 0) {
-            //t_thread_data* thread_data = (t_thread_data*)thread_data_void;
             result = connect_pvs(&thread_data.pv_data, 1);
 
                                         /* Read and print data */
@@ -418,21 +442,21 @@ void caget_caller (void* queueId_void)
                 result = caget(thread_data.pv_data, thread_data.request, thread_data.format, thread_data.dbrType, thread_data.reqElems, thread_data.printMutex);
 
             epicsMutexLock(thread_data.resultMutex);
-            pvs_with_trouble += result;
+            pvs_with_trouble += result ? 1 : 0;
             ++completedPVs;
             epicsMutexUnlock(thread_data.resultMutex);
         }
 
+        // All PVs processed; there's nothing else expected to arrive in the queue
         if (completedPVs >= thread_data.totalNumberOfPvs) {
+            //ca_detach_context();
             break;
         }
     }
-
-    //free(thread_data);
 }
 
 // Creates the threads that will read from the message queue
-void thread_builder (epicsMessageQueueId queueId, int index)
+void thread_builder (t_init_thread init_thread, int index)
 {
     char th_name[9];
     thread_name(index, th_name);
@@ -440,7 +464,7 @@ void thread_builder (epicsMessageQueueId queueId, int index)
     // Must be joinable so the main thread can wait for all the threads to
     // complete their job.
     thread_opts.joinable = 1;
-    epicsThreadCreateOpt(th_name, &caget_caller, queueId, &thread_opts);
+    epicsThreadCreateOpt(th_name, &caget_caller, &init_thread, &thread_opts);
 }
 
 
@@ -617,14 +641,16 @@ int main (int argc, char *argv[])
         fprintf(stderr, "No pv name specified. ('caget -h' for help.)\n");
         return 3;
     }
-                                /* Start up Channel Access */
+                                /* sTart up Channel Access */
 
-    result = ca_context_create(ca_disable_preemptive_callback);
+    result = ca_context_create(ca_enable_preemptive_callback);
     if (result != ECA_NORMAL) {
         fprintf(stderr, "CA error %s occurred while trying "
                 "to start channel access.\n", ca_message(result));
         return 3;
     }
+    // Global variable to be used by all threads
+    ca_context = ca_current_context();
                                 /* Allocate PV structure array */
 
     pvs = calloc (nPvs, sizeof(pv));
@@ -642,9 +668,10 @@ int main (int argc, char *argv[])
     epicsMutexId printMutex = epicsMutexCreate();
     // Mutex to access result counter
     epicsMutexId resultMutex = epicsMutexCreate();
+    // Global variable
+    queueId = epicsMessageQueueCreate(QUEUE_CAPACITY, sizeof(t_thread_data));
 
-    epicsMessageQueueId queueId = epicsMessageQueueCreate(QUEUE_CAPACITY, sizeof(t_thread_data));
-
+    // We use up to NUMBER_OF_THREADS threads
     int number_of_threads;
     if (nPvs > NUMBER_OF_THREADS) {
         number_of_threads = NUMBER_OF_THREADS;
@@ -652,10 +679,17 @@ int main (int argc, char *argv[])
         number_of_threads = nPvs;
     }
 
+    // Prepare data used during thread initialization
+    t_init_thread init_thread;
+    //init_thread.queueId = queueId;
+
+    // Build and start all threads that will consume the message queue
     for (int iii=0; iii<number_of_threads; ++iii) {
-        thread_builder(queueId, iii);
+        thread_builder(init_thread, iii);
     }
 
+    // Fill the message queue with thread_data messages.
+    // Blocks if maximum capacity of queue is achieved.
     for (int iii=0; iii<nPvs; ++iii) {
         t_thread_data* thread_data;
         thread_data = malloc(sizeof(t_thread_data));
@@ -666,19 +700,17 @@ int main (int argc, char *argv[])
         thread_data->reqElems = count;
         thread_data->printMutex = printMutex;
         thread_data->resultMutex = resultMutex;
-        thread_data->queueId = queueId;
         thread_data->totalNumberOfPvs = nPvs;
         epicsMessageQueueSend(queueId, thread_data, sizeof(t_thread_data));
     }
-
-    epicsThreadId thread_id;
-    char th_name[9];
 
     // Wait for all threads to consume the queue before ending the main thread
     while (epicsMessageQueuePending(queueId)) {
         epicsThreadSleep(0.1);
     }
 
+    epicsThreadId thread_id;
+    char th_name[9];
     // Make sure the threads ended up their processing
     for (int iii=0; iii<number_of_threads; ++iii) {
         thread_name(iii, th_name);

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -384,15 +384,6 @@ static void complainIfNotPlainAndSet (OutputT *current, const OutputT requested)
                 "('caget -h' for help.)\n");
     *current = requested;
 }
-/*
-void test(void* thread_data_void) {
-printf("called\n");
-    //t_thread_data* thread_data = (t_thread_data*)thread_data_void;
-    //epicsSpinLock(thread_data->spin);
-    //epicsMutexUnlock(thread_data->printMutex_lock_main);
-printf("End of test\n");
-}
-*/
 
 // Create a thread name based on the PV index in the order sent as argument for caget
 void thread_name (int pv_num, char* th_name) {

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -230,7 +230,7 @@ static int caget (pv pv_data, RequestT request, OutputT format,
                 epicsMutexLock(printMutex);
                 fprintf(stderr,"Memory allocation failed\n");
                 epicsMutexUnlock(printMutex);
-                return 1;
+                return 3;
             }
             result = ca_array_get(pv_data.dbrType,
                                   pv_data.nElems,
@@ -242,7 +242,7 @@ static int caget (pv pv_data, RequestT request, OutputT format,
         pv_data.status = ECA_DISCONN;
     }
 
-    if (!nConn) return 1;              /* No connection? We're done. */
+    if (!nConn) return 3;              /* No connection? We're done. */
 
                                 /* Wait for completion */
                                 /* ------------------- */
@@ -598,15 +598,15 @@ int main (int argc, char *argv[])
             fprintf(stderr,
                     "Unrecognized option: '-%c'. ('caget -h' for help.)\n",
                     optopt);
-            return -1;
+            return 3;
         case ':':
             fprintf(stderr,
                     "Option '-%c' requires an argument. ('caget -h' for help.)\n",
                     optopt);
-            return -1;
+            return 3;
         default :
             usage();
-            return -1;
+            return 3;
         }
     }
 
@@ -615,7 +615,7 @@ int main (int argc, char *argv[])
     if (nPvs < 1)
     {
         fprintf(stderr, "No pv name specified. ('caget -h' for help.)\n");
-        return -1;
+        return 3;
     }
                                 /* Start up Channel Access */
 
@@ -623,7 +623,7 @@ int main (int argc, char *argv[])
     if (result != ECA_NORMAL) {
         fprintf(stderr, "CA error %s occurred while trying "
                 "to start channel access.\n", ca_message(result));
-        return -1;
+        return 3;
     }
                                 /* Allocate PV structure array */
 
@@ -631,7 +631,7 @@ int main (int argc, char *argv[])
     if (!pvs)
     {
         fprintf(stderr, "Memory allocation for channel structures failed.\n");
-        return -1;
+        return 3;
     }
                                 /* Connect channels */
 
@@ -674,7 +674,12 @@ int main (int argc, char *argv[])
     epicsThreadId thread_id;
     char th_name[9];
 
-    // Wait for all threads to finish their business before ending the main thread
+    // Wait for all threads to consume the queue before ending the main thread
+    while (epicsMessageQueuePending(queueId)) {
+        epicsThreadSleep(0.1);
+    }
+
+    // Make sure the threads ended up their processing
     for (int iii=0; iii<number_of_threads; ++iii) {
         thread_name(iii, th_name);
         thread_id = epicsThreadGetId(th_name);
@@ -688,5 +693,18 @@ int main (int argc, char *argv[])
     epicsMutexDestroy(resultMutex);
     epicsMessageQueueDestroy(queueId);
 
-    return pvs_with_trouble;
+    /*
+    0: success
+    1: some channels not found
+    2: all channels not found
+    3: other error
+    */
+
+    if (pvs_with_trouble == nPvs)
+        return 2;
+
+    if (pvs_with_trouble != 0)
+        return 1;
+
+    return 0;
 }

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -36,6 +36,9 @@
 #include <cadef.h>
 #include <epicsGetopt.h>
 #include "epicsVersion.h"
+#include "epicsMutex.h"
+#include "epicsExit.h"
+#include "epicsSpin.h"
 
 #include "tool_lib.h"
 
@@ -48,11 +51,23 @@ typedef enum { plain, terse, all, specifiedDbr } OutputT;
 /* Different request types */
 typedef enum { get, callback } RequestT;
 
+// Struct to hold data used by caget threads
+typedef struct
+{
+    pv pv_data;
+    RequestT request;
+    OutputT format;
+    chtype dbrType;
+    unsigned long reqElems;
+    epicsMutexId printMutex;
+    epicsMutexId resultMutex;
+} t_thread_data;
+
 static int nConn = 0;           /* Number of connected PVs */
 static int nRead = 0;           /* Number of channels that were read */
 static int floatAsString = 0;   /* Flag: fetch floats as string */
+static int pvs_with_trouble = 0; /* Counter for PVs with result not zero */
 
-
 static void usage (void)
 {
     fprintf (stderr, "\nUsage: caget [options] <PV name> ...\n\n"
@@ -107,7 +122,6 @@ static void usage (void)
 }
 
 
-
 /*+**************************************************************************
  *
  * Function:    event_handler
@@ -135,7 +149,6 @@ static void event_handler (evargs args)
 }
 
 
-
 /*+**************************************************************************
  *
  * Function:    caget
@@ -143,92 +156,100 @@ static void event_handler (evargs args)
  * Description: Issue read requests, wait for incoming data
  *              and print the data according to the selected format
  *
- * Arg(s) In:   pvs       -  Pointer to an array of pv structures
- *              nPvs      -  Number of elements in the pvs array
+ * Arg(s) In:   pv_data   -  pv structure
  *              request   -  Request type
  *              format    -  Output format
  *              dbrType   -  Requested dbr type
  *              reqElems  -  Requested number of (array) elements
+ *              printMutex     -  Mutex to avoid commingling of outputs from several PVs
  *
  * Return(s):   Error code: 0 = OK, 1 = Error
  *
  **************************************************************************-*/
 
-static int caget (pv *pvs, int nPvs, RequestT request, OutputT format,
-           chtype dbrType, unsigned long reqElems)
+static int caget (pv pv_data, RequestT request, OutputT format,
+           chtype dbrType, unsigned long reqElems, epicsMutexId printMutex)
 {
     unsigned int i;
     int n, result;
 
-    for (n = 0; n < nPvs; n++) {
-        unsigned long nElems;
+    unsigned long nElems;
 
-                                /* Set up pvs structure */
-                                /* -------------------- */
+                        /* Set up pv_data structure */
+                        /* -------------------- */
 
-                                /* Get natural type and array count */
-        nElems         = ca_element_count(pvs[n].chid);
-        pvs[n].dbfType = ca_field_type(pvs[n].chid);
-        pvs[n].dbrType = dbrType;
+    /* Get natural type and array count */
+    nElems         = ca_element_count(pv_data.chid);
+    pv_data.dbfType = ca_field_type(pv_data.chid);
+    pv_data.dbrType = dbrType;
 
-                                /* Set up value structures */
-        if (format != specifiedDbr)
+    /* Set up value structures */
+    if (format != specifiedDbr)
+    {
+        pv_data.dbrType = dbf_type_to_DBR_TIME(pv_data.dbfType); /* Use native type */
+        if (dbr_type_is_ENUM(pv_data.dbrType))                  /* Enums honour -n option */
         {
-            pvs[n].dbrType = dbf_type_to_DBR_TIME(pvs[n].dbfType); /* Use native type */
-            if (dbr_type_is_ENUM(pvs[n].dbrType))                  /* Enums honour -n option */
-            {
-                if (enumAsNr) pvs[n].dbrType = DBR_TIME_INT;
-                else          pvs[n].dbrType = DBR_TIME_STRING;
-            }
-            else if (floatAsString &&
-                     (dbr_type_is_FLOAT(pvs[n].dbrType) || dbr_type_is_DOUBLE(pvs[n].dbrType)))
-            {
-                pvs[n].dbrType = DBR_TIME_STRING;
-            }
+            if (enumAsNr) pv_data.dbrType = DBR_TIME_INT;
+            else          pv_data.dbrType = DBR_TIME_STRING;
         }
-
-                                /* Issue CA request */
-                                /* ---------------- */
-
-        if (ca_state(pvs[n].chid) == cs_conn)
+        else if (floatAsString &&
+                 (dbr_type_is_FLOAT(pv_data.dbrType) || dbr_type_is_DOUBLE(pv_data.dbrType)))
         {
-            nConn++;
-            pvs[n].onceConnected = 1;
-            if (request == callback)
-            {
-                /* Event handler will allocate value and set nElems */
-                pvs[n].reqElems = reqElems > nElems ? nElems : reqElems;
-                result = ca_array_get_callback(pvs[n].dbrType,
-                                               pvs[n].reqElems,
-                                               pvs[n].chid,
-                                               event_handler,
-                                               &pvs[n]);
-            } else {
-                /* We allocate value structure and set nElems */
-                pvs[n].nElems = reqElems && reqElems < nElems ? reqElems : nElems;
-                pvs[n].value = calloc(1, dbr_size_n(pvs[n].dbrType, pvs[n].nElems));
-                if (!pvs[n].value) {
-                    fprintf(stderr,"Memory allocation failed\n");
-                    return 1;
-                }
-                result = ca_array_get(pvs[n].dbrType,
-                                      pvs[n].nElems,
-                                      pvs[n].chid,
-                                      pvs[n].value);
-            }
-            pvs[n].status = result;
-        } else {
-            pvs[n].status = ECA_DISCONN;
+            pv_data.dbrType = DBR_TIME_STRING;
         }
     }
+
+                        /* Issue CA request */
+                        /* ---------------- */
+
+    if (ca_state(pv_data.chid) == cs_conn)
+    {
+        nConn++;
+        pv_data.onceConnected = 1;
+        if (request == callback)
+        {
+            /* Event handler will allocate value and set nElems */
+            pv_data.reqElems = reqElems > nElems ? nElems : reqElems;
+            result = ca_array_get_callback(pv_data.dbrType,
+                                           pv_data.reqElems,
+                                           pv_data.chid,
+                                           event_handler,
+                                           &pv_data);
+        } else {
+            /* We allocate value structure and set nElems */
+            pv_data.nElems = reqElems && reqElems < nElems ? reqElems : nElems;
+            pv_data.value = calloc(1, dbr_size_n(pv_data.dbrType, pv_data.nElems));
+            if (!pv_data.value) {
+                // Lock printMutex before printing to avoid having multiple
+                // threads printing at the same time
+                epicsMutexLock(printMutex);
+                fprintf(stderr,"Memory allocation failed\n");
+                epicsMutexUnlock(printMutex);
+                return 1;
+            }
+            result = ca_array_get(pv_data.dbrType,
+                                  pv_data.nElems,
+                                  pv_data.chid,
+                                  pv_data.value);
+        }
+        pv_data.status = result;
+    } else {
+        pv_data.status = ECA_DISCONN;
+    }
+
     if (!nConn) return 1;              /* No connection? We're done. */
 
                                 /* Wait for completion */
                                 /* ------------------- */
 
     result = ca_pend_io(caTimeout);
-    if (result == ECA_TIMEOUT)
+    if (result == ECA_TIMEOUT) {
+        // Lock printMutex before printing to avoid having multiple
+        // threads printing at the same time
+        epicsMutexLock(printMutex);
         fprintf(stderr, "Read operation timed out: some PV data was not read.\n");
+        epicsMutexUnlock(printMutex);
+    }
 
     if (request == callback)    /* Also wait for callbacks */
     {
@@ -240,8 +261,13 @@ static int caget (pv *pvs, int nPvs, RequestT request, OutputT format,
                 ca_pend_event(slice);
                 if (nRead >= nConn) break;
             }
-            if (nRead < nConn)
+            if (nRead < nConn) {
+                // Lock printMutex before printing to avoid having multiple
+                // threads printing at the same time
+                epicsMutexLock(printMutex);
                 fprintf(stderr, "Read operation timed out: some PV data was not read.\n");
+                epicsMutexUnlock(printMutex);
+            }
         } else {
             /* For 0 timeout keep waiting until all are done */
             while (nRead < nConn) {
@@ -250,29 +276,76 @@ static int caget (pv *pvs, int nPvs, RequestT request, OutputT format,
         }
     }
 
-                                /* Print the data */
-                                /* -------------- */
+                            /* Print the data */
+                            /* -------------- */
 
-    for (n = 0; n < nPvs; n++) {
-
-        switch (format) {
-        case plain:             /* Emulate old caget behavior */
-            if (pvs[n].nElems <= 1 && fieldSeparator == ' ') printf("%-30s", pvs[n].name);
-            else                                               printf("%s", pvs[n].name);
-            printf("%c", fieldSeparator);
-        case terse:
-            if (pvs[n].status == ECA_DISCONN)
-                printf("*** not connected\n");
-            else if (pvs[n].status == ECA_NORDACCESS)
-                printf("*** no read access\n");
-            else if (pvs[n].status != ECA_NORMAL)
-                printf("*** CA error %s\n", ca_message(pvs[n].status));
-            else if (pvs[n].value == 0)
-                printf("*** no data available (timeout)\n");
-            else
-            {
-                if (charArrAsStr && dbr_type_is_CHAR(pvs[n].dbrType) && (reqElems || pvs[n].nElems > 1)) {
-                    dbr_char_t *s = (dbr_char_t*) dbr_value_ptr(pvs[n].value, pvs[n].dbrType);
+    // Lock printMutex before printing to avoid having multiple
+    // threads printing at the same time
+    epicsMutexLock(printMutex);
+    switch (format) {
+    case plain:             /* Emulate old caget behavior */
+        if (pv_data.nElems <= 1 && fieldSeparator == ' ') printf("%-30s", pv_data.name);
+        else                                               printf("%s", pv_data.name);
+        printf("%c", fieldSeparator);
+    case terse:
+        if (pv_data.status == ECA_DISCONN)
+            printf("*** not connected\n");
+        else if (pv_data.status == ECA_NORDACCESS)
+            printf("*** no read access\n");
+        else if (pv_data.status != ECA_NORMAL)
+            printf("*** CA error %s\n", ca_message(pv_data.status));
+        else if (pv_data.value == 0)
+            printf("*** no data available (timeout)\n");
+        else
+        {
+            if (charArrAsStr && dbr_type_is_CHAR(pv_data.dbrType) && (reqElems || pv_data.nElems > 1)) {
+                dbr_char_t *s = (dbr_char_t*) dbr_value_ptr(pv_data.value, pv_data.dbrType);
+                int dlen = epicsStrnEscapedFromRawSize((char*)s, strlen((char*)s));
+                char *d = calloc(dlen+1, sizeof(char));
+                if(d) {
+                    epicsStrnEscapedFromRaw(d, dlen+1, (char*)s, strlen((char*)s));
+                    printf("%s", d);
+                    free(d);
+                } else {
+                    fprintf(stderr,"Failed to allocate space for escaped string\n");
+                }
+            } else {
+                if (reqElems || pv_data.nElems > 1) printf("%lu%c", pv_data.nElems, fieldSeparator);
+                for (i=0; i<pv_data.nElems; ++i) {
+                    if (i) printf ("%c", fieldSeparator);
+                    printf("%s", val2str(pv_data.value, pv_data.dbrType, i));
+                }
+            }
+            printf("\n");
+        }
+        break;
+    case all:
+        print_time_val_sts(&pv_data, reqElems);
+        break;
+    case specifiedDbr:
+        printf("%s\n", pv_data.name);
+        if (pv_data.status == ECA_DISCONN)
+            printf("    *** not connected\n");
+        else if (pv_data.status == ECA_NORDACCESS)
+            printf("    *** no read access\n");
+        else if (pv_data.status != ECA_NORMAL)
+            printf("    *** CA error %s\n", ca_message(pv_data.status));
+        else
+        {
+            printf("    Native data type: %s\n",
+                   dbf_type_to_text(pv_data.dbfType));
+            printf("    Request type:     %s\n",
+                   dbr_type_to_text(pv_data.dbrType));
+            if (pv_data.dbrType == DBR_CLASS_NAME)
+                printf("    Class Name:       %s\n",
+                       *((dbr_string_t*)dbr_value_ptr(pv_data.value,
+                                                      pv_data.dbrType)));
+            else {
+                printf("    Element count:    %lu\n"
+                       "    Value:            ",
+                       pv_data.nElems);
+                if (charArrAsStr && dbr_type_is_CHAR(pv_data.dbrType) && (reqElems || pv_data.nElems > 1)) {
+                    dbr_char_t *s = (dbr_char_t*) dbr_value_ptr(pv_data.value, pv_data.dbrType);
                     int dlen = epicsStrnEscapedFromRawSize((char*)s, strlen((char*)s));
                     char *d = calloc(dlen+1, sizeof(char));
                     if(d) {
@@ -283,74 +356,87 @@ static int caget (pv *pvs, int nPvs, RequestT request, OutputT format,
                         fprintf(stderr,"Failed to allocate space for escaped string\n");
                     }
                 } else {
-                    if (reqElems || pvs[n].nElems > 1) printf("%lu%c", pvs[n].nElems, fieldSeparator);
-                    for (i=0; i<pvs[n].nElems; ++i) {
+                    for (i=0; i<pv_data.nElems; ++i) {
                         if (i) printf ("%c", fieldSeparator);
-                        printf("%s", val2str(pvs[n].value, pvs[n].dbrType, i));
+                        printf("%s", val2str(pv_data.value, pv_data.dbrType, i));
                     }
                 }
                 printf("\n");
+                if (pv_data.dbrType > DBR_DOUBLE) /* Extended type extra info */
+                    printf("%s\n", dbr2str(pv_data.value, pv_data.dbrType));
             }
-            break;
-        case all:
-            print_time_val_sts(&pvs[n], reqElems);
-            break;
-        case specifiedDbr:
-            printf("%s\n", pvs[n].name);
-            if (pvs[n].status == ECA_DISCONN)
-                printf("    *** not connected\n");
-            else if (pvs[n].status == ECA_NORDACCESS)
-                printf("    *** no read access\n");
-            else if (pvs[n].status != ECA_NORMAL)
-                printf("    *** CA error %s\n", ca_message(pvs[n].status));
-            else
-            {
-                printf("    Native data type: %s\n",
-                       dbf_type_to_text(pvs[n].dbfType));
-                printf("    Request type:     %s\n",
-                       dbr_type_to_text(pvs[n].dbrType));
-                if (pvs[n].dbrType == DBR_CLASS_NAME)
-                    printf("    Class Name:       %s\n",
-                           *((dbr_string_t*)dbr_value_ptr(pvs[n].value,
-                                                          pvs[n].dbrType)));
-                else {
-                    printf("    Element count:    %lu\n"
-                           "    Value:            ",
-                           pvs[n].nElems);
-                    if (charArrAsStr && dbr_type_is_CHAR(pvs[n].dbrType) && (reqElems || pvs[n].nElems > 1)) {
-                        dbr_char_t *s = (dbr_char_t*) dbr_value_ptr(pvs[n].value, pvs[n].dbrType);
-                        int dlen = epicsStrnEscapedFromRawSize((char*)s, strlen((char*)s));
-                        char *d = calloc(dlen+1, sizeof(char));
-                        if(d) {
-                            epicsStrnEscapedFromRaw(d, dlen+1, (char*)s, strlen((char*)s));
-                            printf("%s", d);
-                            free(d);
-                        } else {
-                            fprintf(stderr,"Failed to allocate space for escaped string\n");
-                        }
-                    } else {
-                        for (i=0; i<pvs[n].nElems; ++i) {
-                            if (i) printf ("%c", fieldSeparator);
-                            printf("%s", val2str(pvs[n].value, pvs[n].dbrType, i));
-                        }
-                    }
-                    printf("\n");
-                    if (pvs[n].dbrType > DBR_DOUBLE) /* Extended type extra info */
-                        printf("%s\n", dbr2str(pvs[n].value, pvs[n].dbrType));
-                }
-            }
-            break;
-        default :
-            break;
         }
-        free(pvs[n].value);
+        break;
+    default :
+        break;
     }
+    free(pvs_data.value);
+    }
+
+    epicsMutexUnlock(printMutex);
+
     return 0;
 }
 
+static void complainIfNotPlainAndSet (OutputT *current, const OutputT requested)
+{
+    if (*current != plain)
+        fprintf(stderr,
+                "Options t,d,a are mutually exclusive. "
+                "('caget -h' for help.)\n");
+    *current = requested;
+}
+/*
+void test(void* thread_data_void) {
+printf("called\n");
+    //t_thread_data* thread_data = (t_thread_data*)thread_data_void;
+    //epicsSpinLock(thread_data->spin);
+    //epicsMutexUnlock(thread_data->printMutex_lock_main);
+printf("End of test\n");
+}
+*/
 
-
-/*+**************************************************************************
+// Create a thread name based on the PV index in the order sent as argument for caget
+void thread_name (int pv_num, char* th_name) {
+    // Threads will be named caget0, caget1, ..., caget42, ...
+    char pv_num_str[3];
+    sprintf(pv_num_str, "%d", pv_num);
+    strcpy(th_name, "caget");
+    strcat(th_name, pv_num_str);
+}
+
+// Function that runs inside each thread, calling the caget function
+void caget_caller (void* thread_data_void)
+{
+    int result;                 /* CA result */
+    t_thread_data* thread_data = (t_thread_data*)thread_data_void;
+    result = connect_pvs(&thread_data->pv_data, 1);
+
+                                /* Read and print data */
+    if (!result)
+        result = caget(thread_data->pv_data, thread_data->request, thread_data->format, thread_data->dbrType, thread_data->reqElems, thread_data->printMutex);
+
+    epicsMutexLock(thread_data->resultMutex);
+    pvs_with_trouble += result;
+    epicsMutexUnlock(thread_data->resultMutex);
+
+    free(thread_data);
+}
+
+// Creates one thread per PV called with caget
+void thread_builder (t_thread_data* thread_data, int pv_num)
+{
+    char th_name[9];
+    thread_name(pv_num, th_name);
+    epicsThreadOpts thread_opts = EPICS_THREAD_OPTS_INIT;
+    // Must be joinable so the main thread can wait for all the threads to
+    // complete their job.
+    thread_opts.joinable = 1;
+    epicsThreadCreateOpt(th_name, &caget_caller, thread_data, &thread_opts);
+}
+
+
+/***************************************************************************
  *
  * Function:    main
  *
@@ -362,18 +448,10 @@ static int caget (pv *pvs, int nPvs, RequestT request, OutputT format,
  *
  * Arg(s) Out:  none
  *
- * Return(s):   Standard return code (0=success, 1=error)
+ * Return(s):   Return code = number of PVs that couldn't be reached
+ *              (0=success, !0=error)
  *
  **************************************************************************-*/
-
-static void complainIfNotPlainAndSet (OutputT *current, const OutputT requested)
-{
-    if (*current != plain)
-        fprintf(stderr,
-                "Options t,d,a are mutually exclusive. "
-                "('caget -h' for help.)\n");
-    *current = requested;
-}
 
 int main (int argc, char *argv[])
 {
@@ -550,15 +628,38 @@ int main (int argc, char *argv[])
     for (n = 0; optind < argc; n++, optind++)
         pvs[n].name = argv[optind] ;       /* Copy PV names from command line */
 
-    result = connect_pvs(pvs, nPvs);
+    // Mutex to avoid commingling of text output by several threads
+    epicsMutexId printMutex = epicsMutexCreate();
+    // Mutex to access result counter
+    epicsMutexId resultMutex = epicsMutexCreate();
+    for (int iii=0; iii<nPvs; ++iii) {
+        t_thread_data* thread_data;
+        thread_data = malloc(sizeof(t_thread_data));
+        thread_data->pv_data = pvs[iii];
+        thread_data->request = request;
+        thread_data->format = format;
+        thread_data->dbrType = type;
+        thread_data->reqElems = count;
+        thread_data->printMutex = printMutex;
+        thread_data->resultMutex = resultMutex;
+        thread_builder(thread_data, iii);
+    }
 
-                                /* Read and print data */
-    if (!result)
-        result = caget(pvs, nPvs, request, format, type, count);
+    epicsThreadId thread_id;
+    char th_name[9];
+
+    // Wait for all threads to finish their business before ending the main thread
+    for (int iii=0; iii<nPvs; ++iii) {
+        thread_name(iii, th_name);
+        thread_id = epicsThreadGetId(th_name);
+        epicsThreadMustJoin(thread_id);
+    }
 
                                 /* Shut down Channel Access */
-    free(pvs);
+    //free(pvs);
     ca_context_destroy();
+    epicsMutexDestroy(printMutex);
+    epicsMutexDestroy(resultMutex);
 
-    return result;
+    return pvs_with_trouble;
 }

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -64,8 +64,6 @@ typedef struct
     epicsMutexId printMutex;
     epicsMutexId resultMutex;
     epicsMessageQueueId queueId;
-    // Make sure we print the results in the same order that caget was called
-    int pvOderIndex;
     int totalNumberOfPvs;
 } t_thread_data;
 
@@ -669,7 +667,6 @@ int main (int argc, char *argv[])
         thread_data->printMutex = printMutex;
         thread_data->resultMutex = resultMutex;
         thread_data->queueId = queueId;
-        thread_data->pvOderIndex = iii;
         thread_data->totalNumberOfPvs = nPvs;
         epicsMessageQueueSend(queueId, thread_data, sizeof(t_thread_data));
     }

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -446,7 +446,9 @@ void thread_builder (t_thread_data* thread_data, int pv_num)
  *
  * Arg(s) Out:  none
  *
- * Return(s):   Return code = number of PVs that couldn't be reached
+ * Return(s):   Return code = number of PVs that couldn't be reached or
+ *              -1 if an error happened before we could start searching
+ *              for the PVs.
  *              (0=success, !0=error)
  *
  **************************************************************************-*/
@@ -586,15 +588,15 @@ int main (int argc, char *argv[])
             fprintf(stderr,
                     "Unrecognized option: '-%c'. ('caget -h' for help.)\n",
                     optopt);
-            return 1;
+            return -1;
         case ':':
             fprintf(stderr,
                     "Option '-%c' requires an argument. ('caget -h' for help.)\n",
                     optopt);
-            return 1;
+            return -1;
         default :
             usage();
-            return 1;
+            return -1;
         }
     }
 
@@ -603,7 +605,7 @@ int main (int argc, char *argv[])
     if (nPvs < 1)
     {
         fprintf(stderr, "No pv name specified. ('caget -h' for help.)\n");
-        return 1;
+        return -1;
     }
                                 /* Start up Channel Access */
 
@@ -611,7 +613,7 @@ int main (int argc, char *argv[])
     if (result != ECA_NORMAL) {
         fprintf(stderr, "CA error %s occurred while trying "
                 "to start channel access.\n", ca_message(result));
-        return 1;
+        return -1;
     }
                                 /* Allocate PV structure array */
 
@@ -619,7 +621,7 @@ int main (int argc, char *argv[])
     if (!pvs)
     {
         fprintf(stderr, "Memory allocation for channel structures failed.\n");
-        return 1;
+        return -1;
     }
                                 /* Connect channels */
 

--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -28,9 +28,11 @@
  */
 
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <epicsStdlib.h>
 #include <epicsString.h>
+#include <epicsMessageQueue.h>
 
 #include <alarm.h>
 #include <cadef.h>
@@ -42,6 +44,8 @@
 
 #define VALID_DOUBLE_DIGITS 18  /* Max usable precision for a double */
 #define PEND_EVENT_SLICES 5     /* No. of pend_event slices for callback requests */
+#define NUMBER_OF_THREADS 5
+#define QUEUE_CAPACITY 100
 
 /* Different output formats */
 typedef enum { plain, terse, all, specifiedDbr } OutputT;
@@ -59,12 +63,17 @@ typedef struct
     unsigned long reqElems;
     epicsMutexId printMutex;
     epicsMutexId resultMutex;
+    epicsMessageQueueId queueId;
+    // Make sure we print the results in the same order that caget was called
+    int pvOderIndex;
+    int totalNumberOfPvs;
 } t_thread_data;
 
 static int nConn = 0;           /* Number of connected PVs */
 static int nRead = 0;           /* Number of channels that were read */
 static int floatAsString = 0;   /* Flag: fetch floats as string */
 static int pvs_with_trouble = 0; /* Counter for PVs with result not zero */
+static int completedPVs = 0;
 
 static void usage (void)
 {
@@ -384,43 +393,56 @@ static void complainIfNotPlainAndSet (OutputT *current, const OutputT requested)
     *current = requested;
 }
 
-// Create a thread name based on the PV index in the order sent as argument for caget
-void thread_name (int pv_num, char* th_name) {
-    // Threads will be named caget0, caget1, ..., caget42, ...
-    char pv_num_str[3];
-    sprintf(pv_num_str, "%d", pv_num);
+// Create a thread name based on the thread index
+void thread_name (int index, char* th_name) {
+    // Threads will be named caget0, caget1, caget2, etc
+    char index_str[2];
+    sprintf(index_str, "%d", index);
     strcpy(th_name, "caget");
-    strcat(th_name, pv_num_str);
+    strcat(th_name, index_str);
 }
 
 // Function that runs inside each thread, calling the caget function
-void caget_caller (void* thread_data_void)
+void caget_caller (void* queueId_void)
 {
     int result;                 /* CA result */
-    t_thread_data* thread_data = (t_thread_data*)thread_data_void;
-    result = connect_pvs(&thread_data->pv_data, 1);
+    t_thread_data thread_data;
 
-                                /* Read and print data */
-    if (!result)
-        result = caget(thread_data->pv_data, thread_data->request, thread_data->format, thread_data->dbrType, thread_data->reqElems, thread_data->printMutex);
+    epicsMessageQueueId queueId = (epicsMessageQueueId) queueId_void;
 
-    epicsMutexLock(thread_data->resultMutex);
-    pvs_with_trouble += result;
-    epicsMutexUnlock(thread_data->resultMutex);
+    while(true) {
+        if (epicsMessageQueueReceiveWithTimeout(queueId, &thread_data, sizeof(t_thread_data), 0.1) > 0) {
+            //t_thread_data* thread_data = (t_thread_data*)thread_data_void;
+            result = connect_pvs(&thread_data.pv_data, 1);
 
-    free(thread_data);
+                                        /* Read and print data */
+            if (!result)
+                result = caget(thread_data.pv_data, thread_data.request, thread_data.format, thread_data.dbrType, thread_data.reqElems, thread_data.printMutex);
+
+            epicsMutexLock(thread_data.resultMutex);
+            pvs_with_trouble += result;
+            ++completedPVs;
+            epicsMutexUnlock(thread_data.resultMutex);
+        }
+
+        if (completedPVs >= thread_data.totalNumberOfPvs) {
+            break;
+        }
+    }
+
+    //free(thread_data);
 }
 
-// Creates one thread per PV called with caget
-void thread_builder (t_thread_data* thread_data, int pv_num)
+// Creates the threads that will read from the message queue
+void thread_builder (epicsMessageQueueId queueId, int index)
 {
     char th_name[9];
-    thread_name(pv_num, th_name);
+    thread_name(index, th_name);
     epicsThreadOpts thread_opts = EPICS_THREAD_OPTS_INIT;
     // Must be joinable so the main thread can wait for all the threads to
     // complete their job.
     thread_opts.joinable = 1;
-    epicsThreadCreateOpt(th_name, &caget_caller, thread_data, &thread_opts);
+    epicsThreadCreateOpt(th_name, &caget_caller, queueId, &thread_opts);
 }
 
 
@@ -622,6 +644,20 @@ int main (int argc, char *argv[])
     epicsMutexId printMutex = epicsMutexCreate();
     // Mutex to access result counter
     epicsMutexId resultMutex = epicsMutexCreate();
+
+    epicsMessageQueueId queueId = epicsMessageQueueCreate(QUEUE_CAPACITY, sizeof(t_thread_data));
+
+    int number_of_threads;
+    if (nPvs > NUMBER_OF_THREADS) {
+        number_of_threads = NUMBER_OF_THREADS;
+    } else {
+        number_of_threads = nPvs;
+    }
+
+    for (int iii=0; iii<number_of_threads; ++iii) {
+        thread_builder(queueId, iii);
+    }
+
     for (int iii=0; iii<nPvs; ++iii) {
         t_thread_data* thread_data;
         thread_data = malloc(sizeof(t_thread_data));
@@ -632,14 +668,17 @@ int main (int argc, char *argv[])
         thread_data->reqElems = count;
         thread_data->printMutex = printMutex;
         thread_data->resultMutex = resultMutex;
-        thread_builder(thread_data, iii);
+        thread_data->queueId = queueId;
+        thread_data->pvOderIndex = iii;
+        thread_data->totalNumberOfPvs = nPvs;
+        epicsMessageQueueSend(queueId, thread_data, sizeof(t_thread_data));
     }
 
     epicsThreadId thread_id;
     char th_name[9];
 
     // Wait for all threads to finish their business before ending the main thread
-    for (int iii=0; iii<nPvs; ++iii) {
+    for (int iii=0; iii<number_of_threads; ++iii) {
         thread_name(iii, th_name);
         thread_id = epicsThreadGetId(th_name);
         epicsThreadMustJoin(thread_id);
@@ -650,6 +689,7 @@ int main (int argc, char *argv[])
     ca_context_destroy();
     epicsMutexDestroy(printMutex);
     epicsMutexDestroy(resultMutex);
+    epicsMessageQueueDestroy(queueId);
 
     return pvs_with_trouble;
 }


### PR DESCRIPTION
resolves #489 

This draft pull request is for caget only. I'll start the work on cainfo once I confirm that the changes in caget used the expected path. If I'm too far from the target, it is easier to change only caget, instead of both caget and cainfo.

The request from #489 asks for caget and cainfo to output data from a list PVs even when some of them are still waiting to timeout due to disconnection. I used one epicsThread per PV to achieve this behavior.
Here's a summary of all the changes in caget:
1. The caget() function is now called once per PV and its context is not in the main thread anymore. This is opposed to caget() being called once and operating in an array of PVs.
2. The original caget() function accepted an array of pv structures and a nPvs (number of PVs) argument. Due to item 1, now caget() receives one single PV on the argument and nPvs was removed.
3. A mutex is used to block when the thread is printing to the console. This is to avoid that output messages would be commingled with characters from different threads at the same time.
4. The threads are joinable, so the main thread can join all of them and wait for them to complete their tasks before quitting.
5. The output of the the caget binary indicates how many PVs are disconnected. So, if zero is returned, this was a successful run. An odd thing is that caget also returns 1 if someone calls it with wrong arguments. Maybe we could change it to return negative numbers to indicate this.

As I removed 2 if conditionals from caget(), I fixed the indentation and now diff shows that almost 100% of the function is changed.     :-(   If you want I can restore the original indentation so you can check where the real changes were.

Here's the result when running the command with some arguments:
```
└─>  ./caget -w 10 -a -# 10 EM1K0:GMD:HPS:BeamRate EM1K0:GMD:HPS:milliJoulesPerPulseHSTTH  dadsadsa hehgfsdgf
EM1K0:GMD:HPS:BeamRate         2024-05-22 11:44:20.569302 1 200
EM1K0:GMD:HPS:milliJoulesPerPulseHSTTH <undefined> 10 0 0 0 0 0 0 0 0 0 0 UDF INVALID
Channel connect timed out: 'dadsadsa' not found.
Channel connect timed out: 'hehgfsdgf' not found.

└─>  echo $?
2
```