### PR TITLE
Allow deleting a record at database creation (take 2).

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -22,6 +22,21 @@ should also be read to understand what has changed since earlier releases:
 
 ## Changes made on the 7.0 branch since 7.0.8.1
 
+### Allow users to delete previously created records from the database
+
+From this release, record instances and aliases that have already been loaded
+by an IOC can be removed from the database again before the call to iocInit
+by loading a second instance of the named records but using `"#"` in place of
+the record type. Values for the fields are not required or advised, just use
+an empty record body { }. This is useful when a template defines records that
+are not wanted in some IOCs, without having to split or duplicate the original
+template.
+
+For example this will remove the record named "unwanted":
+
+```
+record("#", "unwanted") { }
+```
 
 -----
 

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1119,6 +1119,19 @@ static void dbRecordHead(char *recordType, char *name, int visible)
         return;
     }
 
+    if (recordType[0] == '#' && recordType[1] == 0) {
+        status = dbFindRecord(pdbentry, name);
+        if (status == 0) {
+            dbDeleteRecord(pdbentry);
+            fprintf(stderr, ERL_WARNING ": Record \"%s\" DELETED!\n", name);
+            return; /* done */
+        }
+        fprintf(stderr, ERL_ERROR ": Record \"%s\" not found\n", name);
+        yyerror(NULL);
+        duplicate = TRUE;
+        return;
+    }
+
     status = dbFindRecordType(pdbentry, recordType);
     if (status) {
         fprintf(stderr, "Record \"%s\" is of unknown type \"%s\"\n",

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1123,14 +1123,14 @@ static void dbRecordHead(char *recordType, char *name, int visible)
         status = dbFindRecord(pdbentry, name);
         if (status == 0) {
             dbDeleteRecord(pdbentry);
-            popFirstTemp();
-            dbFreeEntry(pdbentry);
-            duplicate = TRUE;
         } else {
             fprintf(stderr, ERL_WARNING ": Unable to delete record \"%s\".  Not found.\n"
                     "  at file %s line %d\n",
                     name, pinputFileNow->filename, pinputFileNow->line_num);
         }
+        popFirstTemp();
+        dbFreeEntry(pdbentry);
+        duplicate = TRUE;
         return;
     }
     status = dbFindRecordType(pdbentry, recordType);

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1123,15 +1123,12 @@ static void dbRecordHead(char *recordType, char *name, int visible)
         status = dbFindRecord(pdbentry, name);
         if (status == 0) {
             dbDeleteRecord(pdbentry);
-            fprintf(stderr, ERL_WARNING ": Record \"%s\" DELETED!\n", name);
-            return; /* done */
+            popFirstTemp();
+            dbFreeEntry(pdbentry);
+            duplicate = TRUE;
         }
-        fprintf(stderr, ERL_ERROR ": Record \"%s\" not found\n", name);
-        yyerror(NULL);
-        duplicate = TRUE;
         return;
     }
-
     status = dbFindRecordType(pdbentry, recordType);
     if (status) {
         fprintf(stderr, "Record \"%s\" is of unknown type \"%s\"\n",

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1126,6 +1126,8 @@ static void dbRecordHead(char *recordType, char *name, int visible)
             popFirstTemp();
             dbFreeEntry(pdbentry);
             duplicate = TRUE;
+        } else {
+            fprintf(stderr, ERL_WARNING ": Record \"%s\" not found\n", name);
         }
         return;
     }

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1127,7 +1127,9 @@ static void dbRecordHead(char *recordType, char *name, int visible)
             dbFreeEntry(pdbentry);
             duplicate = TRUE;
         } else {
-            fprintf(stderr, ERL_WARNING ": Record \"%s\" not found\n", name);
+            fprintf(stderr, ERL_WARNING ": Unable to delete record \"%s\".  Not found.\n"
+                    "  at file %s line %d\n",
+                    name, pinputFileNow->filename, pinputFileNow->line_num);
         }
         return;
     }

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -1519,7 +1519,6 @@ long dbDeleteRecord(DBENTRY *pdbentry)
     dbBase          *pdbbase = pdbentry->pdbbase;
     dbRecordType    *precordType = pdbentry->precordType;
     dbRecordNode    *precnode = pdbentry->precnode;
