### PR TITLE
Add SPDX license tags to templates

### DIFF
--- a/modules/ca/src/template/top/caClientApp/Makefile
+++ b/modules/ca/src/template/top/caClientApp/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2003 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=..
 
 include $(TOP)/configure/CONFIG

--- a/modules/ca/src/template/top/caClientApp/caExample.c
+++ b/modules/ca/src/template/top/caClientApp/caExample.c
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
+/* SPDX-FileCopyrightText: 1998 Argonne National Laboratory */
+
+/* SPDX-License-Identifier: EPICS */
 
 /*caExample.c*/
 #include <stddef.h>

--- a/modules/ca/src/template/top/caClientApp/caExample.c
+++ b/modules/ca/src/template/top/caClientApp/caExample.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /*caExample.c*/
 #include <stddef.h>
 #include <stdlib.h>

--- a/modules/ca/src/template/top/caClientApp/caMonitor.c
+++ b/modules/ca/src/template/top/caClientApp/caMonitor.c
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2000 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
+/* SPDX-FileCopyrightText: 2000 Argonne National Laboratory */
+
+/* SPDX-License-Identifier: EPICS */
 
 /*caMonitor.c*/
 

--- a/modules/ca/src/template/top/caClientApp/caMonitor.c
+++ b/modules/ca/src/template/top/caClientApp/caMonitor.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /*caMonitor.c*/
 
 /* This example accepts the name of a file containing a list of pvs to monitor.

--- a/modules/ca/src/template/top/caPerlApp/Makefile
+++ b/modules/ca/src/template/top/caPerlApp/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=..
 
 include $(TOP)/configure/CONFIG

--- a/modules/ca/src/template/top/caPerlApp/caget.pl
+++ b/modules/ca/src/template/top/caPerlApp/caget.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# SPDX-FileCopyrightText: 2008 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 use strict;
 
 # This construct sets @INC to search lib/perl of all RELEASE entries

--- a/modules/ca/src/template/top/caPerlApp/cainfo.pl
+++ b/modules/ca/src/template/top/caPerlApp/cainfo.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# SPDX-FileCopyrightText: 2008 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 use strict;
 
 # This construct sets @INC to search lib/perl of all RELEASE entries

--- a/modules/ca/src/template/top/caPerlApp/camonitor.pl
+++ b/modules/ca/src/template/top/caPerlApp/camonitor.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# SPDX-FileCopyrightText: 2008 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 use strict;
 
 # This construct sets @INC to search lib/perl of all RELEASE entries

--- a/modules/ca/src/template/top/caPerlApp/caput.pl
+++ b/modules/ca/src/template/top/caPerlApp/caput.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# SPDX-FileCopyrightText: 2008 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 use strict;
 
 # This construct sets @INC to search lib/perl of all RELEASE entries

--- a/modules/database/src/template/top/Makefile
+++ b/modules/database/src/template/top/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Makefile at top of application tree
 TOP = .
 include $(TOP)/configure/CONFIG

--- a/modules/database/src/template/top/exampleApp/Db/Makefile
+++ b/modules/database/src/template/top/exampleApp/Db/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../..
 include $(TOP)/configure/CONFIG
 #----------------------------------------

--- a/modules/database/src/template/top/exampleApp/Db/_APPNAME_Version.db
+++ b/modules/database/src/template/top/exampleApp/Db/_APPNAME_Version.db
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 record(lsi, "$(user):_APPNAME_:version") {
     field(DTYP, "_APPNAME_ version")
     field(DESC, "Version string")

--- a/modules/database/src/template/top/exampleApp/Db/circle.db
+++ b/modules/database/src/template/top/exampleApp/Db/circle.db
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 ITER Organization
+#
+# SPDX-License-Identifier: EPICS
+
 record(ao, "$(user):circle:step") {
   field(VAL , "1.0")
   field(DRVL, "0.0")

--- a/modules/database/src/template/top/exampleApp/Db/dbExample1.db
+++ b/modules/database/src/template/top/exampleApp/Db/dbExample1.db
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 record(ai, "$(user):aiExample")
 {
 	field(DESC, "Analog input")

--- a/modules/database/src/template/top/exampleApp/Db/dbExample2.db
+++ b/modules/database/src/template/top/exampleApp/Db/dbExample2.db
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 record(calc, "$(user):calcExample$(no)")
 {
 	alias("$(user):calc$(no)")

--- a/modules/database/src/template/top/exampleApp/Db/dbSubExample.db
+++ b/modules/database/src/template/top/exampleApp/Db/dbSubExample.db
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2002 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 record(sub,"$(user):subExample")
 {
     field(INAM,"mySubInit")

--- a/modules/database/src/template/top/exampleApp/Db/user.substitutions
+++ b/modules/database/src/template/top/exampleApp/Db/user.substitutions
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Example substitutions file
 
 file "db/circle.db" {

--- a/modules/database/src/template/top/exampleApp/Makefile
+++ b/modules/database/src/template/top/exampleApp/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Makefile at top of application tree
 TOP = ..
 include $(TOP)/configure/CONFIG

--- a/modules/database/src/template/top/exampleApp/src/Makefile
+++ b/modules/database/src/template/top/exampleApp/src/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../..
 
 include $(TOP)/configure/CONFIG

--- a/modules/database/src/template/top/exampleApp/src/_APPNAME_Hello.c
+++ b/modules/database/src/template/top/exampleApp/src/_APPNAME_Hello.c
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2005 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
+/* SPDX-FileCopyrightText: 2005 Argonne National Laboratory */
+
+/* SPDX-License-Identifier: EPICS */
 
 /* Example showing how to register a new command with iocsh */
 

