### PR TITLE
genVersionHeader: work with git submodules and worktrees.

### DIFF
--- a/src/tools/genVersionHeader.pl
+++ b/src/tools/genVersionHeader.pl
@@ -86,7 +86,7 @@ elsif (-d '.hg') { # Mercurial
     }
     $cv = `hg log -l1 --template '{date|isodate}'`
 }
-elsif (-d '.git') { # Git
+elsif (-d '.git' || -f '.git') { # Git
     print "== Found <top>/.git directory\n" if $opt_v;
     # v1-4-abcdef-dirty
     # is 4 commits after tag 'v1' with short hash abcdef


### PR DESCRIPTION
When the epics-base directory is used as a git submodule, or checked out in multiple places as a git worktree, ".git" is not a directory, but a file which points to the location of the git directory. In that case, the git tools can still be used to determine the version information.

Without this change, the version string is determined from the build date/time, which has multiple issues:

- it doesn't include the full information about the build environment
- it is not reproducible
- it leads to unnecessary rebuilds, since a lot of files depend on "epicsVCS.h"