### PR TITLE
Show buffered line along with DB parse error

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbYacc.y
+++ b/modules/database/src/ioc/dbStatic/dbYacc.y
@@ -378,6 +378,7 @@ static int yyerror(char *str)
         dbIncludePrint();
         yyFailed = TRUE;
     }
+    fprintf(stderr, "\n %d | %s\n", pinputFileNow->line_num, my_buffer);
     return(0);
 }
 static long pvt_yy_parse(void)


### PR DESCRIPTION
Yet again I find myself looking at a parse error in a generated .db file with the usual sigh.  Wondering what I mistyped, and where.  Then it occurs to me that the .db file parse input is buffered by line.  So why not show the whole line with the syntax error?

```
ERROR: field(bi, "LOCALHOST:NET:lo:CR") {
ERROR: syntax error
 at or before 'field' in path "/home/dev/epics/linStat/iocBoot/iocdemo/../../db"  file "linStatNIC.db" line 192
ERROR failed to load 'linStatNIC.db'
```

Now I see both what and where I typo'd!