--- a/modules/database/src/template/top/exampleApp/src/_APPNAME_Hello.c
+++ b/modules/database/src/template/top/exampleApp/src/_APPNAME_Hello.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2005 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /* Example showing how to register a new command with iocsh */
 
 #include <stdio.h>

--- a/modules/database/src/template/top/exampleApp/src/_APPNAME_Hello.dbd
+++ b/modules/database/src/template/top/exampleApp/src/_APPNAME_Hello.dbd
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2005 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 registrar(helloRegister)

--- a/modules/database/src/template/top/exampleApp/src/_APPNAME_Main.cpp
+++ b/modules/database/src/template/top/exampleApp/src/_APPNAME_Main.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /* _APPNAME_Main.cpp */
 /* Author:  Marty Kraimer Date:    17MAR2000 */
 

--- a/modules/database/src/template/top/exampleApp/src/dbSubExample.c
+++ b/modules/database/src/template/top/exampleApp/src/dbSubExample.c
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2002 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
+/* SPDX-FileCopyrightText: 2002 Argonne National Laboratory */
+
+/* SPDX-License-Identifier: EPICS */
 
 #include <stdio.h>
 

--- a/modules/database/src/template/top/exampleApp/src/dbSubExample.c
+++ b/modules/database/src/template/top/exampleApp/src/dbSubExample.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2002 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 #include <stdio.h>
 
 #include <dbDefs.h>

--- a/modules/database/src/template/top/exampleApp/src/dbSubExample.dbd
+++ b/modules/database/src/template/top/exampleApp/src/dbSubExample.dbd
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2004 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 variable(mySubDebug)
 function(mySubInit)
 function(mySubProcess)

--- a/modules/database/src/template/top/exampleApp/src/devXxxSoft.c
+++ b/modules/database/src/template/top/exampleApp/src/devXxxSoft.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /* devXxxSoft.c */
 /* Example device support module */
 

--- a/modules/database/src/template/top/exampleApp/src/devXxxSoft.c
+++ b/modules/database/src/template/top/exampleApp/src/devXxxSoft.c
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
+/* SPDX-FileCopyrightText: 1998 Argonne National Laboratory */
+
+/* SPDX-License-Identifier: EPICS */
 
 /* devXxxSoft.c */
 /* Example device support module */

--- a/modules/database/src/template/top/exampleApp/src/dev_APPNAME_Version.c
+++ b/modules/database/src/template/top/exampleApp/src/dev_APPNAME_Version.c
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2015 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
+/* SPDX-FileCopyrightText: 2015 Argonne National Laboratory */
+
+/* SPDX-License-Identifier: EPICS */
 
 /* dev_APPNAME_Version.c */
 /* Example device support for the lsi (long string input) record

--- a/modules/database/src/template/top/exampleApp/src/dev_APPNAME_Version.c
+++ b/modules/database/src/template/top/exampleApp/src/dev_APPNAME_Version.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2015 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /* dev_APPNAME_Version.c */
 /* Example device support for the lsi (long string input) record
  * providing the module version string as the value

--- a/modules/database/src/template/top/exampleApp/src/dev_APPNAME_Version.dbd
+++ b/modules/database/src/template/top/exampleApp/src/dev_APPNAME_Version.dbd
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2015 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 device(lsi,INST_IO,dev_CSAFEAPPNAME_Version,"_APPNAME_ version")

--- a/modules/database/src/template/top/exampleApp/src/initTrace.c
+++ b/modules/database/src/template/top/exampleApp/src/initTrace.c
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2008 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
+/* SPDX-FileCopyrightText: 2008 Argonne National Laboratory */
+
+/* SPDX-License-Identifier: EPICS */
 
 /* initTrace.c */
 