-    struct dbCommon *prec = pdbentry->precnode->precord;
     ELLLIST         *preclist;
     long            status;
 
@@ -1530,7 +1529,7 @@ long dbDeleteRecord(DBENTRY *pdbentry)
     preclist = &precordType->recList;
     ellDelete(preclist, &precnode->node);
     dbPvdDelete(pdbbase, precnode);
-    dbDeleteRecordLinks(precordType, prec);
+    dbDeleteRecordLinks(precordType, precnode->precord);
     while (!dbFirstInfo(pdbentry)) {
         dbDeleteInfo(pdbentry);
     }

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -1478,11 +1478,48 @@ long dbDeleteAliases(DBENTRY *pdbentry)
     return 0;
 }
 
+static long dbDeleteRecordLinks(dbRecordType *rtyp, struct dbCommon *prec)
+{
+    short i;
+
+    for (i=0; i<rtyp->no_links; i++) {
+        dbFldDes *pflddes = rtyp->papFldDes[rtyp->link_ind[i]];
+        DBLINK *plink = (DBLINK *)(((char *)prec) + pflddes->offset);
+
+        // TODO: How to handle different link types?
+
+        // switch (plink->type) {
+        // /* constantStr is allowed to remain NULL if plink->text==NULL
+        //  * constantStr==NULL has special meaning in recGblInitConstantLink()
+        //  */
+        // case CONSTANT: plink->value.constantStr = NULL; break;
+        // case PV_LINK:  plink->value.pv_link.pvname = callocMustSucceed(1, 1, "init PV_LINK"); break;
+        // case JSON_LINK: plink->value.json.string = pNullString; break;
+        // case VME_IO: plink->value.vmeio.parm = pNullString; break;
+        // case CAMAC_IO: plink->value.camacio.parm = pNullString; break;
+        // case AB_IO: plink->value.abio.parm = pNullString; break;
+        // case GPIB_IO: plink->value.gpibio.parm = pNullString; break;
+        // case BITBUS_IO: plink->value.bitbusio.parm = pNullString; break;
+        // case INST_IO: plink->value.instio.string = pNullString; break;
+        // case BBGPIB_IO: plink->value.bbgpibio.parm = pNullString; break;
+        // case VXI_IO: plink->value.vxiio.parm = pNullString; break;
+        // }
+
+        if(!plink->text)
+            continue;
+
+        free(plink->text);
+        plink->text = NULL;
+    }
+    return 0;
+}
+
 long dbDeleteRecord(DBENTRY *pdbentry)
 {
     dbBase          *pdbbase = pdbentry->pdbbase;
     dbRecordType    *precordType = pdbentry->precordType;
     dbRecordNode    *precnode = pdbentry->precnode;
+    struct dbCommon *prec = pdbentry->precnode->precord;
     ELLLIST         *preclist;
     long            status;
 
@@ -1493,6 +1530,7 @@ long dbDeleteRecord(DBENTRY *pdbentry)
     preclist = &precordType->recList;
     ellDelete(preclist, &precnode->node);
     dbPvdDelete(pdbbase, precnode);
+    dbDeleteRecordLinks(precordType, prec);
     while (!dbFirstInfo(pdbentry)) {
         dbDeleteInfo(pdbentry);
     }

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -1478,40 +1478,15 @@ long dbDeleteAliases(DBENTRY *pdbentry)
     return 0;
 }
 
