### PR TITLE
libCom: don't use std::unexpected in epicsThread.

### DIFF
--- a/modules/libcom/src/osi/epicsThread.cpp
+++ b/modules/libcom/src/osi/epicsThread.cpp
@@ -16,6 +16,7 @@
 
 #include <stdio.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <float.h>
 #include <string.h>
 
@@ -78,10 +79,8 @@ void epicsThread :: printLastChanceExceptionMessage (
         "with type \"%s\" in thread \"%s\" at %s\n",
         pExceptionContext, pExceptionTypeName, name, date );
     errlogFlush ();
-    // This behavior matches the C++ implementation when an exception
-    // isn't handled by the thread code. Users can install their own
-    // application-specific unexpected handler if preferred.
-    std::unexpected ();
+
+    abort();
 }
 
 extern "C" void epicsThreadCallEntryPoint ( void * pPvt )


### PR DESCRIPTION
Besides being deprecated in C++11 and removed in C++17, the intended use case for this was always wrong, since std::unexpected() is called by the C++ runtime when a function throws an exception that was not specified in its "dynamic exception specification", which is different from an exception thrown by user code which wasn't caught [1,2].

Allowing the program to proceed instead of terminating it (via std::terminate(), which is the default unexpected handler) also seems to be more correct, since the thread which threw the exception has already exited anyway.

[1] https://github.com/epics-base/epics-base/issues/343
[2] https://en.cppreference.com/w/cpp/error/unexpected

---

Fixes #343