### PR TITLE
Aliases

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -22,6 +22,13 @@ should also be read to understand what has changed since earlier releases:
 
 ## Changes made on the 7.0 branch since 7.0.8.1
 
+### Allow to load the same alias multiple times
+
+Aliases can now be defined multiple times as long as they still refer to the
+same record, unless the shell variable dbRecordsOnceOnly is set.
+This allows to load database files multiple times, even if they contain
+alias definitions.
+
 ### DBE_PROPERTY event rate changed
 
 Updating property fields now only post DBE_PROPERTY events if the

--- a/modules/database/test/ioc/db/Makefile
+++ b/modules/database/test/ioc/db/Makefile
@@ -36,6 +36,7 @@ dbTestIoc_DBD += xLink.dbd
 dbTestIoc_DBD += devx.dbd
 dbTestIoc_DBD += jlinkz.dbd
 dbTestIoc_DBD += dbLinkdset.dbd
+dbTestIoc_DBD += dbCore.dbd
 TESTFILES += $(COMMON_DIR)/dbTestIoc.dbd ../xRecord.db
 
 testHarness_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
@@ -183,6 +184,11 @@ testHarness_SRCS += dbStaticTest.c
 TESTFILES += ../dbStaticTest.db
 TESTFILES += ../dbStaticTestAlias1.db
 TESTFILES += ../dbStaticTestAlias2.db
+TESTFILES += ../dbStaticTestAliasAgain1.db
+TESTFILES += ../dbStaticTestAliasAgain2.db
+TESTFILES += ../dbStaticTestAliasAgain3.db
+TESTFILES += ../dbStaticTestAliasAgainError1.db
+TESTFILES += ../dbStaticTestAliasAgainError2.db
 TESTFILES += ../dbStaticTestRemove.db
 TESTS += dbStaticTest
 

--- a/modules/database/test/ioc/db/dbStaticTestAliasAgain1.db
+++ b/modules/database/test/ioc/db/dbStaticTestAliasAgain1.db
@@ -1,0 +1,4 @@
+# Test re-load alias in record
+record(x, "testrecAgain") {
+    alias("testaliasAgain1")
+}

--- a/modules/database/test/ioc/db/dbStaticTestAliasAgain2.db
+++ b/modules/database/test/ioc/db/dbStaticTestAliasAgain2.db
@@ -1,0 +1,2 @@
+# Test re-load alias for record
+alias("testrecAgain", "testaliasAgain2")

--- a/modules/database/test/ioc/db/dbStaticTestAliasAgain3.db
+++ b/modules/database/test/ioc/db/dbStaticTestAliasAgain3.db
@@ -1,0 +1,2 @@
+# Test re-load alias for alias
+alias("testaliasAgain2", "testaliasAgain3")

--- a/modules/database/test/ioc/db/dbStaticTestAliasAgainError1.db
+++ b/modules/database/test/ioc/db/dbStaticTestAliasAgainError1.db
@@ -1,0 +1,2 @@
+# ERROR: alias using name of exising alias for different record
+alias("testrec", "testaliasAgain1")

--- a/modules/database/test/ioc/db/dbStaticTestAliasAgainError2.db
+++ b/modules/database/test/ioc/db/dbStaticTestAliasAgainError2.db
@@ -1,0 +1,2 @@
+# ERROR: alias using name of exising record fails
+alias("testrecAgain", "testrec")


### PR DESCRIPTION
Allow to redefine the same alias for the same record.

Normally, loading the same record (db file) twice is allowed (and is a no-op), but that fails if the db file contains aliases. This patch allows it even with aliases.

Also if creating the alias fails because the name already exists (as a record or an alias for a different record), the error message is more specific about this.

My use case: I have a template file for a multi channel device with many records per channel and a few per device. When I load the template multiple times with different macro values per channel but for the same device, the per-device records are re-loaded multiple times -- with the same values, which is no problem. But having per-device aliases fails in this case.