### PR TITLE
Fix conflicts from `windows.h` in `epicsAtomicOSD.h`

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -18,6 +18,14 @@ __This version of EPICS has not been released yet.__
 
 __Add new items below here__
 
+### Reduce symbol and macro pollution from epicsAtomic.h on WIN32
+
+`epicsAtomic.h` no longer pulls in as many unneeded declarations and macros from
+`windows.h`. Prior to this change, including `epicsAtomic.h` at the wrong time
+could result in unexpected compiler errors. Due to the nature of `windows.h`,
+some unneeded declarations are still pulled in, however the number is greatly reduced.
+Code that needs these declarations should explicitly include `windows.h` before `epicsAtomic.h`.
+
 ### epicsExport simplifications
 
 `epicsExportAddress()`, `epicsExportRegistrar()` and `epicsRegisterFunction()`

--- a/modules/libcom/src/osi/os/WIN32/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsAtomicOSD.h
@@ -19,27 +19,50 @@
 
 #define EPICS_ATOMIC_OS_NAME "WIN32"
 
-#ifdef VC_EXTRALEAN
-#   define VC_EXTRALEAN_DETECTED_epicsAtomicOSD_h
-#else
-#   define VC_EXTRALEAN
-#endif
+/* Disable extra declarations that we don't need here (i.e. winsock1, rpc, etc.) */
+#pragma push_macro("WIN32_LEAN_AND_MEAN")
+#undef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 
-#ifdef STRICT
-#   define STRICT_DETECTED_epicsAtomicOSD_h
-#else
-#   define STRICT
-#endif
+#pragma push_macro("STRICT")
+#undef STRICT
+#define STRICT
+
+/* Disable min/max macros from windows.h. These macros can cause issues with headers such as <algorithm> that declare or use std::min/max */
+#pragma push_macro("NOMINMAX")
+#undef NOMINMAX
+#define NOMINMAX
+
+/* Disable 'service controller' includes */
+#pragma push_macro("NOSERVICE")
+#undef NOSERVICE
+#define NOSERVICE
+
+/* Disable 'input management engine' includes */
+#pragma push_macro("NOIME")
+#undef NOIME
+#define NOIME
+
+/* Disable 'modem configuration extensions' includes */
+#pragma push_macro("NOMCX")
+#undef NOMCX
+#define NOMCX
+
+/* Disable GDI includes */
+#pragma push_macro("NOGDI")
+#undef NOGDI
+#define NOGDI
 
 #include "windows.h"
 
-#ifndef VC_EXTRALEAN_DETECTED_epicsAtomicOSD_h
-#   undef VC_EXTRALEAN
-#endif
-
-#ifndef STRICT_DETECTED_epicsAtomicOSD_h
-#   undef STRICT
-#endif
+/* Restore previous macro values */
+#pragma pop_macro("WIN32_LEAN_AND_MEAN")
+#pragma pop_macro("STRICT")
+#pragma pop_macro("NOMINMAX")
+#pragma pop_macro("NOSERVICE")
+#pragma pop_macro("NOIME")
+#pragma pop_macro("NOMCX")
+#pragma pop_macro("NOGDI")
 
 #if defined ( _WIN64 )
 #    define MS_ATOMIC_64

--- a/modules/libcom/src/osi/os/WIN32/epicsAtomicOSD.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsAtomicOSD.h
@@ -53,6 +53,21 @@
 #undef NOGDI
 #define NOGDI
 
+/* Disable crypto stuff */
+#pragma push_macro("NOCRYPT")
+#undef NOCRYPT
+#define NOCRYPT
+
+/* Disable sound driver routines */
+#pragma push_macro("NOSOUND")
+#undef NOSOUND
+#define NOSOUND
+
+/* Disable Kanji writing system support */
+#pragma push_macro("NOKANJI")
+#undef NOKANJI
+#define NOKANJI
+
 #include "windows.h"
 
 /* Restore previous macro values */
@@ -63,6 +78,9 @@
 #pragma pop_macro("NOIME")
 #pragma pop_macro("NOMCX")
 #pragma pop_macro("NOGDI")
+#pragma pop_macro("NOCRYPT")
+#pragma pop_macro("NOSOUND")
+#pragma pop_macro("NOKANJI")
 
 #if defined ( _WIN64 )
 #    define MS_ATOMIC_64


### PR DESCRIPTION
In short:
* `VC_EXTRALEAN` is only relevant to the ATL/MFC headers
* `WIN32_LEAN_AND_MEAN` excludes a bunch of random declarations that come from `windows.h` (i.e. winsock1)
* `NOMINMAX` disables the min/max macros defined by `windows.h`. These tend to cause funny issues in C++ STL headers such as `<algorithm>`

Part of the work for #513 split from #510 