-static long dbDeleteRecordLinks(dbRecordType *rtyp, struct dbCommon *prec)
+static void dbDeleteRecordLinks(dbRecordType *rtyp, struct dbCommon *prec)
 {
     short i;
 
     for (i=0; i<rtyp->no_links; i++) {
         dbFldDes *pflddes = rtyp->papFldDes[rtyp->link_ind[i]];
         DBLINK *plink = (DBLINK *)(((char *)prec) + pflddes->offset);
-
-        // TODO: How to handle different link types?
-
-        // switch (plink->type) {
-        // /* constantStr is allowed to remain NULL if plink->text==NULL
-        //  * constantStr==NULL has special meaning in recGblInitConstantLink()
-        //  */
-        // case CONSTANT: plink->value.constantStr = NULL; break;
-        // case PV_LINK:  plink->value.pv_link.pvname = callocMustSucceed(1, 1, "init PV_LINK"); break;
-        // case JSON_LINK: plink->value.json.string = pNullString; break;
-        // case VME_IO: plink->value.vmeio.parm = pNullString; break;
-        // case CAMAC_IO: plink->value.camacio.parm = pNullString; break;
-        // case AB_IO: plink->value.abio.parm = pNullString; break;
-        // case GPIB_IO: plink->value.gpibio.parm = pNullString; break;
-        // case BITBUS_IO: plink->value.bitbusio.parm = pNullString; break;
-        // case INST_IO: plink->value.instio.string = pNullString; break;
-        // case BBGPIB_IO: plink->value.bbgpibio.parm = pNullString; break;
-        // case VXI_IO: plink->value.vxiio.parm = pNullString; break;
-        // }
-
-        if(!plink->text)
-            continue;
-
-        free(plink->text);
-        plink->text = NULL;
+        dbFreeLinkContents(plink);
     }
-    return 0;
 }
 
 long dbDeleteRecord(DBENTRY *pdbentry)

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -1219,7 +1219,9 @@ long dbNextRecordType(DBENTRY *pdbentry)
 
 char * dbGetRecordTypeName(DBENTRY *pdbentry)
 {
-    return(pdbentry->precordType->name);
+    dbRecordType *pdbRecordType = pdbentry->precordType;
+    if(!pdbRecordType) return NULL;
+    return(pdbRecordType->name);
 }
 
 int dbGetNRecordTypes(DBENTRY *pdbentry)

--- a/modules/database/test/ioc/db/Makefile
+++ b/modules/database/test/ioc/db/Makefile
@@ -183,6 +183,7 @@ testHarness_SRCS += dbStaticTest.c
 TESTFILES += ../dbStaticTest.db
 TESTFILES += ../dbStaticTestAlias1.db
 TESTFILES += ../dbStaticTestAlias2.db
+TESTFILES += ../dbStaticTestRemove.db
 TESTS += dbStaticTest
 
 # This runs all the test programs in a known working order:

--- a/modules/database/test/ioc/db/dbStaticTest.c
+++ b/modules/database/test/ioc/db/dbStaticTest.c
@@ -14,6 +14,35 @@
 #include <dbUnitTest.h>
 #include <testMain.h>
 
+
+static void testEntryRemoved(const char *pv)
+{
+    DBENTRY entry;
+
+    testDiag("testEntryRemoved(\"%s\")", pv);
+
+    dbInitEntry(pdbbase, &entry);
+
+    testOk(dbFindRecord(&entry, pv)==S_dbLib_recNotFound,
+        "Record '%s' not present", pv);
+
+    dbFinishEntry(&entry);
+}
+
+static void testEntryPresent(const char *pv)
+{
+    DBENTRY entry;
+
+    testDiag("testEntryPresent(\"%s\")", pv);
+
+    dbInitEntry(pdbbase, &entry);
+
+    testOk(dbFindRecord(&entry, pv)==0,
+        "Record '%s' present", pv);
+
+    dbFinishEntry(&entry);
+}
+
 static void testEntry(const char *pv)
 {
     DBENTRY entry;
@@ -310,7 +339,7 @@ MAIN(dbStaticTest)
     const char *ldir;
     FILE *fp = NULL;
 
-    testPlan(312);
+    testPlan(338);
     testdbPrepare();
 
     testdbReadDatabase("dbTestIoc.dbd", NULL, NULL);
@@ -322,6 +351,16 @@ MAIN(dbStaticTest)
     }
     if(dbReadDatabaseFP(&pdbbase, fp, NULL, NULL)) {
         testAbort("Unable to load %s%sdbStaticTest.db",
+                  ldir, OSI_PATH_LIST_SEPARATOR);
+    }
+
+    dbPath(pdbbase,"." OSI_PATH_LIST_SEPARATOR "..");
+    ldir = dbOpenFile(pdbbase, "dbStaticTestRemove.db", &fp);
+    if(!fp) {
+        testAbort("Unable to read dbStaticTestRemove.db");
+    }
+    if(dbReadDatabaseFP(&pdbbase, fp, NULL, NULL)) {
+        testAbort("Unable to load %s%sdbStaticTestRemove.db",
                   ldir, OSI_PATH_LIST_SEPARATOR);
     }
 
