### PR TITLE
protect isnan/isinf define on c++

### DIFF
--- a/modules/libcom/src/osi/os/WIN32/epicsMath.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsMath.h
@@ -19,6 +19,14 @@
 #define finite(D) _finite(D)
 #endif
 
+#ifndef __cplusplus
+
+/* these are macros in C but inline functions in C++
+ * so ifndef does not work as a check in c++
+ * and in a recent VS2022 update causes a conflict and
+ * compile time error
+ */
+
 #ifndef isnan
 #define isnan(D) _isnan(D)
 #endif
@@ -26,6 +34,8 @@
 #ifndef isinf
 #define isinf(D) ( !_finite(D) && !_isnan(D) )
 #endif
+
+#endif /* ifndef __cplusplus */
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/libcom/src/osi/os/WIN32/epicsMath.h
+++ b/modules/libcom/src/osi/os/WIN32/epicsMath.h
@@ -19,12 +19,13 @@
 #define finite(D) _finite(D)
 #endif
 
-#ifndef __cplusplus
+#if !defined(__cplusplus) || (defined(_MSC_VER) && (_MSC_VER < 1800))
 
-/* these are macros in C but inline functions in C++
- * so ifndef does not work as a check in c++
- * and in a recent VS2022 update causes a conflict and
- * compile time error
+/* these are macros in C but usually inline functions in C++
+ * so macro ifndef does not work as a check in c++
+ * In a recent VS2022 update redefining as macros causes a conflict and
+ * compile time error. It looks like VS2013 and above supply
+ * isnan and isinf functions for in C++ so no need to create them
  */
 
 #ifndef isnan


### PR DESCRIPTION
Protect  isnan/isinf defines from being called under c++ as these now create a compile failure on a recent VS2022 update 

See #541