### PR TITLE
fix warning when dbf_type_to_text is called with an unsigned arg

### DIFF
--- a/modules/ca/src/client/db_access.h
+++ b/modules/ca/src/client/db_access.h
@@ -676,7 +676,7 @@ union db_access_val{
                  (type)%(LAST_TYPE+1) == DBR_DOUBLE)
 
 #define dbf_type_to_text(type)   \
-    (  ((type) >= -1 && (type) < dbf_text_dim-2) ? \
+    (  ((type+1) >= 0 && (type) < dbf_text_dim-2) ? \
         dbf_text[type+1] : dbf_text_invalid  )
 
 #define dbf_text_to_type(text, type)   \


### PR DESCRIPTION
Some compilers emit a warning when `dbf_type_to_text` is called with an unsigned `type` argument.

For example clang:
```
../db/dbChannelIO.cpp:152:13: warning: result of comparison of constant -1 with expression of type 'unsigned short' is always true [-Wtautological-constant-out-of-range-compare]
  152 |             dbf_type_to_text ( dbChannelExportCAType ( this->dbch ) ),
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../../include/db_access.h:679:16: note: expanded from macro 'dbf_type_to_text'
  679 |     (  ((type) >= -1 && (type) < dbf_text_dim-2) ? \
      |         ~~~~~~ ^  ~~
```
This patch avoids comparing `type` with a negative constant.