--- a/modules/database/src/template/top/exampleApp/src/initTrace.c
+++ b/modules/database/src/template/top/exampleApp/src/initTrace.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2008 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /* initTrace.c */
 
 /*

--- a/modules/database/src/template/top/exampleApp/src/initTrace.dbd
+++ b/modules/database/src/template/top/exampleApp/src/initTrace.dbd
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2008 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 registrar(initTraceRegister)

--- a/modules/database/src/template/top/exampleApp/src/sncExample.dbd
+++ b/modules/database/src/template/top/exampleApp/src/sncExample.dbd
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2004 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # The name below is derived from the name of the SNL program
 # inside the source file, not from its filename. Here the
 # program is called sncExample, but is compiled in both the

--- a/modules/database/src/template/top/exampleApp/src/sncExample.stt
+++ b/modules/database/src/template/top/exampleApp/src/sncExample.stt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 program sncExample
 double v;
 assign v to "{user}:aiExample";

--- a/modules/database/src/template/top/exampleApp/src/sncExample.stt
+++ b/modules/database/src/template/top/exampleApp/src/sncExample.stt
@@ -1,7 +1,3 @@
-// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
-
 program sncExample
 double v;
 assign v to "{user}:aiExample";
@@ -24,3 +20,9 @@ ss ss1 {
         } state low
     }
 }
+
+/*
+SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+
+SPDX-License-Identifier: EPICS
+*/

--- a/modules/database/src/template/top/exampleApp/src/sncProgram.st
+++ b/modules/database/src/template/top/exampleApp/src/sncProgram.st
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: 2004 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
-
 #include "../sncExample.stt"
+
+/*
+SPDX-FileCopyrightText: 2004 Argonne National Laboratory
+
+SPDX-License-Identifier: EPICS
+*/

--- a/modules/database/src/template/top/exampleApp/src/sncProgram.st
+++ b/modules/database/src/template/top/exampleApp/src/sncProgram.st
@@ -1,1 +1,5 @@
+// SPDX-FileCopyrightText: 2004 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 #include "../sncExample.stt"

--- a/modules/database/src/template/top/exampleApp/src/xxxRecord.c
+++ b/modules/database/src/template/top/exampleApp/src/xxxRecord.c
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
+/* SPDX-FileCopyrightText: 1998 Argonne National Laboratory */
+
+/* SPDX-License-Identifier: EPICS */
 
 /* xxxRecord.c */
 /* Example record support module */

--- a/modules/database/src/template/top/exampleApp/src/xxxRecord.c
+++ b/modules/database/src/template/top/exampleApp/src/xxxRecord.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /* xxxRecord.c */
 /* Example record support module */
 

