### PR TITLE
makeBpt: fix memory leaks

### DIFF
--- a/modules/database/src/ioc/bpt/makeBpt.c
+++ b/modules/database/src/ioc/bpt/makeBpt.c
@@ -224,6 +224,8 @@ got_header:
     fprintf(outFile,"}\n");
     fclose(inFile);
     fclose(outFile);
+    free(outFilename);
+    free(pname);
     return(0);
 }
 


### PR DESCRIPTION
Free leaked memory allocated by `cmalloc` for filenames in makeBpt.