### PR TITLE
fix string to epicsUInt32 conversion via double

### DIFF
--- a/modules/database/src/ioc/db/dbConstLink.c
+++ b/modules/database/src/ioc/db/dbConstLink.c
@@ -94,7 +94,7 @@ static long cvt_st_UInt32(const char *from, void *pfield, const dbAddr *paddr)
         status = epicsParseFloat64(from, &dval, &end);
         if (!status &&
             dval >=0 &&
-            dval <= ULONG_MAX)
+            dval <= UINT_MAX)
             *to = dval;
     }
     return status;

--- a/modules/database/src/ioc/db/dbConvert.c
+++ b/modules/database/src/ioc/db/dbConvert.c
@@ -302,7 +302,7 @@ static long getStringUlong(const dbAddr *paddr,
                 epicsFloat64 dval;
 
                 status = epicsParseFloat64(psrc, &dval, &end);
-                if (!status && 0 <= dval && dval <= ULONG_MAX)
+                if (!status && 0 <= dval && dval <= UINT_MAX)
                     *pdst = dval;
             }
             if (status)
@@ -1052,7 +1052,7 @@ static long putStringUlong(dbAddr *paddr,
             epicsFloat64 dval;
 
             status = epicsParseFloat64(psrc, &dval, &end);
-            if (!status && 0 <= dval && dval <= ULONG_MAX)
+            if (!status && 0 <= dval && dval <= UINT_MAX)
                 *pdst = dval;
         }
         if (status)

--- a/modules/database/src/ioc/db/dbFastLinkConv.c
+++ b/modules/database/src/ioc/db/dbFastLinkConv.c
@@ -181,7 +181,7 @@ static long cvt_st_ul(const void *f, void *t, const dbAddr *paddr)
         status = epicsParseFloat64(from, &dval, &end);
         if (!status &&
             dval >=0 &&
-            dval <= ULONG_MAX)
+            dval <= UINT_MAX)
             *to = dval;
     }
     return status;


### PR DESCRIPTION
Some compilers (e.g. clang 17) show warnings like this on 64 bit architectures:
```
../db/dbConstLink.c:97:21: warning: implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Wimplicit-const-int-float-conversion]
   97 |             dval <= ULONG_MAX)
      |                  ~~ ^~~~~~~~~
/usr/bin/../lib/clang/17/include/limits.h:61:37: note: expanded from macro 'ULONG_MAX'
   61 | #define ULONG_MAX (__LONG_MAX__ *2UL+1UL)
      |                    ~~~~~~~~~~~~~~~~~^~~~

```
The reason is that on most 64 bit architectures (except Windows), `unsigned long` and thus `ULONG_MAX` has 64  bits  but a `double` has less that 64 bits mantissa. Thus, converting `unsigned long` to `double` for the comparison may lead to unexpected results when the value uses too many bits (as `ULONG_MAX` does).
But I think the use of `ULONG_MAX` is wrong in this context anyway because, despite some of their names, the affected functions want to convert a string to an `epicsUInt32` and not to an `unsigned long` and `epicsUInt32` is defined as `unsigned int` in epicsTypes.h. Thus, the value should be tested against `UINT_MAX` instead (which does not cause compiler warnings).

BTW: Any reason that only the conversions to `epicsUInt32` have a code path that uses `epicsParseFloat64` and thus accept exponential notation but none of the conversion to other integer types like `epicsInt32`, `epicsUInt16`, `epicsUInt64` etc?