--- a/modules/database/src/template/top/exampleApp/src/xxxRecord.dbd
+++ b/modules/database/src/template/top/exampleApp/src/xxxRecord.dbd
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 recordtype(xxx) {
 	include "dbCommon.dbd" 
 	field(VAL,DBF_DOUBLE) {

--- a/modules/database/src/template/top/exampleApp/src/xxxSupport.dbd
+++ b/modules/database/src/template/top/exampleApp/src/xxxSupport.dbd
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2003 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 include "xxxRecord.dbd"
 device(xxx,CONSTANT,devXxxSoft,"Soft Channel")

--- a/modules/database/src/template/top/exampleBoot/Makefile
+++ b/modules/database/src/template/top/exampleBoot/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ..
 include $(TOP)/configure/CONFIG
 DIRS += $(wildcard *ioc*)

--- a/modules/database/src/template/top/exampleBoot/ioc/Makefile@Common
+++ b/modules/database/src/template/top/exampleBoot/ioc/Makefile@Common
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = $(EPICS_HOST_ARCH)

--- a/modules/database/src/template/top/exampleBoot/ioc/Makefile@cygwin
+++ b/modules/database/src/template/top/exampleBoot/ioc/Makefile@cygwin
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = _ARCH_

--- a/modules/database/src/template/top/exampleBoot/ioc/Makefile@vxWorks
+++ b/modules/database/src/template/top/exampleBoot/ioc/Makefile@vxWorks
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = _ARCH_

--- a/modules/database/src/template/top/exampleBoot/ioc/Makefile@win32
+++ b/modules/database/src/template/top/exampleBoot/ioc/Makefile@win32
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2008 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = _ARCH_

--- a/modules/database/src/template/top/exampleBoot/ioc/Makefile@windows
+++ b/modules/database/src/template/top/exampleBoot/ioc/Makefile@windows
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = _ARCH_

--- a/modules/database/src/template/top/exampleBoot/ioc/README@Common
+++ b/modules/database/src/template/top/exampleBoot/ioc/README@Common
@@ -10,6 +10,4 @@ st.cmd's dbLoadDatabase() command before starting the ioc.
 
 
 SPDX-FileCopyrightText: 2001 Argonne National Laboratory
-
 SPDX-License-Identifier: EPICS
-

--- a/modules/database/src/template/top/exampleBoot/ioc/README@Common
+++ b/modules/database/src/template/top/exampleBoot/ioc/README@Common
@@ -7,3 +7,9 @@ and check the executable name on the first line of the st.cmd file
 
 You may need to change the name of the .dbd file given in the
 st.cmd's dbLoadDatabase() command before starting the ioc.
+
+
+SPDX-FileCopyrightText: 2001 Argonne National Laboratory
+
+SPDX-License-Identifier: EPICS
+

--- a/modules/database/src/template/top/exampleBoot/ioc/README@RTEMS
+++ b/modules/database/src/template/top/exampleBoot/ioc/README@RTEMS
@@ -7,6 +7,4 @@ etc.) and start it.
 
 
 SPDX-FileCopyrightText: 2001 Lawrence Berkeley National Laboratory
-
 SPDX-License-Identifier: EPICS
-

--- a/modules/database/src/template/top/exampleBoot/ioc/README@RTEMS
+++ b/modules/database/src/template/top/exampleBoot/ioc/README@RTEMS
@@ -4,3 +4,9 @@ contents to
 
 Then load the executable into the IOC (floppy disk, network boot, debugger,
 etc.) and start it.
+
+
+SPDX-FileCopyrightText: 2001 Lawrence Berkeley National Laboratory
+
+SPDX-License-Identifier: EPICS
+

--- a/modules/database/src/template/top/exampleBoot/ioc/README@RTEMS
+++ b/modules/database/src/template/top/exampleBoot/ioc/README@RTEMS
@@ -6,5 +6,5 @@ Then load the executable into the IOC (floppy disk, network boot, debugger,
 etc.) and start it.
 
 
-SPDX-FileCopyrightText: 2001 Lawrence Berkeley National Laboratory
+SPDX-FileCopyrightText: 2001 Argonne National Laboratory
 SPDX-License-Identifier: EPICS

--- a/modules/database/src/template/top/exampleBoot/ioc/README@vxWorks
+++ b/modules/database/src/template/top/exampleBoot/ioc/README@vxWorks
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2001 Argonne National Laboratory
+
+SPDX-License-Identifier: EPICS

--- a/modules/database/src/template/top/exampleBoot/ioc/README@vxWorks
+++ b/modules/database/src/template/top/exampleBoot/ioc/README@vxWorks
@@ -1,3 +1,0 @@
-SPDX-FileCopyrightText: 2001 Argonne National Laboratory
-
-SPDX-License-Identifier: EPICS

--- a/modules/database/src/template/top/exampleBoot/ioc/st.cmd@Common
+++ b/modules/database/src/template/top/exampleBoot/ioc/st.cmd@Common
@@ -1,5 +1,9 @@
 #!../../bin/_ARCH_/_APPNAME_
 
+#- SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#-
+#- SPDX-License-Identifier: EPICS
+
 #- You may have to change _APPNAME_ to something else
 #- everywhere it appears in this file
 

--- a/modules/database/src/template/top/exampleBoot/ioc/st.cmd@RTEMS
+++ b/modules/database/src/template/top/exampleBoot/ioc/st.cmd@RTEMS
@@ -1,3 +1,7 @@
+#- SPDX-FileCopyrightText: 2001 Argonne National Laboratory
+#-
+#- SPDX-License-Identifier: EPICS
+
 #- Example RTEMS startup script
 
 #- You may have to change _APPNAME_ to something else

--- a/modules/database/src/template/top/exampleBoot/ioc/st.cmd@vxWorks
+++ b/modules/database/src/template/top/exampleBoot/ioc/st.cmd@vxWorks
@@ -1,3 +1,7 @@
+#- SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#-
+#- SPDX-License-Identifier: EPICS
+
 #- Example vxWorks startup file
 
 #- The following is needed if your board support package doesn't at boot time

--- a/modules/database/src/template/top/exampleBoot/nfsCommands@RTEMS
+++ b/modules/database/src/template/top/exampleBoot/nfsCommands@RTEMS
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2005 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #- Instructions for creating and using a real nfsCommands file
 #- 
 #- in order to use nfs do the following:

--- a/modules/database/src/template/top/exampleBoot/nfsCommands@vxWorks
+++ b/modules/database/src/template/top/exampleBoot/nfsCommands@vxWorks
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #- Instructions for creating and using a real nfsCommands file
 #- 
 #- in order to use nfs do the following:

--- a/modules/database/src/template/top/iocApp/Db/Makefile
+++ b/modules/database/src/template/top/iocApp/Db/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../..
 include $(TOP)/configure/CONFIG
 #----------------------------------------

--- a/modules/database/src/template/top/iocApp/Makefile
+++ b/modules/database/src/template/top/iocApp/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Makefile at top of application tree
 TOP = ..
 include $(TOP)/configure/CONFIG

--- a/modules/database/src/template/top/iocApp/src/Makefile
+++ b/modules/database/src/template/top/iocApp/src/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2003 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../..
 
 include $(TOP)/configure/CONFIG

--- a/modules/database/src/template/top/iocApp/src/_APPNAME_Main.cpp
+++ b/modules/database/src/template/top/iocApp/src/_APPNAME_Main.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /* _APPNAME_Main.cpp */
 /* Author:  Marty Kraimer Date:    17MAR2000 */
 

--- a/modules/database/src/template/top/iocBoot/Makefile
+++ b/modules/database/src/template/top/iocBoot/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ..
 include $(TOP)/configure/CONFIG
 DIRS += $(wildcard *ioc*)

--- a/modules/database/src/template/top/iocBoot/ioc/Makefile@Common
+++ b/modules/database/src/template/top/iocBoot/ioc/Makefile@Common
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = $(EPICS_HOST_ARCH)

--- a/modules/database/src/template/top/iocBoot/ioc/Makefile@cygwin
+++ b/modules/database/src/template/top/iocBoot/ioc/Makefile@cygwin
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = _ARCH_

--- a/modules/database/src/template/top/iocBoot/ioc/Makefile@vxWorks
+++ b/modules/database/src/template/top/iocBoot/ioc/Makefile@vxWorks
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = _ARCH_

--- a/modules/database/src/template/top/iocBoot/ioc/Makefile@win32
+++ b/modules/database/src/template/top/iocBoot/ioc/Makefile@win32
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2008 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = _ARCH_

--- a/modules/database/src/template/top/iocBoot/ioc/Makefile@windows
+++ b/modules/database/src/template/top/iocBoot/ioc/Makefile@windows
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ../..
 include $(TOP)/configure/CONFIG
 ARCH = _ARCH_

--- a/modules/database/src/template/top/iocBoot/ioc/st.cmd@Common
+++ b/modules/database/src/template/top/iocBoot/ioc/st.cmd@Common
@@ -1,5 +1,9 @@
 #!../../bin/_ARCH_/_APPNAME_
 
+#- SPDX-FileCopyrightText: 2003 Argonne National Laboratory
+#-
+#- SPDX-License-Identifier: EPICS
+
 #- You may have to change _APPNAME_ to something else
 #- everywhere it appears in this file
 

--- a/modules/database/src/template/top/iocBoot/ioc/st.cmd@Cross
+++ b/modules/database/src/template/top/iocBoot/ioc/st.cmd@Cross
@@ -1,5 +1,9 @@
 #!../../bin/_ARCH_/_APPNAME_
 
+#- SPDX-FileCopyrightText: 2005 Argonne National Laboratory
+#-
+#- SPDX-License-Identifier: EPICS
+
 #- You may have to change _APPNAME_ to something else
 #- everywhere it appears in this file
 

--- a/modules/database/src/template/top/iocBoot/ioc/st.cmd@RTEMS
+++ b/modules/database/src/template/top/iocBoot/ioc/st.cmd@RTEMS
@@ -1,3 +1,7 @@
+#- SPDX-FileCopyrightText: 2001 Argonne National Laboratory
+#-
+#- SPDX-License-Identifier: EPICS
+
 #- Example RTEMS startup script
 
 #- You may have to change _APPNAME_ to something else

--- a/modules/database/src/template/top/iocBoot/ioc/st.cmd@vxWorks
+++ b/modules/database/src/template/top/iocBoot/ioc/st.cmd@vxWorks
@@ -1,3 +1,7 @@
+#- SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#-
+#- SPDX-License-Identifier: EPICS
+
 #- Example vxWorks startup file
 
 #- The following is needed if your board support package doesn't at boot time

--- a/modules/database/src/template/top/iocBoot/nfsCommands@RTEMS
+++ b/modules/database/src/template/top/iocBoot/nfsCommands@RTEMS
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2005 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #- Instructions for creating and using a real nfsCommands file
 #- 
 #- in order to use nfs do the following:

--- a/modules/database/src/template/top/iocBoot/nfsCommands@vxWorks
+++ b/modules/database/src/template/top/iocBoot/nfsCommands@vxWorks
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #- Instructions for creating and using a real nfsCommands file
 #- 
 #- in order to use nfs do the following:

--- a/modules/database/src/template/top/supportApp/Db/Makefile
+++ b/modules/database/src/template/top/supportApp/Db/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../..
 include $(TOP)/configure/CONFIG
 #----------------------------------------

--- a/modules/database/src/template/top/supportApp/Makefile
+++ b/modules/database/src/template/top/supportApp/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Makefile at top of application tree
 TOP = ..
 include $(TOP)/configure/CONFIG

--- a/modules/database/src/template/top/supportApp/src/Makefile
+++ b/modules/database/src/template/top/supportApp/src/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2003 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../..
 
 include $(TOP)/configure/CONFIG

--- a/modules/database/src/template/top/supportApp/src/_APPNAME_.dbd
+++ b/modules/database/src/template/top/supportApp/src/_APPNAME_.dbd
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2003 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # provide definitions such as
 #include "xxxRecord.dbd"
 #device(xxx,CONSTANT,devXxxSoft,"SoftChannel")

--- a/src/template/base/Makefile
+++ b/src/template/base/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../../..
 
 include $(TOP)/configure/CONFIG

--- a/src/template/base/makeBaseApp.pl
+++ b/src/template/base/makeBaseApp.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Authors: Ralph Lange, Marty Kraimer, Andrew Johnson and Janet Anderson
 
 use FindBin qw($RealBin);

--- a/src/template/base/top/.gitignore
+++ b/src/template/base/top/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Install directories
 /bin/
 /cfg/

--- a/src/template/base/top/Makefile
+++ b/src/template/base/top/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Makefile at top of application tree
 TOP = .
 include $(TOP)/configure/CONFIG

--- a/src/template/base/top/configure/CONFIG
+++ b/src/template/base/top/configure/CONFIG
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # CONFIG - Load build configuration data
 #
 # Do not make changes to this file!

--- a/src/template/base/top/configure/CONFIG_SITE
+++ b/src/template/base/top/configure/CONFIG_SITE
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # CONFIG_SITE
 
 # Make any application-specific changes to the EPICS build

--- a/src/template/base/top/configure/Makefile
+++ b/src/template/base/top/configure/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1999 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=..
 
 include $(TOP)/configure/CONFIG

--- a/src/template/base/top/configure/RELEASE
+++ b/src/template/base/top/configure/RELEASE
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # RELEASE - Location of external support modules
 #
 # IF YOU CHANGE ANY PATHS in this file or make API changes to

--- a/src/template/base/top/configure/RULES
+++ b/src/template/base/top/configure/RULES
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # RULES
 
 include $(CONFIG)/RULES

--- a/src/template/base/top/configure/RULES.ioc
+++ b/src/template/base/top/configure/RULES.ioc
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 1999 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #RULES.ioc
 include $(CONFIG)/RULES.ioc

--- a/src/template/base/top/configure/RULES_DIRS
+++ b/src/template/base/top/configure/RULES_DIRS
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 1999 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #RULES_DIRS
 include $(CONFIG)/RULES_DIRS

--- a/src/template/base/top/configure/RULES_TOP
+++ b/src/template/base/top/configure/RULES_TOP
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 1997 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #RULES_TOP
 include $(CONFIG)/RULES_TOP
 

--- a/src/template/ext/Makefile
+++ b/src/template/ext/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../../..
 
 include $(TOP)/configure/CONFIG

--- a/src/template/ext/makeBaseExt.pl
+++ b/src/template/ext/makeBaseExt.pl
@@ -1,5 +1,9 @@
 #!/usr/bin/env perl
 
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Authors: Ralph Lange, Marty Kraimer, Andrew Johnson and Janet Anderson
 
 use Cwd;

--- a/src/template/ext/top/.gitignore
+++ b/src/template/ext/top/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Install directories
 /bin/
 /cfg/

--- a/src/template/ext/top/Makefile
+++ b/src/template/ext/top/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Makefile at the top of an extensions tree
 
 TOP = .

--- a/src/template/ext/top/README
+++ b/src/template/ext/top/README
@@ -3,3 +3,9 @@ Notes:
 Each time you add a new extension in the src directory you
 must add the extension directory name to src/Makefile.
 
+
+SPDX-FileCopyrightText: 2000 Argonne National laboratory
+
+SPDX-License-Identifier: EPICS
+
+

--- a/src/template/ext/top/README
+++ b/src/template/ext/top/README
@@ -5,7 +5,4 @@ must add the extension directory name to src/Makefile.
 
 
 SPDX-FileCopyrightText: 2000 Argonne National laboratory
-
 SPDX-License-Identifier: EPICS
-
-

--- a/src/template/ext/top/configure/CONFIG
+++ b/src/template/ext/top/configure/CONFIG
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # CONFIG - Load build configuration data
 #
 # Do not make changes to this file!

--- a/src/template/ext/top/configure/CONFIG_SITE
+++ b/src/template/ext/top/configure/CONFIG_SITE
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # CONFIG_SITE
 #
 # Make any extensions-specific changes to the EPICS build

--- a/src/template/ext/top/configure/Makefile
+++ b/src/template/ext/top/configure/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Makefile in extensions/configure directory
 
 TOP=..

--- a/src/template/ext/top/configure/RELEASE
+++ b/src/template/ext/top/configure/RELEASE
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # RELEASE Locations of external modules
 #
 # NOTE: The build does not check dependancies on files

--- a/src/template/ext/top/configure/RULES
+++ b/src/template/ext/top/configure/RULES
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # extensions/configure/RULES
 
 include $(CONFIG)/RULES

--- a/src/template/ext/top/configure/RULES_DIRS
+++ b/src/template/ext/top/configure/RULES_DIRS
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # extensions/configure/RULES_DIRS
 
 include $(CONFIG)/RULES_DIRS

--- a/src/template/ext/top/configure/RULES_IDL
+++ b/src/template/ext/top/configure/RULES_IDL
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2004 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # extensions/configure/RULES_IDL
 
 ifdef T_A

--- a/src/template/ext/top/configure/RULES_JAVA
+++ b/src/template/ext/top/configure/RULES_JAVA
@@ -1,5 +1,3 @@
-# Copyright (c) 2002 The Regents of the University of California, as
-# Copyright (c) 2002 The University of Chicago, as Operator of Argonne
 # SPDX-FileCopyrightText: 2000 Argonne National Laboratory
 #
 # SPDX-License-Identifier: EPICS

--- a/src/template/ext/top/configure/RULES_JAVA
+++ b/src/template/ext/top/configure/RULES_JAVA
@@ -1,13 +1,8 @@
-#*************************************************************************
-# Copyright (c) 2002 The University of Chicago, as Operator of Argonne
-#     National Laboratory.
 # Copyright (c) 2002 The Regents of the University of California, as
-#     Operator of Los Alamos National Laboratory.
+# Copyright (c) 2002 The University of Chicago, as Operator of Argonne
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
 # SPDX-License-Identifier: EPICS
-# EPICS Base is distributed subject to a Software License Agreement found
-# in file LICENSE that is included with this distribution. 
-#*************************************************************************
-
 
 ifeq ($(BUILD_CLASS),HOST)
 

--- a/src/template/ext/top/configure/RULES_TOP
+++ b/src/template/ext/top/configure/RULES_TOP
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # extensions/configure/RULES_TOP
 
 include $(CONFIG)/RULES_TOP

--- a/src/template/ext/top/configure/os/CONFIG_SITE.darwin-aarch64.darwin-aarch64
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.darwin-aarch64.darwin-aarch64
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 

--- a/src/template/ext/top/configure/os/CONFIG_SITE.darwin-x86.darwin-x86
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.darwin-x86.darwin-x86
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 

--- a/src/template/ext/top/configure/os/CONFIG_SITE.freebsd-x86_64.freebsd-x86_64
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.freebsd-x86_64.freebsd-x86_64
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 # Only the local epics system manager should modify this file

--- a/src/template/ext/top/configure/os/CONFIG_SITE.linux-aarch64.linux-aarch64
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.linux-aarch64.linux-aarch64
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 # Site Specific Configuration Information
 
 X11_LIB=/usr/lib/aarch64-linux-gnu

--- a/src/template/ext/top/configure/os/CONFIG_SITE.linux-ppc.linux-ppc
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.linux-ppc.linux-ppc
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 # Only the local epics system manager should modify this file

--- a/src/template/ext/top/configure/os/CONFIG_SITE.linux-x86-debug.linux-x86-debug
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.linux-x86-debug.linux-x86-debug
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 # Only the local epics system manager should modify this file

--- a/src/template/ext/top/configure/os/CONFIG_SITE.linux-x86.linux-x86
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.linux-x86.linux-x86
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 # Only the local epics system manager should modify this file

--- a/src/template/ext/top/configure/os/CONFIG_SITE.linux-x86_64-debug.linux-x86_64-debug
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.linux-x86_64-debug.linux-x86_64-debug
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 # Only the local epics system manager should modify this file

--- a/src/template/ext/top/configure/os/CONFIG_SITE.linux-x86_64.linux-x86_64
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.linux-x86_64.linux-x86_64
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 # Only the local epics system manager should modify this file

--- a/src/template/ext/top/configure/os/CONFIG_SITE.win32-x86-debug.win32-x86-debug
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.win32-x86-debug.win32-x86-debug
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2006 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 # Only the local epics system manager should modify this file

--- a/src/template/ext/top/configure/os/CONFIG_SITE.win32-x86.win32-x86
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.win32-x86.win32-x86
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # CONFIG_SITE.win32-x86.win32-x86,v 1.3 2003/09/03 19:06:10 jba Exp
 #

--- a/src/template/ext/top/configure/os/CONFIG_SITE.windows-x64.windows-x64
+++ b/src/template/ext/top/configure/os/CONFIG_SITE.windows-x64.windows-x64
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2010 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 #
 # Site Specific Configuration Information
 # Only the local epics system manager should modify this file

--- a/src/template/ext/top/exampleExt/Makefile
+++ b/src/template/ext/top/exampleExt/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../..
 include $(TOP)/configure/CONFIG
 

--- a/src/template/ext/top/exampleExt/RELEASE_NOTES.HTM
+++ b/src/template/ext/top/exampleExt/RELEASE_NOTES.HTM
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2000 Argonne National laboratory
+
+SPDX-License-Identifier: EPICS
+-->
+
 <HTML>
 <BODY>
 

--- a/src/template/ext/top/exampleExt/caExample.c
+++ b/src/template/ext/top/exampleExt/caExample.c
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
-//
-// SPDX-License-Identifier: EPICS
+/* SPDX-FileCopyrightText: 1998 Argonne National Laboratory */
+
+/* SPDX-License-Identifier: EPICS */
 
 /*caExample.c*/
 #include <stddef.h>

--- a/src/template/ext/top/exampleExt/caExample.c
+++ b/src/template/ext/top/exampleExt/caExample.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 1998 Argonne National Laboratory
+//
+// SPDX-License-Identifier: EPICS
+
 /*caExample.c*/
 #include <stddef.h>
 #include <stdlib.h>

--- a/src/template/ext/top/simpleExt/Makefile
+++ b/src/template/ext/top/simpleExt/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP=../..
 include $(TOP)/configure/CONFIG
 

--- a/src/template/ext/top/src/Makefile
+++ b/src/template/ext/top/src/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2000 Argonne National Laboratory
+#
+# SPDX-License-Identifier: EPICS
+
 TOP = ..
 include $(TOP)/configure/CONFIG
 


### PR DESCRIPTION
The goal here is twofold:

- Provide clarification on the licensing of files that are "given over" to the user by `makeBaseApp.pl`. Until now, it was a bit unclear; one could only assume that the files are available under the EPICS license, but couldn't be sure.
- Allow using a linter (like the one provided by the [REUSE initiative](https://reuse.software/)) by tagging *every* file. In practice, dealing with exceptions and such is quite annoying, and tagging everything is the only reasonable way to deal with licensing.

Copyright information was gathered using `git log` with per-line history tracking, which allows following the history of a file through renames. There were a couple of cases (e.g.  caPerlApp) where this didn't work, so I traced the history manually.

Tagging every file means that plain-text READMEs are also tagged, which is a bit annoying. I put the tags at the bottom of the files so that they're not the first thing you read.