### PR TITLE
Add RTEMS ntpd support

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS
+++ b/configure/os/CONFIG.Common.RTEMS
@@ -140,7 +140,12 @@ OP_SYS_CFLAGS += $(OP_SYS_CFLAGS_NET_$(RTEMS_NETWORKING))
 POSIX_CPPFLAGS_posix = -D_GNU_SOURCE -D_DEFAULT_SOURCE
 POSIX_CPPFLAGS = $(POSIX_CPPFLAGS_$(OS_API))
 
+ifneq ($(RTEMS_VERSION),5)
+LDLIBS_posix_NET_ntp = -lntp
+endif
+
 OP_SYS_LDLIBS_posix_NET_yes = -ltftpfs -lz -ltelnetd
+OP_SYS_LDLIBS_posix_NET_yes += $(LDLIBS_posix_NET_ntp)
 OP_SYS_LDLIBS_posix_NET_yes += $(RTEMS_NET_LIB_$(RTEMS_NETWORKING))
 OP_SYS_LDLIBS_posix_NET_no = -ltftpfs -lz
 OP_SYS_LDLIBS_score_NET_yes = -lnfs

--- a/documentation/new-notes/PR-528.md
+++ b/documentation/new-notes/PR-528.md
@@ -1,0 +1,125 @@
+### Add RTEMS ntpd support
+
+GitHub [PR #528](https://github.com/epics-base/epics-base/pull/528)
+
+This changes requires `libntp` available in the RTEMS
+[`rtems-net-services`](https://gitlab.rtems.org/rtems/pkg/rtems-net-services)
+package. The package builds for the legacy and libbsd networking
+stacks.
+
+The `ntpd` module works with RTEMS 6 and later. EPICS base built
+against RTEMS 5 uses default POSIX support as RTEMS 5 does not have
+the kernel NTP support `ntpd` requires.
+
+#### NTP Time Commands
+
+Configure and start `ntpd` using IOC Shell commands:
+
+- `NTPTime_Start`
+- `NTPTime_SyncWait`
+- `NTPTime_Update`
+
+##### `NTPTime_Start`
+
+This command configures and start `ntpd` running. It sets environment
+variables the NTP support in EPICS base uses. The command accepts two
+arguments:
+
+1. `ip` - the IP address of the NTP to use
+1. `config` - the path to an `ntp.conf` format configuration file
+
+If the BSP you are using sets the `RTEMS_NET_NTP_IP` environment
+variables when booting you can the follow command in your `st.cmd`
+file:
+
+```
+NTPTime_Update("${RTEMS_NET_NTP_IP}")
+```
+
+An example of this is:
+
+```
+NTPTime_Update("1.2.3.4")
+NTP update: time is 08/19/26 01:59:00.011927552 UTC
+```
+
+An `ntpd` started with an IP address used a [configuration
+template](https://gitlab.rtems.org/rtems/pkg/rtems-net-services/-/blob/main/bsd/rtemsbsd/rtems/rtems-ntpd-configs.c)
+from RTEMS. If you require site specific configuration settings use
+this command with the `config` option.
+
+The `config` option accepts a path to an `ntp.conf` format
+configuration file. Placing this file on your NFS server lets you
+manage your NTP settings at a system level without rebuilding EPICS
+base. The following in an `st.cmd` file uses configuration file:
+
+```
+NTPTime_Start("config", "/mnt/site/iocapp/ntp.conf")
+```
+
+An example of this is:
+
+```
+NTPTime_Start("config", "/mnt/site/iocapp/ntp.conf")
+NTP: setenv /mnt/site/iocapp/ntp.conf -> EPICS_TS_NTP_CONF_FILE
+```
+
+##### `NTPTime_SyncWait`
+
+This command waits for `ntpd` to synchronize the RTEMS clock with the
+NTP server. NTP has to have been started or an error is printed. The
+command is useful if your IOC requires an accurate clock. The time
+`ntpd` takes to synchronize can depend on a range of factors and ca
+vary from site to site.
+
+The command accepts a time out in seconds to wait. The time out
+ensures the start up does not stop if `ntpd` does not synchronize the
+clock. A timeout prints an error and returns on IOC shell error.
+
+The following example `st.cmd` waits up to 30 seconds:
+
+```
+NTPTime_SyncWait(30)
+```
+
+An example of this is:
+
+```
+NTPTime_SyncWait(30)
+RTEMS NTP: waiting 30 seconds for sync
+NTP is synchronized
+```
+
+##### `NTPTime_Update`
+
+This command is a Simple NTP synchronous poll of an NTP server to get
+the time and set the RTEMS clock. It provides a fast means to set the
+local clock close to the NTP server's clock. You should run `ntpd` to
+maintain an accurate clock however a site that only needs to the clock
+to be close to the NTP clock use this command.
+
+The following line in an `st.cmd` script:
+
+```
+NTPTime_Update("${RTEMS_NET_NTP_IP}")
+```
+
+results in:
+
+```
+NTPTime_Update("1.2.3.4")
+NTP update: time is 08/19/26 01:59:00.011927552 UTC
+```
+
+Updating the clock before starting `ntpd` brings the clock close to
+the NTP and avoid waiting for the time to synchronize.
+
+#### NTP Environment Variables
+
+Configure `ntpd` with the following env variables:
+
+1. `EPICS_TS_NTP_INET` - NTP server
+1. `EPICS_TS_NTP_CONF_FILE` - `ntpd` configuration file
+
+A configuration file is used if both a configuration file and server
+IP address are set.

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -1165,8 +1165,6 @@ POSIX_Init ( void *argument __attribute__((unused)))
         rtems_bsd_command_netstat(2, (char**) netstat_args);
     }
 
-    /* until now there is no NTP support in libbsd -> Sebastian Huber ... */
-    printf("\n***** Until now no NTP support in RTEMS 5 with rtems-libbsd *****\n");
     printf("\n***** Ask ntp server once... *****\n");
     if (rtemsInit_NTP_server_ip[0]=='\0') {
       printf ("***** No NTP server ...\n");

--- a/modules/libcom/src/osi/Makefile
+++ b/modules/libcom/src/osi/Makefile
@@ -82,7 +82,7 @@ Com_SRCS += epicsGeneralTime.c
 # Time providers
 Com_SRCS += osiClockTime.c
 Com_SRCS_vxWorks += osiNTPTime.c tz2timezone.c
-Com_SRCS_RTEMS += osiNTPTime.c
+Com_SRCS_RTEMS += osiNTPTime.c epicsSimpleNtp.c
 
 ifeq ($(OS_CLASS),vxWorks)
 osdTime.o: USR_CXXFLAGS += -DBUILD_TIME=$(shell perl -e 'print time')

--- a/modules/libcom/src/osi/os/RTEMS-posix/epicsSimpleNtp.c
+++ b/modules/libcom/src/osi/os/RTEMS-posix/epicsSimpleNtp.c
@@ -1,0 +1,90 @@
+/*************************************************************************\
+* (C) 2014 David Lettier.
+* http://www.lettier.com/
+* SPDX-License-Identifier: BSD-3-Clause
+*
+* use of UDP funktions and implement timeout, HPJ 15.12.2025
+\*************************************************************************/
+
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <rtems.h>
+#include "epicsSimpleNtp.h"
+
+int epicsSimpleNtpGetTime(char *ntpIp, struct timespec *now)
+{
+  int sockfd, n; // Socket file descriptor and the n return result from writing/reading from the socket.
+  int portno = 123; // NTP UDP port number.
+
+  // Create and zero out the packet. All 48 bytes worth.
+  ntp_packet packet = { 0 };
+  // Set the first byte's bits to 00,011,011 for li = 0, vn = 3, and mode = 3. The rest will be left set to zero.
+  *( ( char * ) &packet + 0 ) = 0x1b; // Represents 27 in base 10 or 00011011 in base 2.
+
+  /* Create an UDP socket, use IP address of given nameserver, set the port number
+     struct sockaddr_in serv_addr; // Server address data structure.
+     add timout of 2 seconds.
+   */
+  struct sockaddr_in serv_addr = {
+    .sin_family = AF_INET,
+    .sin_addr.s_addr = inet_addr(ntpIp),
+    .sin_port = htons( portno ),
+  };
+
+  sockfd = socket( AF_INET, SOCK_DGRAM, 0 );
+  if ( sockfd < 0 ) {
+    perror( "epicsNtpGetTime creating socket" );
+    return -1;
+  }
+
+  /* Set receive timeout to 2 seconds */
+  struct timeval tv = { .tv_sec = 2, .tv_usec = 0 };
+  if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+    perror("setsockopt");
+    return -1;
+  }
+
+  // Send it the NTP packet it wants. If n == -1, it failed.
+  n = sendto(sockfd, ( char* ) &packet, sizeof( ntp_packet ), 0, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
+  if ( n < 0 ) {
+    perror( "epicsNtpGetTime sending NTP request" );
+    close( sockfd );
+    return -1;
+  }
+
+  // Wait and receive the packet back from the server. If n == -1, it failed.
+  n = recvfrom(sockfd, ( char* ) &packet, sizeof( ntp_packet ), 0, NULL, NULL);
+  if (n < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      printf("Timeout - no response\n");
+    } else {
+      perror( "epicsNtpGetTime reading NTP reply" );
+    }
+    close( sockfd );
+    return -1;
+  }
+  close( sockfd );
+
+  // These two fields contain the time-stamp seconds as the packet left the NTP server.
+  // The number of seconds correspond to the seconds passed since 1900.
+  // ntohl() converts the bit/byte order from the network's to host's "endianness".
+  packet.txTm_s = ntohl( packet.txTm_s ); // Time-stamp seconds.
+  packet.txTm_f = ntohl( packet.txTm_f ); // Time-stamp fraction of a second.
+
+  // Extract the 32 bits that represent the time-stamp seconds (since NTP epoch) from when the packet left the server.
+  // Subtract 70 years worth of seconds from the seconds since 1900.
+  // This leaves the seconds since the UNIX epoch of 1970.
+  // (1900)------------------(1970)**************************************(Time Packet Left the Server)
+  time_t txTm = ( time_t ) ( packet.txTm_s - NTP_TIMESTAMP_DELTA );
+  now->tv_sec = txTm;
+  return 0;
+}

--- a/modules/libcom/src/osi/os/RTEMS-posix/epicsSimpleNtp.h
+++ b/modules/libcom/src/osi/os/RTEMS-posix/epicsSimpleNtp.h
@@ -1,0 +1,50 @@
+/*************************************************************************\
+* (C) 2014 David Lettier.
+* http://www.lettier.com/
+* SPDX-License-Identifier: BSD-3-Clause
+\*************************************************************************/
+#ifndef EPICSSIMPLENTP_H
+#define EPICSSIMPLENTP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NTP_TIMESTAMP_DELTA 2208988800ull
+
+int epicsSimpleNtpGetTime(char *ntpIp, struct timespec *now);
+
+typedef struct
+{
+
+  uint8_t li_vn_mode __attribute__((unused));      // Eight bits. li, vn, and mode.
+                                                   // li.   Two bits.   Leap indicator.
+                                                   // vn.   Three bits. Version number of the protocol.
+                                                   // mode. Three bits. Client will pick mode 3 for client.
+
+  uint8_t stratum __attribute__((unused));         // Eight bits. Stratum level of the local clock.
+  uint8_t poll __attribute__((unused));            // Eight bits. Maximum interval between successive messages.
+  uint8_t precision __attribute__((unused));       // Eight bits. Precision of the local clock.
+
+  uint32_t rootDelay __attribute__((unused));      // 32 bits. Total round trip delay time.
+  uint32_t rootDispersion __attribute__((unused)); // 32 bits. Max error aloud from primary clock source.
+  uint32_t refId __attribute__((unused));          // 32 bits. Reference clock identifier.
+
+  uint32_t refTm_s __attribute__((unused));        // 32 bits. Reference time-stamp seconds.
+  uint32_t refTm_f __attribute__((unused));        // 32 bits. Reference time-stamp fraction of a second.
+
+  uint32_t origTm_s __attribute__((unused));       // 32 bits. Originate time-stamp seconds.
+  uint32_t origTm_f __attribute__((unused));       // 32 bits. Originate time-stamp fraction of a second.
+
+  uint32_t rxTm_s __attribute__((unused));         // 32 bits. Received time-stamp seconds.
+  uint32_t rxTm_f __attribute__((unused));         // 32 bits. Received time-stamp fraction of a second.
+
+  uint32_t txTm_s __attribute__((unused));         // 32 bits and the most important field the client cares about. Transmit time-stamp seconds.
+  uint32_t txTm_f __attribute__((unused));         // 32 bits. Transmit time-stamp fraction of a second.
+
+} ntp_packet;              // Total: 384 bits or 48 bytes.
+
+#ifdef __cplusplus
+}
+#endif
+#endif // EPICSSIMPLENTP_H

--- a/modules/libcom/src/osi/os/RTEMS-posix/osdTime.cpp
+++ b/modules/libcom/src/osi/os/RTEMS-posix/osdTime.cpp
@@ -1,0 +1,749 @@
+/*************************************************************************\
+* Copyright (c) 2002 The University of Saskatchewan
+* Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
+*     National Laboratory.
+* Copyright (c) 2023 Chris Johns <chris@contemporary.software>
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+/*
+ * Author: Chris Johns
+ */
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#define EPICS_EXPOSE_LIBCOM_MONOTONIC_PRIVATE
+#include <epicsStdio.h>
+#include "epicsExit.h"
+#include "epicsTime.h"
+#include "errlog.h"
+#include "osdTime.h"
+#include "osiNTPTime.h"
+#include "osiClockTime.h"
+#include "generalTimeSup.h"
+#include "iocsh.h"
+#include "taskwd.h"
+
+#include "epicsSimpleNtp.h"
+
+#include <iocsh/initHooks.h>
+
+#include <rtems.h>
+
+/*
+ * This file is built automatically by EPICS's build system
+ */
+#if __RTEMS_MAJOR__ < 6
+
+/* Include the code from posix/osdTime.cpp. Better solutions welcome */
+
+#include "../posix/osdTime.cpp"
+
+#else /* __RTEMS_MAJOR__ < 6 */
+
+#include <string.h>
+
+#include <rtems/ntpd.h>
+#include <rtems/ntpq.h>
+
+extern "C" {
+
+/*
+ * NTPD is configured by a file /etc/ntp.conf. The RTEMS /etc/ directory
+ * does not survive a reset so ntp.conf is created each boot.
+ *
+ * Users can configure ntpd by:
+ *
+ *  None:
+ *     ntpd is not started
+ *
+ *  BOOTP/DHCP/Init:
+ *     The BOOTP server IP address is used if there is a valid BOOTP
+ *     record and variable rtemsInit_NTP_server_ip is empty and
+ *     rtems_bsdnet_config.ntp_server is set. If the variable
+ *     rtems_bsdnet_config.ntp_server is empty and rtemsInit_NTP_server_ip
+ *     is set it is used.
+ *
+ *  NTP Server IP:
+ *     The environment variable EPICS_TS_NTP_INET is used as the
+ *     address if no configuration file is set. This option takes
+ *     priority over BOOTP/DHCP/Init.
+ *
+ *  Configuration File:
+ *     The environment variable EPICS_TS_NTP_CONF_FILE is a path to a
+ *     configuration file that is used as is. This allows site specifc
+ *     and even board specific configuration support at run time. It
+ *     is recommended you provide a site specific configuration file
+ *     if you need site specific control. This option takes
+ *     priority over NTP Server IP.
+ *
+ *  The Configuration File option provides a system level means to
+ *  configure a site specific ntpd configuration that can be loaded
+ *  from a NFS file system when the system starts. This option
+ *  provides the ability to implement a site specific configuration of
+ *  ntpd.
+ *
+ *  Notes:
+ *    1. ntpd can take a while to synchronize the realtime clock
+ *    2. Changes in the environment variables not do reconfigure ntpd
+ */
+
+#define NTPD_CONFIG_NONE   0
+#define NTPD_CONFIG_BOOTP  1
+#define NTPD_CONFIG_NTP_IP 2
+#define NTPD_CONFIG_FILE   3
+
+#define osdNTP_NTPD_Fails  4
+
+/*
+ * NTPD Runner Interval
+ *
+ * The period in seconds the ntpd thread checks for a valid
+ * configuration.
+ */
+#define EPICS_NTPD_RUNNER_INTERVAL 1.0
+
+/*
+ * NTPD Monitor Intervals
+ *
+ * The periods are in seconds. The first is the period used when
+ * NtpD is not running. The second is the period when running.
+ * configuration.
+ */
+#define EPICS_NTPD_MONITOR_IDLE_INTERVAL   1.0
+#define EPICS_NTPD_MONITOR_ACTIVE_INTERVAL 10.0
+
+/*
+ * Environment variables
+ */
+#define EPICS_TS_NTP_INET      "EPICS_TS_NTP_INET"
+#define EPICS_TS_NTP_CONF_FILE "EPICS_TS_NTP_CONF_FILE"
+
+typedef ntp_sys_var_data ntpq_rl_data;
+
+/*
+ * Declared in rtems_init.c. No header.
+ */
+extern char rtemsInit_NTP_server_ip[16];
+
+/*
+ * For rtems_bsdnet_config.
+ */
+#ifdef RTEMS_LEGACY_STACK
+#include <rtems/rtems_bsdnet.h>
+extern struct rtems_bsdnet_config rtems_bsdnet_config;
+#endif /* RTEMS_LEGACY_STACK */
+
+ /*
+  * NTPD Private data
+  */
+static struct {
+    int          config_source;
+    char         config_arg[256]; /* could be a long path */
+    char         config_ip[32];
+    int          active;
+    int          synchronized;
+    int          ntpd_active;
+    int          ntpd_active_secs;
+    int          ntpd_finished;
+    float        runner_interval;
+    float        monitor_interval;
+    epicsEventId monitorEvent;
+    epicsEventId runnerEvent;
+    epicsMutexId lock;
+    int          ntpq_open;
+    ntpq_rl_data rl;
+    char         last_updated[64];
+    char         ntpq_output[2048];
+} osdNTPPvt;
+
+static epicsThreadOnceId onceId = EPICS_THREAD_ONCE_INIT;
+
+static void osdNTP_Configure(void);
+static void osdNTP_Runner(void *dummy);
+static void osdNTP_Monitor(void *dummy);
+
+void osdNTP_Shutdown(void *dummy);
+
+static const char etc_services[] =
+    "ntp                123/tcp      # Network Time Protocol  [Dave_Mills] [RFC5905]\n"
+    "ntp                123/udp      # Network Time Protocol  [Dave_Mills] [RFC5905]\n";
+
+static void set_rl_last_updated()
+{
+    struct timespec ts;
+    int r = clock_gettime(CLOCK_REALTIME, &ts);
+    if (r == 0) {
+        struct tm tm;
+        localtime_r(&ts.tv_sec, &tm);
+        strftime(
+            osdNTPPvt.last_updated, sizeof(osdNTPPvt.last_updated),
+            "%Y-%m-%d %H:%M:%S", &tm);
+    } else {
+        strlcpy(osdNTPPvt.last_updated, "unknown", sizeof(osdNTPPvt.last_updated));
+    }
+}
+
+static void ntpq_open(void)
+{
+    const char *argv[] = {
+        "host",
+        "127.0.0.1",
+        NULL
+    };
+    const int argc = ((sizeof(argv) / sizeof(argv[0])) - 1);
+    rtems_ntpq_create(1024);
+    int r = rtems_ntpq_query(
+        argc, argv, osdNTPPvt.ntpq_output, sizeof(osdNTPPvt.ntpq_output));
+    if (r != 0) {
+        errlogPrintf("osdNTP: ntpq host 127.0.0.1 failed\n");
+    }
+}
+
+static bool osdNTP_Get_Active(void)
+{
+    epicsMutexMustLock(osdNTPPvt.lock);
+    bool active = osdNTPPvt.ntpd_active;
+    epicsMutexUnlock(osdNTPPvt.lock);
+    return active;
+}
+
+static void osdNTP_Set_Active(bool active)
+{
+    epicsMutexMustLock(osdNTPPvt.lock);
+    osdNTPPvt.ntpd_active = active ? 1 : 0;
+    epicsMutexUnlock(osdNTPPvt.lock);
+}
+
+static void osdNTP_Set_ConfigSource(int config_source)
+{
+    epicsMutexMustLock(osdNTPPvt.lock);
+    osdNTPPvt.config_source = config_source;
+    epicsMutexUnlock(osdNTPPvt.lock);
+}
+
+static int osdNTP_Get_ConfigSource(void)
+{
+    epicsMutexMustLock(osdNTPPvt.lock);
+    int config_source = osdNTPPvt.config_source;
+    epicsMutexUnlock(osdNTPPvt.lock);
+    return config_source;
+}
+
+static bool osdNTP_Configured(void)
+{
+    return osdNTP_Get_ConfigSource() != NTPD_CONFIG_NONE;
+}
+
+static bool osdNTP_Synchronized(void)
+{
+    epicsMutexMustLock(osdNTPPvt.lock);
+    int synchronized = osdNTPPvt.synchronized;
+    epicsMutexUnlock(osdNTPPvt.lock);
+    return synchronized != 0;
+}
+
+static void osdNTP_Set_Synchronized(int synchronized)
+{
+    epicsMutexMustLock(osdNTPPvt.lock);
+    osdNTPPvt.synchronized = synchronized;
+    epicsMutexUnlock(osdNTPPvt.lock);
+}
+
+static bool osdNTP_Update_ActiveSecs(int secs)
+{
+    const int active_before_ntpq_open = 15;
+    epicsMutexMustLock(osdNTPPvt.lock);
+    if (osdNTPPvt.active) {
+        int active_secs = osdNTPPvt.ntpd_active_secs;
+        osdNTPPvt.ntpd_active_secs += secs;
+        /*
+         * Has the active time been long enough to check the ntpd
+         * port?  The ntpq host command checks.
+         */
+        if (active_secs <= active_before_ntpq_open
+            && osdNTPPvt.ntpd_active_secs > active_before_ntpq_open) {
+            epicsMutexUnlock(osdNTPPvt.lock);
+            ntpq_open();
+            epicsMutexMustLock(osdNTPPvt.lock);
+            osdNTPPvt.ntpq_open = 1;
+        }
+    }
+    bool ntpq_is_open = osdNTPPvt.ntpq_open != 0;
+    epicsMutexUnlock(osdNTPPvt.lock);
+    return ntpq_is_open;
+}
+
+static void osdNTP_InitOnce(void *not_used)
+{
+    (void) not_used;
+
+    osdNTPPvt = { 0 };
+    osdNTPPvt.config_source    = NTPD_CONFIG_NONE;
+    osdNTPPvt.active           = 1;
+    osdNTPPvt.synchronized     = 0;
+    osdNTPPvt.ntpd_active      = 1;
+    osdNTPPvt.ntpd_active_secs = 0;
+    osdNTPPvt.ntpd_finished    = 0;
+    osdNTPPvt.runner_interval  = EPICS_NTPD_RUNNER_INTERVAL;
+    osdNTPPvt.monitor_interval = EPICS_NTPD_MONITOR_IDLE_INTERVAL;
+    osdNTPPvt.monitorEvent     = epicsEventMustCreate(epicsEventEmpty);
+    osdNTPPvt.runnerEvent      = epicsEventMustCreate(epicsEventEmpty);
+    osdNTPPvt.lock             = epicsMutexCreate();
+    osdNTPPvt.ntpq_open        = 0;
+
+    epicsThreadCreate("osdNTP_Runner", epicsThreadPriorityHigh,
+        epicsThreadGetStackSize(epicsThreadStackMedium),
+        osdNTP_Runner, nullptr);
+    epicsThreadCreate("osdNTP_Monitor", epicsThreadPriorityMedium,
+        epicsThreadGetStackSize(epicsThreadStackSmall),
+        osdNTP_Monitor, nullptr);
+    epicsAtExit(osdNTP_Shutdown, nullptr);
+}
+
+static void osdNTP_Configure(void)
+{
+    int config_source = NTPD_CONFIG_NONE;
+    const char* ev;
+    int r;
+
+    /*
+     * Add NTP ports to /etc/services
+     */
+    r = rtems_ntpd_add_etc_services();
+    if (r == 0) {
+        /*
+         * Configuration file? Set the leapfile field in the config file.
+         */
+        ev = getenv(EPICS_TS_NTP_CONF_FILE);
+        if (ev != nullptr) {
+            strlcpy(osdNTPPvt.config_arg, "--configfile=", sizeof(osdNTPPvt.config_arg));
+            strlcat(osdNTPPvt.config_arg, ev, sizeof(osdNTPPvt.config_arg));
+            config_source = NTPD_CONFIG_FILE;
+        }
+
+        /*
+         * Server IP address?
+         */
+        if (config_source == NTPD_CONFIG_NONE) {
+            ev = getenv(EPICS_TS_NTP_INET);
+            if (ev != nullptr) {
+                strlcpy(
+                    osdNTPPvt.config_ip, "EPICS_TS_NTP_INET: ",
+                    sizeof(osdNTPPvt.config_ip));
+                strlcpy(osdNTPPvt.config_ip, ev, sizeof(osdNTPPvt.config_ip));
+                r = rtems_ntpd_client_pool_config(ev);
+                if (r == 0) {
+                    config_source = NTPD_CONFIG_NTP_IP;
+                }
+            }
+        }
+
+        /*
+         * BOOTP/DHCP/Init?
+         */
+        if (config_source == NTPD_CONFIG_NONE) {
+            ev = nullptr;
+#ifdef RTEMS_LEGACY_STACK
+            if (rtems_bsdnet_config.ntp_server[0] != nullptr) {
+                ev = rtems_bsdnet_config.ntp_server[0];
+                strlcpy(
+                    osdNTPPvt.config_ip, "BSDNET_CONFIG: ",
+                    sizeof(osdNTPPvt.config_ip));
+            }
+#endif /* RTEMS_LEGACY_STACK */
+            if (ev == nullptr && rtemsInit_NTP_server_ip[0] != '\0') {
+                ev = &rtemsInit_NTP_server_ip[0];
+                strlcpy(
+                    osdNTPPvt.config_ip, "RTEMS_INIT: ",
+                    sizeof(osdNTPPvt.config_ip));
+            }
+            if (ev != nullptr) {
+                strlcat(osdNTPPvt.config_ip, ev, sizeof(osdNTPPvt.config_ip));
+                r = rtems_ntpd_client_pool_config(ev);
+                if (r == 0) {
+                    config_source = NTPD_CONFIG_BOOTP;
+                }
+            }
+        }
+    }
+
+    osdNTP_Set_ConfigSource(config_source);
+}
+
+void osdNTP_Shutdown(void *dummy)
+{
+    epicsMutexMustLock(osdNTPPvt.lock);
+    osdNTPPvt.config_source = NTPD_CONFIG_NONE;
+    osdNTPPvt.active = 0;
+    osdNTPPvt.synchronized = 0;
+    osdNTPPvt.ntpq_open = 0;
+    epicsMutexUnlock(osdNTPPvt.lock);
+    rtems_ntpd_stop();
+    rtems_ntpq_destroy();
+    epicsEventSignal(osdNTPPvt.runnerEvent);
+    epicsEventSignal(osdNTPPvt.monitorEvent);
+}
+
+static int osdNTP_RunCommand(const char* activity, int *fails, int argc, char** argv)
+{
+    osdNTP_Set_Active(true);
+    int r = rtems_ntpd_run(argc, argv);
+    osdNTP_Set_Active(false);
+    if (r != 0) {
+        *fails += 1;
+        errlogPrintf("osdNTP: ntpd error (fails=%d): %d: %s\n", *fails, r, activity);
+    } else {
+        *fails = 0;
+    }
+    return r;
+}
+
+static int osdNTP_Run(int *fails)
+{
+    const char *argv[] = {
+        "ntpd",
+        "-g",
+#if NTP_DEBUG
+        "--set-debug-level=2",
+#endif
+        osdNTPPvt.config_arg,
+        nullptr
+    };
+    const int argc = ((sizeof(argv) / sizeof(argv[0])) - 1);
+    return osdNTP_RunCommand("daemon", fails, argc, (char**) argv);
+}
+
+static void osdNTP_Runner(void *dummy)
+{
+    int ntpd_fails = 0;
+
+    taskwdInsert(0, nullptr, nullptr);
+
+    /*
+     * Wait for a valid configuration mode to be set. Restart ntpd if
+     * it exits limiting the number of attempts if there is a persistent
+     * error.
+     */
+    for (epicsEventWaitWithTimeout(osdNTPPvt.runnerEvent, osdNTPPvt.runner_interval);
+         osdNTPPvt.active && ntpd_fails < osdNTP_NTPD_Fails;
+         epicsEventWaitWithTimeout(osdNTPPvt.runnerEvent, osdNTPPvt.runner_interval)) {
+
+        if (osdNTP_Configured()) {
+            int r = osdNTP_Run(&ntpd_fails);
+            if (r == 0) {
+                osdNTPPvt.monitor_interval = EPICS_NTPD_MONITOR_ACTIVE_INTERVAL;
+            }
+        }
+    }
+
+    epicsMutexMustLock(osdNTPPvt.lock);
+    osdNTPPvt.ntpd_finished = 1;
+    epicsMutexUnlock(osdNTPPvt.lock);
+
+    taskwdRemove(0);
+}
+
+static void osdNTP_Monitor(void *dummy)
+{
+    taskwdInsert(0, nullptr, nullptr);
+
+    for (epicsEventWaitWithTimeout(osdNTPPvt.monitorEvent, osdNTPPvt.monitor_interval);
+         osdNTPPvt.active;
+         epicsEventWaitWithTimeout(osdNTPPvt.monitorEvent, osdNTPPvt.monitor_interval)) {
+
+        if (osdNTP_Configured()
+            && osdNTP_Get_Active()
+            && osdNTP_Update_ActiveSecs(osdNTPPvt.monitor_interval)) {
+            epicsMutexMustLock(osdNTPPvt.lock);
+            rtems_ntpd_get_sys_vars(&osdNTPPvt.rl);
+            set_rl_last_updated();
+            epicsMutexUnlock(osdNTPPvt.lock);
+        }
+
+        osdNTP_Set_Synchronized(rtems_ntpd_is_synchronized(&osdNTPPvt.rl));
+
+        if (!osdNTP_Configured()) {
+            osdNTP_Configure();
+        }
+    }
+
+    osdNTP_Set_Synchronized(0);
+
+    taskwdRemove(0);
+}
+
+void osdTimeRegister(void)
+{
+    /* Init NTP first so it can be used to sync ClockTime */
+    NTPTime_Init(100);
+    ClockTime_Init(CLOCKTIME_SYNC);
+
+    osdMonotonicInit();
+}
+
+int osdNTPGet(struct timespec *ts)
+{
+    int r;
+    if (osdNTP_Synchronized()) {
+        r = clock_gettime(CLOCK_REALTIME, ts);
+    } else {
+        r = -1;
+    }
+    return r;
+}
+
+void osdNTPInit(void)
+{
+    printf("ntpd: RTEMS service init\n");
+    epicsThreadOnce(&onceId, osdNTP_InitOnce, nullptr);
+}
+
+void osdNTPReport(void)
+{
+    epicsMutexMustLock(osdNTPPvt.lock);
+    int config_source = osdNTPPvt.config_source;
+    int synchronized = osdNTPPvt.synchronized;
+    bool ntpd_active = osdNTPPvt.ntpd_active == 1;
+    int ntpd_active_secs = osdNTPPvt.ntpd_active_secs;
+    bool ntpq_open = osdNTPPvt.ntpq_open == 1;
+    epicsMutexUnlock(osdNTPPvt.lock);
+    printf("RTEMS NTP Status:\n");
+    printf(" config type = ");
+    if (config_source <= NTPD_CONFIG_FILE) {
+        static const char* config_str[4] = {
+            "NTPD_CONFIG_NONE",
+            "NTPD_CONFIG_BOOTP",
+            "NTPD_CONFIG_NTP_IP",
+            "NTPD_CONFIG_FILE"
+        };
+        printf("%s\n", config_str[config_source]);
+
+    } else {
+        printf("INVALID (%i)\n", config_source);
+    }
+    if (osdNTPPvt.config_arg[0] != '\0') {
+        printf(" config arg = %s\n", osdNTPPvt.config_arg);
+    }
+    if (osdNTPPvt.config_ip[0] != '\0') {
+        printf(" config ip = %s\n", osdNTPPvt.config_ip);
+    }
+    printf(" ntpd active = %s\n", ntpd_active ? "yes" : "no");
+    printf(" ntpd active sec = %d\n", ntpd_active_secs);
+    printf(" ntpq open = %s\n", ntpq_open ? "yes" : "no");
+    printf(" status last updated = %s\n", osdNTPPvt.last_updated);
+    printf(" synchronized = %s\n", synchronized ? "yes" : "no");
+    printf(" status = (%04x) %s\n", osdNTPPvt.rl.status, osdNTPPvt.rl.status_str);
+    printf(" version = %s\n", osdNTPPvt.rl.version);
+    printf(" processor = %s\n", osdNTPPvt.rl.processor);
+    printf(" system = %s\n", osdNTPPvt.rl.system);
+    printf(" leap = %d\n", (int) osdNTPPvt.rl.leap);
+    printf(" stratum = %d\n", (int) osdNTPPvt.rl.stratum);
+    printf(" precision = %i\n", (int) osdNTPPvt.rl.precision);
+    printf(" rootdelay = %f\n", osdNTPPvt.rl.rootdelay);
+    printf(" rootdisp = %f\n", osdNTPPvt.rl.rootdisp);
+    printf(" refid = %s\n", osdNTPPvt.rl.refid);
+    printf(" reftime = %" PRIu64 ".%" PRIu64"\n",
+           osdNTPPvt.rl.reftime_sec, osdNTPPvt.rl.reftime_nsec);
+    printf(" clock = %" PRIu64 ".%" PRIu64 "\n",
+           osdNTPPvt.rl.clock_sec, osdNTPPvt.rl.clock_nsec);
+    printf(" peer = %d\n", osdNTPPvt.rl.peer);
+    printf(" tc = %d\n", osdNTPPvt.rl.tc);
+    printf(" mintc = %d\n", osdNTPPvt.rl.mintc);
+    printf(" offset = %f\n", osdNTPPvt.rl.offset);
+    printf(" frequency = %f\n", osdNTPPvt.rl.frequency);
+    printf(" sys_jitter = %f\n", osdNTPPvt.rl.sys_jitter);
+    printf(" clk_jitter = %f\n", osdNTPPvt.rl.clk_jitter);
+    printf(" clk_wander = %f\n", osdNTPPvt.rl.clk_wander);
+    printf(" tai = %d\n", osdNTPPvt.rl.tai);
+    printf(" leapsec = %" PRIu64 "\n", osdNTPPvt.rl.leapsec);
+    printf(" expire = %" PRIu64 "\n", osdNTPPvt.rl.expire);
+    /*
+     * Query the peers. We need to be able to see what ntpd is using
+     * as a time source.
+     */
+    printf("Peers:\n");
+    if (ntpq_open) {
+        const char *argv[] = {
+            "peers",
+            nullptr
+        };
+        const int argc = ((sizeof(argv) / sizeof(argv[0])) - 1);
+        int r = rtems_ntpq_query(
+            argc, argv, osdNTPPvt.ntpq_output,
+            sizeof(osdNTPPvt.ntpq_output));
+        if (r == 0) {
+            printf(osdNTPPvt.ntpq_output);
+        } else {
+            printf("%s\n", rtems_ntpq_error_text());
+        }
+    } else {
+        printf("ntpq: not open\n");
+    }
+}
+
+int osdTickGet(void)
+{
+    return rtems_clock_get_ticks_since_boot();
+}
+
+int osdTickRateGet(void)
+{
+    return rtems_clock_get_ticks_per_second();
+}
+
+/*
+ * Use reentrant versions of time access
+ */
+int epicsTime_gmtime ( const time_t *pAnsiTime, struct tm *pTM )
+{
+    struct tm * pRet = gmtime_r ( pAnsiTime, pTM );
+    if ( pRet ) {
+        return epicsTimeOK;
+    }
+    else {
+        return errno;
+    }
+}
+
+int epicsTime_localtime ( const time_t *clock, struct tm *result )
+{
+    struct tm * pRet = localtime_r ( clock, result );
+    if ( pRet ) {
+        return epicsTimeOK;
+    }
+    else {
+        return errno;
+    }
+}
+
+} // extern "C"
+
+static const iocshArg ntpStartArg0 = { "command (ip or config)", iocshArgString };
+static const iocshArg ntpStartArg1 = { "value (addr or file)", iocshArgString };
+static const iocshArg * const ntpStartArgs[2] = { &ntpStartArg0, &ntpStartArg1 };
+static const iocshFuncDef ntpStartFuncDef = { "NTPTime_Start", 2, ntpStartArgs
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                            , "Start NTP with IP or configuration file"
+#endif
+                                           };
+
+static void ntpStartFunc(const iocshArgBuf *args) {
+    if (osdNTP_Configured()) {
+        printf("error: NTP: start: already configured\n");
+        iocshSetError(1);
+        return;
+    }
+    std::string arg0 = args[0].sval;
+    const char* env = nullptr;
+    if (arg0 == "ip") {
+        env = EPICS_TS_NTP_INET;
+    } else if (arg0 == "config") {
+        env = EPICS_TS_NTP_CONF_FILE;
+    } else {
+        printf("error: NTP: start: invalid command (ip or config)\n");
+        iocshSetError(1);
+    }
+    printf("NTP: setenv %s -> %s\n", args[1].sval, env);
+    auto r = setenv(env, args[1].sval, 1);
+    if (r != 0) {
+        printf("error: NTP: start: cannot set env: %s\n", env);
+        iocshSetError(1);
+    }
+    osdNTP_Configure();
+    iocshSetError(0);
+}
+
+static const iocshArg ntpWaitForSyncArg0 = { "seconds", iocshArgInt };
+static const iocshArg * const ntpWaitForSyncArgs[1] = { &ntpWaitForSyncArg0 };
+static const iocshFuncDef ntpWaitForSyncFuncDef = { "NTPTime_SyncWait", 1, ntpWaitForSyncArgs
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                            , "Wait for NTP to synchronize with timeout, 0 is forever"
+#endif
+                                           };
+
+static void ntpWaitForSyncFunc(const iocshArgBuf *args) {
+    if (!osdNTP_Configured()) {
+        printf("error: NTP: not configured\n");
+        return;
+    }
+    constexpr int wait_for = 500;
+    int msecs = args[0].ival * 1000;
+    printf("RTEMS NTP: waiting %i seconds for sync\n", args[0].ival);
+    while (!osdNTP_Synchronized()) {
+        epicsThreadSleep(wait_for / 1000.0);
+        if (msecs > 0) {
+            if (msecs > wait_for) {
+                msecs -= wait_for;
+            } else {
+                msecs = 0;
+            }
+            if (msecs == 0) {
+                printf("error: NTP: timeout, not synchronized\n");
+                iocshSetError(1);
+                return;
+            }
+        }
+    }
+    printf("NTP is synchronized\n");
+    iocshSetError(0);
+}
+
+static const iocshArg ntpUpdateArg0 = { "host ip", iocshArgString };
+static const iocshArg * const ntpUpdateArgs[1] = { &ntpUpdateArg0 };
+static const iocshFuncDef ntpUpdateFuncDef = { "NTPTime_Update", 1, ntpUpdateArgs
+#ifdef IOCSHFUNCDEF_HAS_USAGE
+                                            , "Update the time via NTP."
+#endif
+                                           };
+
+static void ntpUpdateFunc(const iocshArgBuf *args) {
+    if (osdNTP_Synchronized()) {
+        printf("error: NTP: no update as NTP has synchronized the time\n");
+        iocshSetError(2);
+        return;
+    }
+    if (osdNTP_Configured()) {
+        printf("warning: NTP: NTP is configured but not synchronized\n");
+    }
+    if (args[0].sval == nullptr) {
+        printf("error: NTP: no host ip address provided\n");
+        iocshSetError(1);
+    }
+    struct timespec now;
+    int r = epicsSimpleNtpGetTime(args[0].sval, &now);
+    if (r != 0) {
+        printf("error: NTP: update from %s failed\n", args[0].sval);
+        iocshSetError(1);
+        return;
+    }
+    r = clock_settime(CLOCK_REALTIME, &now);
+    if (r < 0) {
+        printf ("error: NTP: clock set time failed: %s\n", strerror(errno));
+        iocshSetError(1);
+        return;
+    }
+    char buffer[100];
+    strftime(buffer, sizeof buffer, "%D %T", gmtime(&now.tv_sec));
+    printf("NTP update: time is %s.%09ld UTC\n", buffer, now.tv_nsec);
+    iocshSetError(0);
+}
+
+static int staticTimeRegister(void)
+{
+    osdTimeRegister();
+    iocshRegister(&ntpStartFuncDef, ntpStartFunc);
+    iocshRegister(&ntpWaitForSyncFuncDef, ntpWaitForSyncFunc);
+    iocshRegister(&ntpUpdateFuncDef, ntpUpdateFunc);
+    return 0;
+
+}
+static int done = staticTimeRegister();
+
+#endif /* __RTEMS_MAJOR__ < 6 */

--- a/modules/libcom/src/osi/os/RTEMS-posix/osdTime.h
+++ b/modules/libcom/src/osi/os/RTEMS-posix/osdTime.h
@@ -1,0 +1,31 @@
+/*************************************************************************\
+* Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
+*     National Laboratory.
+* Copyright (c) 2002 The Regents of the University of California, as
+*     Operator of Los Alamos National Laboratory.
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef INC_osdTime_H
+#define INC_osdTime_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void osdTimeRegister(void);
+
+void osdNTPInit(void);
+int  osdNTPGet(struct timespec *);
+void osdNTPReport(void);
+
+int  osdTickRateGet(void);
+int  osdTickGet(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INC_osdTime_H */


### PR DESCRIPTION
With RTEMS 6 this changes require `libntp` and that is available in the `rtems-net-services` package. The repository is available on https://gitlab.rtems.org and it builds for the legacy and `libbsd` networking stacks. 

RTEMS 5 builds the default POSIX support as RTEMS 5 does not have the kernel NTP support.

Configure ntpd with the following env variables:

- `EPICS_TS_NTP_INET` : NTP server
- `EPICS_TS_NTP_CONF_FILE` : ntpd configuration file

or use the IOC shell commands:

- NTPTime_Start()
- NTPTime_SyncWait()
- NTPTime_Update()

The `NTPTime_Start()` command accepts `ip` of `config` as the first argument and an IP address if `ip` or the path to an `ntpd` configuration file if `config`.

The `NTPTime_SyncWait()` command lets you wait in the IOC shell until the time is synchronized before you run `iocInit` and start to initialize the system. This can be important if an accurate time is needed. 

The `NTPTime_Update()` command accepts the IP address of an NTP server time is fetched from.

A configuration file is used if both a configuration file and server IP address are set.

This PR depends on https://github.com/epics-base/epics-base/pull/375. I do not know how to make a merge train on GitHub.