@@ -341,6 +380,20 @@ MAIN(dbStaticTest)
     testRec2Entry("testalias2");
     testRec2Entry("testalias3");
 
+    testEntryPresent("testdelrec");
+    testEntryPresent("testdelrec6");
+    testEntryPresent("testdelalias66");
+    testEntryRemoved("testdelrec1");
+    testEntryRemoved("testdelrec2");
+    testEntryRemoved("testdelrec3");
+    testEntryRemoved("testdelrec4");
+    testEntryRemoved("testdelrec5");
+    testEntryRemoved("testdelalias6");
+    testEntryRemoved("testdelrec7");
+    testEntryRemoved("testdelalias7");
+    testEntryRemoved("testdelalias77");
+    testEntryRemoved("testdelrec8");
+
     eltc(0);
     testIocInitOk();
     eltc(1);
@@ -357,6 +410,20 @@ MAIN(dbStaticTest)
     testRec2Entry("testalias");
     testRec2Entry("testalias2");
     testRec2Entry("testalias3");
+
+    testEntryPresent("testdelrec");
+    testEntryPresent("testdelrec6");
+    testEntryPresent("testdelalias66");
+    testEntryRemoved("testdelrec1");
+    testEntryRemoved("testdelrec2");
+    testEntryRemoved("testdelrec3");
+    testEntryRemoved("testdelrec4");
+    testEntryRemoved("testdelrec5");
+    testEntryRemoved("testdelalias6");
+    testEntryRemoved("testdelrec7");
+    testEntryRemoved("testdelalias7");
+    testEntryRemoved("testdelalias77");
+    testEntryRemoved("testdelrec8");
 
     testDbVerify("testrec");
 

--- a/modules/database/test/ioc/db/dbStaticTest.c
+++ b/modules/database/test/ioc/db/dbStaticTest.c
@@ -393,6 +393,7 @@ MAIN(dbStaticTest)
     testEntryRemoved("testdelalias7");
     testEntryRemoved("testdelalias77");
     testEntryRemoved("testdelrec8");
+    testEntryRemoved("testdelrec11");
 
     eltc(0);
     testIocInitOk();
@@ -424,6 +425,7 @@ MAIN(dbStaticTest)
     testEntryRemoved("testdelalias7");
     testEntryRemoved("testdelalias77");
     testEntryRemoved("testdelrec8");
+    testEntryRemoved("testdelrec11");
 
     testDbVerify("testrec");
 

--- a/modules/database/test/ioc/db/dbStaticTest.c
+++ b/modules/database/test/ioc/db/dbStaticTest.c
@@ -13,6 +13,7 @@
 #include <dbStaticPvt.h>
 #include <dbUnitTest.h>
 #include <testMain.h>
+#include <epicsString.h>
 
 
 static void testEntryRemoved(const char *pv)
@@ -337,6 +338,7 @@ void dbTestIoc_registerRecordDeviceDriver(struct dbBase *);
 MAIN(dbStaticTest)
 {
     const char *ldir;
+    char *ldirDup;
     FILE *fp = NULL;
 
     testPlan(340);
@@ -349,20 +351,24 @@ MAIN(dbStaticTest)
     if(!fp) {
         testAbort("Unable to read dbStaticTest.db");
     }
+    ldirDup = epicsStrDup(ldir);
     if(dbReadDatabaseFP(&pdbbase, fp, NULL, NULL)) {
         testAbort("Unable to load %s%sdbStaticTest.db",
-                  ldir, OSI_PATH_LIST_SEPARATOR);
+                  ldirDup, OSI_PATH_LIST_SEPARATOR);
     }
+    free(ldirDup);
 
     dbPath(pdbbase,"." OSI_PATH_LIST_SEPARATOR "..");
     ldir = dbOpenFile(pdbbase, "dbStaticTestRemove.db", &fp);
     if(!fp) {
         testAbort("Unable to read dbStaticTestRemove.db");
     }
