### PR TITLE
send DBE_PROPERTY events only if property field actually changed

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -22,6 +22,11 @@ should also be read to understand what has changed since earlier releases:
 
 ## Changes made on the 7.0 branch since 7.0.8.1
 
+### DBE_PROPERTY event rate changed
+
+Updating property fields now only post DBE_PROPERTY events if the
+field actually changed.
+
 ### Allow users to delete previously created records from the database
 
 From this release, record instances and aliases that have already been loaded

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -1390,6 +1390,11 @@ long dbPut(DBADDR *paddr, short dbrType,
         }
     }
 
+    /* Post property updates before second dbPutSpecial */
+    /* which may post DBE_VALUE and/or DBE_LOG events */
+    if (propertyUpdate && !status)
+        db_post_events(precord, NULL, DBE_PROPERTY);
+
     /* Always do special processing if needed */
     if (special) {
         long status2 = dbPutSpecial(paddr, 1);
@@ -1406,8 +1411,6 @@ long dbPut(DBADDR *paddr, short dbrType,
     if (precord->mlis.count &&
         !(isValueField && pfldDes->process_passive))
         db_post_events(precord, pfieldsave, DBE_VALUE | DBE_LOG);
-    if (propertyUpdate)
-        db_post_events(precord, NULL, DBE_PROPERTY);
 done:
     paddr->pfield = pfieldsave;
     return status;

--- a/modules/database/src/std/rec/mbbiRecord.c
+++ b/modules/database/src/std/rec/mbbiRecord.c
@@ -220,12 +220,9 @@ static long special(DBADDR *paddr, int after)
             return 0;
         init_common(prec);
         /* Note: ZRVL..FFVL are also SPC_MOD */
-        if (fieldIndex >= mbbiRecordZRST && fieldIndex <= mbbiRecordFFST) {
-            int event = DBE_PROPERTY;
-
-            if (prec->val == fieldIndex - mbbiRecordZRST)
-                event |= DBE_VALUE | DBE_LOG;
-            db_post_events(prec, &prec->val, event);
+        if (fieldIndex >= mbbiRecordZRST && fieldIndex <= mbbiRecordFFST
+                && prec->val == fieldIndex - mbbiRecordZRST) {
+            db_post_events(prec, &prec->val, DBE_VALUE | DBE_LOG);
         }
         return 0;
 

--- a/modules/database/src/std/rec/mbbiRecord.dbd.pod
+++ b/modules/database/src/std/rec/mbbiRecord.dbd.pod
@@ -276,6 +276,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(ONST,DBF_STRING) {
 		prompt("One String")
@@ -284,6 +285,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(TWST,DBF_STRING) {
 		prompt("Two String")
@@ -292,6 +294,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(THST,DBF_STRING) {
 		prompt("Three String")
@@ -300,6 +303,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(FRST,DBF_STRING) {
 		prompt("Four String")
@@ -308,6 +312,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(FVST,DBF_STRING) {
 		prompt("Five String")
@@ -316,6 +321,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(SXST,DBF_STRING) {
 		prompt("Six String")
@@ -324,6 +330,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(SVST,DBF_STRING) {
 		prompt("Seven String")
@@ -332,6 +339,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(EIST,DBF_STRING) {
 		prompt("Eight String")
@@ -340,6 +348,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(NIST,DBF_STRING) {
 		prompt("Nine String")
@@ -348,6 +357,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(TEST,DBF_STRING) {
 		prompt("Ten String")
@@ -356,6 +366,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(ELST,DBF_STRING) {
 		prompt("Eleven String")
@@ -364,6 +375,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(TVST,DBF_STRING) {
 		prompt("Twelve String")
@@ -372,6 +384,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(TTST,DBF_STRING) {
 		prompt("Thirteen String")
@@ -380,6 +393,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(FTST,DBF_STRING) {
 		prompt("Fourteen String")
@@ -388,6 +402,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(FFST,DBF_STRING) {
 		prompt("Fifteen String")
@@ -396,6 +411,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 
 =head3 Alarm Parameters

--- a/modules/database/src/std/rec/mbboRecord.c
+++ b/modules/database/src/std/rec/mbboRecord.c
@@ -285,12 +285,9 @@ static long special(DBADDR *paddr, int after)
             return 0;
         init_common(prec);
         /* Note: ZRVL..FFVL are also SPC_MOD */
-        if (fieldIndex >= mbboRecordZRST && fieldIndex <= mbboRecordFFST) {
-            int event = DBE_PROPERTY;
-
-            if (prec->val == fieldIndex - mbboRecordZRST)
-                event |= DBE_VALUE | DBE_LOG;
-            db_post_events(prec, &prec->val, event);
+        if (fieldIndex >= mbboRecordZRST && fieldIndex <= mbboRecordFFST
+                && prec->val == fieldIndex - mbboRecordZRST) {
+            db_post_events(prec, &prec->val, DBE_VALUE | DBE_LOG);
         }
         return 0;
 

--- a/modules/database/src/std/rec/mbboRecord.dbd.pod
+++ b/modules/database/src/std/rec/mbboRecord.dbd.pod
@@ -354,6 +354,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(ONST,DBF_STRING) {
 		prompt("One String")
@@ -362,6 +363,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(TWST,DBF_STRING) {
 		prompt("Two String")
@@ -370,6 +372,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(THST,DBF_STRING) {
 		prompt("Three String")
@@ -378,6 +381,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(FRST,DBF_STRING) {
 		prompt("Four String")
@@ -386,6 +390,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(FVST,DBF_STRING) {
 		prompt("Five String")
@@ -394,6 +399,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(SXST,DBF_STRING) {
 		prompt("Six String")
@@ -402,6 +408,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(SVST,DBF_STRING) {
 		prompt("Seven String")
@@ -410,6 +417,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(EIST,DBF_STRING) {
 		prompt("Eight String")
@@ -418,6 +426,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(NIST,DBF_STRING) {
 		prompt("Nine String")
@@ -426,6 +435,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(TEST,DBF_STRING) {
 		prompt("Ten String")
@@ -434,6 +444,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(ELST,DBF_STRING) {
 		prompt("Eleven String")
@@ -442,6 +453,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(TVST,DBF_STRING) {
 		prompt("Twelve String")
@@ -450,6 +462,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(TTST,DBF_STRING) {
 		prompt("Thirteen String")
@@ -458,6 +471,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(FTST,DBF_STRING) {
 		prompt("Fourteen String")
@@ -466,6 +480,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(FFST,DBF_STRING) {
 		prompt("Fifteen String")
@@ -474,6 +489,7 @@ for more information on simulation mode and its fields.
 		pp(TRUE)
 		interest(1)
 		size(26)
+		prop(YES)
 	}
 	field(ZRSV,DBF_MENU) {
 		prompt("State Zero Severity")


### PR DESCRIPTION
The `dbPut()` function now compares (scalar) property fields to their old values and posts a DBE_PROPERTY event only if the value changed.

This change allows IOCs to write to property fields regularly (e.g. an IOC receiving values and alarm limits from a PLC periodically) without generating a large number of DBE_PROPERTY events. In the case I have seen, the IOC updated LOLO, LOW, HIGH and HIHI each time it updated VAL, resulting in a DBE_PROPERTY event rate 4 time as high as the DBE_VALUE event rate, even though the limits rarely ever changed. This undermines the idea of DBE_PROPERTY monitors to update properties only when needed.
