### PR TITLE
Fix for `-D_FORTIFY_SOURCE=3`

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -60,7 +60,10 @@ jobs:
             # Remove respective -Wno-error=... flag once it is fixed.
             extra: "CMD_CXXFLAGS=-std=c++20
                     CMD_CPPFLAGS='-fdiagnostics-color
+                                  -fstack-protector-strong
+                                  -Wformat
                                   -Werror
+                                  -Werror=format-security
                                   -Wno-error=deprecated-declarations
                                   -Wno-error=stringop-truncation
                                   -Wno-error=restrict
@@ -68,8 +71,9 @@ jobs:
                                   -Wno-error=nonnull
                                   -Wno-error=dangling-pointer
                                   -Wno-error=format-overflow
-                                  -Wno-error=format-security
-                                  -Wno-error=stringop-overread'"
+                                  -Wno-error=stringop-overread
+                                  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3'
+                    CMD_LDFLAGS=-Wl,-z,relro"
 
           - os: ubuntu-20.04
             cmp: gcc

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -145,63 +145,66 @@ long dbPutSpecial(DBADDR *paddr,int pass)
 }
 
 static void get_enum_strs(DBADDR *paddr, char **ppbuffer,
-    rset *prset,long    *options)
+                          rset *prset, long *options)
 {
-        short           field_type=paddr->field_type;
-        dbFldDes        *pdbFldDes = paddr->pfldDes;
-        dbMenu          *pdbMenu;
-        dbDeviceMenu    *pdbDeviceMenu;
-        char            **papChoice;
-        unsigned long   no_str;
-        char            *ptemp;
-        struct dbr_enumStrs *pdbr_enumStrs=(struct dbr_enumStrs*)(*ppbuffer);
-    unsigned int i;
+    struct dbr_enumStrs *penum=(struct dbr_enumStrs*)(*ppbuffer);
+    /* advance output buffer on success or failure for next option */
+    *ppbuffer = dbr_enumStrs_size + (char*)penum;
 
-        memset(pdbr_enumStrs,'\0',dbr_enumStrs_size);
-        switch(field_type) {
-                case DBF_ENUM:
-                    if( prset && prset->get_enum_strs ) {
-                        (*prset->get_enum_strs)(paddr,pdbr_enumStrs);
-                    } else {
-                        *options = (*options)^DBR_ENUM_STRS;/*Turn off option*/
-                    }
-                    break;
-                case DBF_MENU:
-                    pdbMenu = (dbMenu *)pdbFldDes->ftPvt;
-                    no_str = pdbMenu->nChoice;
-                    papChoice= pdbMenu->papChoiceValue;
-                    goto choice_common;
-                case DBF_DEVICE:
-                    pdbDeviceMenu = (dbDeviceMenu *)pdbFldDes->ftPvt;
-                    if(!pdbDeviceMenu) {
-                        *options = (*options)^DBR_ENUM_STRS;/*Turn off option*/
-                        break;
-                    }
-                    no_str = pdbDeviceMenu->nChoice;
-                    papChoice = pdbDeviceMenu->papChoice;
-                    goto choice_common;
-choice_common:
-                    i = sizeof(pdbr_enumStrs->strs)/
-                        sizeof(pdbr_enumStrs->strs[0]);
-                    if(i<no_str) no_str = i;
-                    pdbr_enumStrs->no_str = no_str;
-                    ptemp = &(pdbr_enumStrs->strs[0][0]);
-                    for (i=0; i<no_str; i++) {
-                        if(papChoice[i]==NULL) *ptemp=0;
-                        else {
-                            strncpy(ptemp,papChoice[i],
-                                sizeof(pdbr_enumStrs->strs[0]));
-                            *(ptemp+sizeof(pdbr_enumStrs->strs[0])-1) = 0;
-                        }
-                        ptemp += sizeof(pdbr_enumStrs->strs[0]);
-                    }
-                    break;
-                default:
-                    *options = (*options)^DBR_ENUM_STRS;/*Turn off option*/
-                    break;
+    memset(penum, 0, dbr_enumStrs_size);
+
+    /* from this point
+     * on success, return early
+     * on failure, jump or fall through to clear *options bit.
+     */
+
+    if(paddr->field_type == DBF_ENUM) {
+        if( prset && prset->get_enum_strs ) {
+            (*prset->get_enum_strs)(paddr,penum);
+            return;
         }
-        *ppbuffer = ((char *)*ppbuffer) + dbr_enumStrs_size;
+
+    } else if(paddr->field_type == DBF_MENU || paddr->field_type == DBF_DEVICE) {
+        char **ppchoices;
+        epicsUInt32 i, nchoices = 0;
+
+        if(paddr->field_type == DBF_MENU) {
+            dbMenu *pmenu = paddr->pfldDes->ftPvt;
+            nchoices = pmenu->nChoice;
+            ppchoices= pmenu->papChoiceValue;
+
+        } else if(paddr->field_type == DBF_DEVICE) {
+            dbDeviceMenu *pdevs = paddr->pfldDes->ftPvt;
+            if(!pdevs)
+                goto nostrs;
+
+            nchoices = pdevs->nChoice;
+            ppchoices = pdevs->papChoice;
+        }
+
+        if(nchoices > NELEMENTS(penum->strs))
+            nchoices = NELEMENTS(penum->strs); /* availible > capacity, truncated list */
+
+        penum->no_str = nchoices;
+
+        for(i=0; i<nchoices; i++) {
+            if(ppchoices[i]) {
+                strncpy(penum->strs[i], ppchoices[i],
+                        sizeof(penum->strs[i]));
+                /* strs[i][] allowed to omit trailing nil */
+            } else {
+                penum->strs[i][0] = '\0';
+            }
+        }
         return;
+
+    } else {
+        /* other DBF_* fall through to error */
+    }
+
+nostrs:
+    /* indicate option data not available.  distinct from no_str==0 */
+    *options = (*options)^DBR_ENUM_STRS;
 }
 
 static void get_graphics(DBADDR *paddr, char **ppbuffer,

--- a/modules/database/src/ioc/db/dbCommonPvt.h
+++ b/modules/database/src/ioc/db/dbCommonPvt.h
@@ -15,13 +15,21 @@ typedef struct dbCommonPvt {
     /* Thread which is currently processing this record */
     struct epicsThreadOSD* procThread;
 
-    struct dbCommon common;
+    /* actually followed by:
+     * struct dbCommon common;
+     */
 } dbCommonPvt;
 
 static EPICS_ALWAYS_INLINE
 dbCommonPvt* dbRec2Pvt(struct dbCommon *prec)
 {
-    return CONTAINER(prec, dbCommonPvt, common);
+    return (dbCommonPvt*)((char*)prec - sizeof(dbCommonPvt));
+}
+
+static EPICS_ALWAYS_INLINE
+dbCommon* dbPvt2Rec(struct dbCommonPvt *pvt)
+{
+    return (dbCommon*)&pvt[1];
 }
 
 #endif // DBCOMMONPVT_H

--- a/modules/database/src/ioc/dbStatic/dbStaticRun.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticRun.c
@@ -66,7 +66,17 @@ void devExtend(dsxt *pdsxt)
         pthisDevSup->pdsxt = pdsxt;
     }
 }
