### PR TITLE
readline: only keep history for interactive session

### DIFF
--- a/modules/libcom/src/osi/os/default/gnuReadline.c
+++ b/modules/libcom/src/osi/os/default/gnuReadline.c
@@ -109,7 +109,7 @@ osdReadline (const char *prompt, struct readlineContext *context)
             line[linelen] = '\0';
     }
     context->line = line;
-    if (line && *line)
+    if (line && *line && !context->in)
         add_history(line);
     return line;
 }


### PR DESCRIPTION
Only `add_history()`, and persist history, for interactive readline session.  Otherwise entries in iocsh scripts end up in `.iocsh_history` repeatedly.

This change is to some extent a matter of opinion, and mine is changing.  I initially through that having the start script history would be useful, but so far have only found it gets in the way of my most common task, re-running the same commands before and after an IOC restart.