+    ldirDup = epicsStrDup(ldir);
     if(dbReadDatabaseFP(&pdbbase, fp, NULL, NULL)) {
         testAbort("Unable to load %s%sdbStaticTestRemove.db",
-                  ldir, OSI_PATH_LIST_SEPARATOR);
+                  ldirDup, OSI_PATH_LIST_SEPARATOR);
     }
+    free(ldirDup);
 
     testWrongAliasRecord("dbStaticTestAlias1.db");
     testWrongAliasRecord("dbStaticTestAlias2.db");

--- a/modules/database/test/ioc/db/dbStaticTest.c
+++ b/modules/database/test/ioc/db/dbStaticTest.c
@@ -339,7 +339,7 @@ MAIN(dbStaticTest)
     const char *ldir;
     FILE *fp = NULL;
 
-    testPlan(338);
+    testPlan(340);
     testdbPrepare();
 
     testdbReadDatabase("dbTestIoc.dbd", NULL, NULL);

--- a/modules/database/test/ioc/db/dbStaticTestRemove.db
+++ b/modules/database/test/ioc/db/dbStaticTestRemove.db
@@ -1,0 +1,45 @@
+record(x, "testdelrec") { }
+
+record(x, "testdelrec1") { }
+
+record(x, "testdelrec2") {
+    field("INP", "foobar")
+}
+
+record(x, "testdelrec3") {
+    info("foo", "bar")
+}
+
+record(x, "testdelrec4") {
+    field("INP", "testdelrec.VAL")
+}
+
+record(x, "testdelrec5") {
+    field("FLNK", "testdelrec.VAL")
+}
+
+record(x, "testdelrec6") { }
+
+alias("testdelrec6", "testdelalias6")
+alias("testdelrec6", "testdelalias66")
+
+
+record(x, "testdelrec7") { }
+
+alias("testdelrec7", "testdelalias7")
+alias("testdelrec7", "testdelalias77")
+
+
+record(x, "testdelrec8") {
+    field("INP", "{z:{good:1}}")
+}
+
+record("#", "testdelrec1") { }
+record("#", "testdelrec2") { }
+record("#", "testdelrec3") { }
+record("#", "testdelrec4") { }
+record("#", "testdelrec5") { }
+record("#", "testdelalias6") { }
+record("#", "testdelrec7") { }
+record("#", "testdelrec8") { }
+

--- a/modules/database/test/ioc/db/dbStaticTestRemove.db
+++ b/modules/database/test/ioc/db/dbStaticTestRemove.db
@@ -34,6 +34,11 @@ record(x, "testdelrec8") {
     field("INP", "{z:{good:1}}")
 }
 
+record("#", "no:such:record") { }
+record("#", "also:non:existant") {
+    field(FOO, "5")
+}
+
 record("#", "testdelrec1") { }
 record("#", "testdelrec2") {
     field("INP", "foobar2")

--- a/modules/database/test/ioc/db/dbStaticTestRemove.db
+++ b/modules/database/test/ioc/db/dbStaticTestRemove.db
@@ -35,11 +35,16 @@ record(x, "testdelrec8") {
 }
 
 record("#", "testdelrec1") { }
-record("#", "testdelrec2") { }
-record("#", "testdelrec3") { }
+record("#", "testdelrec2") {
+    field("INP", "foobar2")
+}
+record("#", "testdelrec3") {
+    field("INP", "foobar2")
+    field("VAL", "1")
+}
 record("#", "testdelrec4") { }
 record("#", "testdelrec5") { }
 record("#", "testdelalias6") { }
 record("#", "testdelrec7") { }
 record("#", "testdelrec8") { }
-
+record("#", "testdelrec11") { }


### PR DESCRIPTION
Using a magical record type "#" will allow the user to delete previously created record  from the database - see #464 for more details.

NOTE:

This is a second attempt at the PR after making a mess of my fork while trying to rebase aginst upstream code. This PR is on top of latest upstream 7.0 branch code and includes original code change from #464 along with the release notes.