-
+
+/* Ensure that: sizeof(dbCommonPvt) + pdbRecordType->rec_size
+ * accounts for necessary alignment of record type struct
+ */
+typedef struct {
+    dbCommonPvt prefix;
+    /* ensure no padding needed... */
+    dbCommon suffix;
+} dbCommonPvtAlignmentTest;
+STATIC_ASSERT(offsetof(dbCommonPvtAlignmentTest, suffix)==sizeof(dbCommonPvt));
+
 long dbAllocRecord(DBENTRY *pdbentry,const char *precordName)
 {
     dbRecordType    *pdbRecordType = pdbentry->precordType;
@@ -90,8 +100,8 @@ long dbAllocRecord(DBENTRY *pdbentry,const char *precordName)
                     precordName, pdbRecordType->name, pdbRecordType->rec_size);
         return(S_dbLib_noRecSup);
     }
-    ppvt = dbCalloc(1, offsetof(dbCommonPvt, common) + pdbRecordType->rec_size);
-    precord = &ppvt->common;
+    ppvt = dbCalloc(1, sizeof(dbCommonPvt) + pdbRecordType->rec_size);
+    precord = dbPvt2Rec(ppvt);
     ppvt->recnode = precnode;
     precord->rdes = pdbRecordType;
     precnode->precord = precord;


### PR DESCRIPTION
Change the composition of `dbCommonPvt`, and require the use of `dbPvt2Rec()` to cast to `dbCommon*`.

Attempt to address #514.  Perhaps more workaround than fix.
