### PR TITLE
Add epicsLimits.h to provide a portable definition of PATH_MAX

### DIFF
--- a/modules/libcom/RTEMS/epicsMemFs.c
+++ b/modules/libcom/RTEMS/epicsMemFs.c
@@ -14,11 +14,8 @@
 #include <sys/types.h>
 #include <fcntl.h>
 
+#include "epicsLimits.h"
 #include "epicsMemFs.h"
-
-#ifndef PATH_MAX
-#  define PATH_MAX 100
-#endif
 
 int epicsMemFsLoad(const epicsMemFS *fs)
 {

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -18,6 +18,7 @@
 #include "epicsTime.h"
 #include "epicsThread.h"
 #include "epicsMutex.h"
+#include "epicsLimits.h"
 #include "envDefs.h"
 #include "osiUnistd.h"
 #include "logClient.h"
@@ -33,7 +34,7 @@
  */
 static void updatePWD() {
     static int lasterror;
-    char buf[1024];
+    char buf[PATH_MAX];
     char *pwd = getcwd(buf, sizeof(buf));
     if (pwd) {
         pwd[sizeof(buf) - 1] = '\0';

--- a/modules/libcom/src/osi/Makefile
+++ b/modules/libcom/src/osi/Makefile
@@ -57,6 +57,7 @@ INC += epicsStdioRedirect.h
 INC += epicsTempFile.h
 INC += epicsGetopt.h
 INC += epicsStackTrace.h
+INC += epicsLimits.h
 
 INC += devLib.h
 INC += devLibVME.h

--- a/modules/libcom/src/osi/os/Linux/osdgetexec.c
+++ b/modules/libcom/src/osi/os/Linux/osdgetexec.c
@@ -10,10 +10,7 @@
 #include <limits.h>
 
 #include <osiFileName.h>
-
-#ifndef PATH_MAX
-#  define PATH_MAX 100
-#endif
+#include <epicsLimits.h>
 
 char *epicsGetExecName(void)
 {

--- a/modules/libcom/src/osi/os/WIN32/epicsLimits.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsLimits.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright: Stanford University / SLAC National Laboratory.
+ *
+ * SPDX-License-Identifier: EPICS
+ * EPICS BASE is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ *
+ * Author: Jeremy Lorelli <lorelli@slac.stanford.edu>, 2024
+ */
+#ifndef _EPICS_LIMITS_H
+#define _EPICS_LIMITS_H
+
+#include <limits.h>
+#include <stdlib.h>
+
+#ifndef PATH_MAX
+#   define PATH_MAX _MAX_PATH
+#endif
+
+#ifndef NAME_MAX
+#   define NAME_MAX _MAX_FNAME
+#endif
+
+#endif /* _EPICS_LIMITS_H */

--- a/modules/libcom/src/osi/os/default/epicsLimits.h
+++ b/modules/libcom/src/osi/os/default/epicsLimits.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright: Stanford University / SLAC National Laboratory.
+ *
+ * SPDX-License-Identifier: EPICS
+ * EPICS BASE is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ *
+ * Author: Jeremy Lorelli <lorelli@slac.stanford.edu>, 2024
+ */
+#ifndef _EPICS_LIMITS_H
+#define _EPICS_LIMITS_H
+
+#include <limits.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 255
+#endif
+
+#endif /* _EPICS_LIMITS_H */


### PR DESCRIPTION
Leaving as a draft to collect feedback.

The goal of this PR is to provide a portable definition of `PATH_MAX`, mostly because Windows only defines `MAX_PATH`.

Updated the `UpdatePWD` function to use `PATH_MAX` instead of an arbitrary length limit of 1024.

As of Windows 10 v1607, path limits may be increased in the registry. Those changes are not affected by the `MAX_PATH` macro. I'm not sure of the best way to handle this edge case- or if it's worth handling it at all.

This is related to the work on #497 