### PR TITLE
fix signedness mismatch in comparison

### DIFF
--- a/modules/database/src/ioc/db/dbChannelIO.cpp
+++ b/modules/database/src/ioc/db/dbChannelIO.cpp
@@ -165,7 +165,7 @@ unsigned long dbChannelIO::nativeElementCount (
 {
     guard.assertIdenticalMutex ( this->mutex );
     long elements = dbChannelElements ( this->dbch );
-    if ( elements >= 0u ) {
+    if ( elements >= 0 ) {
         return static_cast < unsigned long > ( elements );
     }
     return 0u;


### PR DESCRIPTION
Some compilers (e.g. gcc 7.5.0  for RTEMS 5) warn about a signedness missmatch:
```
../db/dbChannelIO.cpp: In member function 'virtual long unsigned int dbChannelIO::nativeElementCount(epicsGuard<epicsMutex>&) const':
../db/dbChannelIO.cpp:168:19: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if ( elements >= 0u ) {
          ~~~~~~~~~^~~~~
```
The type promotions in C are subtle and may give unexpected results. Here it works, because the unsigned int `0u` is implicitly converted to signed long int `0l` to match `elements`, but comparing with `0ul` would have been a real bug, because then `elements` would have been implicitly converted to `unsigned long` to match `0ul`. As this is hard to spot, I suggest to avoid any comparison with mixed signedness and enable at least the compiler warning for all compilers (if not even making this an error).

Here, clearly a signed comparison is desired, thus don't use `0u`.