### PR TITLE
freebsd: Add support for x86 and amd64 builds

### DIFF
--- a/configure/os/CONFIG.freebsd-x86_64.freebsd-x86_64
+++ b/configure/os/CONFIG.freebsd-x86_64.freebsd-x86_64
@@ -2,13 +2,23 @@
 # Definitions for freebsd-x86_64 host - freebsd-x86_64 target builds
 # Sites may override these definitions in CONFIG_SITE.freebsd-x86_64.freebsd-x86_64
 #-------------------------------------------------------
-GNU_DIR=/usr/local
+GNU_DIR=/usr
 
 # Include common gnu compiler definitions
 include $(CONFIG)/CONFIG.gnuCommon
+
+GNU_BIN = $(GNU_DIR)/bin
+GNU_LIB = $(GNU_DIR)/lib
+
+CMPLR_CLASS = clang
+
+CC = $(GNU_BIN)/$(CMPLR_PREFIX)cc$(CMPLR_SUFFIX)
+CCC = $(GNU_BIN)/$(CMPLR_PREFIX)c++$(CMPLR_SUFFIX)
+CPP = $(CC) -x c -E
+
+GNU_LDLIBS_YES =
 
 STATIC_LDFLAGS_YES= -Wl,-Bstatic
 STATIC_LDFLAGS_NO=
 STATIC_LDLIBS_YES= -Wl,-Bdynamic
 STATIC_LDLIBS_NO=
-

--- a/modules/libcom/src/osi/os/default/epicsMMIODef.h
+++ b/modules/libcom/src/osi/os/default/epicsMMIODef.h
@@ -139,8 +139,12 @@ bswap32(epicsUInt32 value)
 /* hton* is optimized or a builtin for most compilers
  * so use it if possible
  */
+#ifndef bswap16
 #define bswap16(v) htons(v)
+#endif
+#ifndef bswap32
 #define bswap32(v) htonl(v)
+#endif
 
 #  define be_ioread16(A)    bswap16(nat_ioread16(A))
 #  define be_ioread32(A)    bswap32(nat_ioread32(A))

--- a/src/tools/EpicsHostArch.pl
+++ b/src/tools/EpicsHostArch.pl
@@ -43,6 +43,8 @@ sub HostArch {
         return "cygwin-x86"     if m/^i[3-6]86-cygwin/;
         return 'solaris-sparc'  if m/^sun4-solaris/;
         return 'solaris-x86'    if m/^i86pc-solaris/;
+        return 'freebsd-x86_64' if m/^x86_64-freebsd/;
+        return 'freebsd-x86_64' if m/^amd64-freebsd/;
 
         my ($kernel, $hostname, $release, $version, $cpu) = uname;
         if (m/^darwin/) {


### PR DESCRIPTION
Use the OS compiler, ie cc and c++.

The version overrides the GNU CC support.