### PR TITLE
use more standard permissions for bins and libs

### DIFF
--- a/configure/CONFIG_COMMON
+++ b/configure/CONFIG_COMMON
@@ -422,9 +422,9 @@ INSTALL_LIB_INSTALLS = $(addprefix $(INSTALL_LIB)/,$(notdir $(LIB_INSTALLS)))
 
 #---------------------------------------------------------------
 # Installed file permissions
-BIN_PERMISSIONS = 555
-LIB_PERMISSIONS = 444
-SHRLIB_PERMISSIONS = 555
+BIN_PERMISSIONS = 755
+LIB_PERMISSIONS = 644
+SHRLIB_PERMISSIONS = 755
 INSTALL_PERMISSIONS = 444
 
 #---------------------------------------------------------------


### PR DESCRIPTION
At least on Linux, system binaries and libraries are usually installed with write permission for the owner (root). Not having the file writable for the owner causes errors while building RPMs from EPICS base, when `rpmbuild` tries to strip the files.

In 2009, the lib permissions had been changed from 644 to 444 (i.e. in the different direction from this PR) in commit 99bd16 but with no deeper explanation:

```
$ git show 99bd16
commit 99bd16d7e6148a54b518f98828268e82ce45a94a
Author: Janet B. Anderson <jba@aps.anl.gov>
Date:   Fri Nov 20 19:04:38 2009 +0000

    LIB_PERMISSIONS and INSTALL_PERMISSIONS set to 444.

diff --git a/configure/CONFIG_COMMON b/configure/CONFIG_COMMON
index 2564ec0c6..a64ea4a6e 100644
--- a/configure/CONFIG_COMMON
+++ b/configure/CONFIG_COMMON
@@ -366,8 +366,8 @@ INSTALL_LIB_INSTALLS = $(addprefix $(INSTALL_LIB)/,$(notdir $(LIB_INSTALLS)))
 #---------------------------------------------------------------
 # Installed file permissions
 BIN_PERMISSIONS = 555
-LIB_PERMISSIONS = 644
-INSTALL_PERMISSIONS = 644
+LIB_PERMISSIONS = 444
+INSTALL_PERMISSIONS = 444
 
 #---------------------------------------------------------------
 #
```