### PR TITLE
decorate functions that do not return

### DIFF
--- a/modules/ca/src/client/acctst.c
+++ b/modules/ca/src/client/acctst.c
@@ -3396,7 +3396,7 @@ void verifyContextRundownChanStillExist (
     showProgressEnd ( interestLevel );
 }
 
-int acctst ( const char * pName, unsigned interestLevel, unsigned channelCount,
+void acctst ( const char * pName, unsigned interestLevel, unsigned channelCount,
             unsigned repetitionCount, enum ca_preemptive_callback_select select )
 {
     chid chan;
@@ -3549,8 +3549,6 @@ int acctst ( const char * pName, unsigned interestLevel, unsigned channelCount,
     printf ( "\nTest Complete\n" );
 
     epicsExit ( EXIT_SUCCESS );
-
-    return 0;
 }
 
 

--- a/modules/ca/src/client/caDiagnostics.h
+++ b/modules/ca/src/client/caDiagnostics.h
@@ -20,7 +20,8 @@ extern "C" {
 enum appendNumberFlag {appendNumber, dontAppendNumber};
 int catime ( const char *channelName, unsigned channelCount, enum appendNumberFlag appNF );
 
-int acctst ( const char *pname, unsigned logggingInterestLevel,
+EPICS_NORETURN
+void acctst ( const char *pname, unsigned logggingInterestLevel,
             unsigned channelCount, unsigned repetitionCount,
             enum ca_preemptive_callback_select select );
 

--- a/modules/libcom/src/flex/flexdef.h
+++ b/modules/libcom/src/flex/flexdef.h
@@ -696,16 +696,16 @@ extern void dataend (void);
 extern void flexerror (char[]) NORETURN;
 
 /* report a fatal error message and terminate */
-extern void flexfatal (char[]);
+extern void flexfatal (char[]) NORETURN;
 
 /* return current time */
 extern char *flex_gettime();
 
 /* report an error message formatted with one integer argument */
-extern void lerrif (char[], int);
+extern void lerrif (char[], int) NORETURN;
 
 /* report an error message formatted with one string argument */
-extern void lerrsf (char[], char[]);
+extern void lerrsf (char[], char[]) NORETURN;
 
 /* spit out a "# line" statement */
 extern void line_directive_out (FILE*);

--- a/modules/libcom/src/misc/cantProceed.h
+++ b/modules/libcom/src/misc/cantProceed.h
@@ -43,7 +43,8 @@ extern "C" {
  * \param errorMessage A printf-style error message describing the error.
  * \param ... Any parameters required for the error message.
  */
-LIBCOM_API void cantProceed(
+LIBCOM_API EPICS_NORETURN
+void cantProceed(
     EPICS_PRINTF_FMT(const char *errorMessage), ...
 ) EPICS_PRINTF_STYLE(1,2);
 

--- a/modules/libcom/src/misc/epicsExit.h
+++ b/modules/libcom/src/misc/epicsExit.h
@@ -23,6 +23,7 @@
 #ifndef epicsExith
 #define epicsExith
 #include <libComAPI.h>
+#include "compilerDependencies.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -38,7 +39,8 @@ typedef void (*epicsExitFunc)(void *arg);
  * \brief Calls epicsExitCallAtExits(), then the OS exit() routine.
  * \param status Passed to exit()
  */
-LIBCOM_API void epicsExit(int status);
+LIBCOM_API EPICS_NORETURN
+void epicsExit(int status);
 /**
  * \brief Arrange to call epicsExit() later from a low priority thread.
  *

--- a/modules/libcom/src/misc/epicsUnitTest.h
+++ b/modules/libcom/src/misc/epicsUnitTest.h
@@ -223,7 +223,8 @@ LIBCOM_API void testTodoEnd(void);
  * \param fmt A printf-style format string giving the reason for stopping.
  * \param ... Any parameters required for the format string.
  */
-LIBCOM_API void testAbort(EPICS_PRINTF_FMT(const char *fmt), ...)
+LIBCOM_API EPICS_NORETURN
+void testAbort(EPICS_PRINTF_FMT(const char *fmt), ...)
     EPICS_PRINTF_STYLE(1, 2);
 /** @} */
 

--- a/modules/libcom/src/osi/compiler/clang/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/clang/compilerSpecific.h
@@ -58,4 +58,9 @@
  */
 #define EPICS_UNUSED __attribute__((unused))
 
+/*
+ * No return marker
+ */
+#define EPICS_NORETURN __attribute__((noreturn))
+
 #endif  /* ifndef compilerSpecific_h */

--- a/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
@@ -57,4 +57,9 @@
  */
 #define EPICS_UNUSED __attribute__((unused))
 
+/*
+ * No return marker
+ */
+#define EPICS_NORETURN __attribute__((noreturn))
+
 #endif  /* ifndef compilerSpecific_h */

--- a/modules/libcom/src/osi/compiler/msvc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/msvc/compilerSpecific.h
@@ -51,4 +51,9 @@
 #   define EPICS_PRINTF_FMT(a) _Printf_format_string_ a
 #endif
 
+/*
+ * No return marker
+ */
+#define EPICS_NORETURN __declspec(noreturn)
+
 #endif  /* ifndef compilerSpecific_h */

--- a/modules/libcom/src/osi/compilerDependencies.h
+++ b/modules/libcom/src/osi/compilerDependencies.h
@@ -52,6 +52,10 @@
 #   define EPICS_UNUSED
 #endif
 
+#ifndef EPICS_NORETURN
+#   define EPICS_NORETURN
+#endif
+
 #ifndef EPICS_FUNCTION
 #if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901)) || (defined(__cplusplus) && __cplusplus>=201103L)
 #  define EPICS_FUNCTION __func__

--- a/modules/libcom/src/osi/epicsThread.h
+++ b/modules/libcom/src/osi/epicsThread.h
@@ -437,6 +437,7 @@ private:
     epicsThread ( const epicsThread & );
     epicsThread & operator = ( const epicsThread & );
     friend void epicsThreadCallEntryPoint ( void * );
+    EPICS_NORETURN
     void printLastChanceExceptionMessage (
         const char * pExceptionTypeName,
         const char * pExceptionContext );

--- a/modules/libcom/src/yacc/defs.h
+++ b/modules/libcom/src/yacc/defs.h
@@ -297,7 +297,7 @@ extern void tokenized_start(char *s) NORETURN;
 extern void retyped_warning(char *s);
 extern void reprec_warning(char *s);
 extern void revalued_warning(char *s);
-extern void terminal_start(char *s);
+extern void terminal_start(char *s) NORETURN;
 extern void restarted_warning(void);
 extern void no_grammar(void) NORETURN;
 extern void terminal_lhs(int s_lineno) NORETURN;


### PR DESCRIPTION
I have decorated most of the functions that gcc found with the option `-Wsuggest-attribute=noreturn`.
Exceptions: `cast_server()` and `rsrv_online_notify_task()`.