### PR TITLE
Fix issue with RSRV_SERVER_PORT above 9999

### DIFF
--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -590,8 +590,7 @@ void rsrv_init (void)
             errlogPrintf ( "cas " ERL_WARNING ": reachable with UDP unicast (a host's IP in EPICS_CA_ADDR_LIST)\n" );
         }
 
-        epicsSnprintf(buf, sizeof(buf)-1u, "%u", ca_server_port);
-        buf[sizeof(buf)-1u] = '\0';
+        epicsSnprintf(buf, sizeof(buf), "%u", ca_server_port);
         epicsEnvSet("RSRV_SERVER_PORT", buf);
     }
 


### PR DESCRIPTION
In reference to https://github.com/epics-base/epics-base/issues/515

```
iocInit
Starting iocInit
############################################################################
## EPICS R7.0.8.1-DEV
## Rev. be8f8b41ff468427b3bf-dirty
## Rev. Date Git: 2024-06-13 14:35:43 -0700
############################################################################
cas WARNING: Configured TCP port was unavailable.
cas WARNING: Using dynamically assigned TCP port 42689,
cas WARNING: but now two or more servers share the same UDP port.
cas WARNING: Depending on your IP kernel this server may not be
cas WARNING: reachable with UDP unicast (a host's IP in EPICS_CA_ADDR_LIST)
iocRun: All initialization complete
epics> epicsEnvShow RSRV_SERVER_PORT
RSRV_SERVER_PORT=42689
```