### PR TITLE
check whether IOCSH_STARTUP_SCRIPT is null before setting it

### DIFF
--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -1325,7 +1325,7 @@ iocshCmd (const char *cmd)
 int epicsStdCall
 iocshLoad(const char *pathname, const char *macros)
 {
-    if (pathname)
+    if (pathname && !getenv("IOCSH_STARTUP_SCRIPT"))
         epicsEnvSet("IOCSH_STARTUP_SCRIPT", pathname);
     return iocshBody(pathname, NULL, macros);
 }


### PR DESCRIPTION
As @simon-ess reported in epics-modules/iocStats#58, if `iocshLoad` is called in `st.cmd`, then `IOCSH_STARTUP_SCRIPT` doesn't correctly display the original startup script. So does iocStats.

How to check the problem:
```shell
$ cat st.cmd
iocshLoad("111.iocsh")
iocshLoad("222.iocsh")
dbLoadRecords("a.db")
iocInit

$ softIocPVA st.cmd
iocshLoad("111.iocsh")
iocshLoad("222.iocsh")
dbLoadRecords("a.db")
iocInit
Starting iocInit
############################################################################
## EPICS R7.0.8
## Rev. 2024-08-29T14:00+0900
## Rev. Date build date/time:
############################################################################
iocRun: All initialization complete
epics> epicsEnvShow IOCSH_STARTUP_SCRIPT
IOCSH_STARTUP_SCRIPT=222.iocsh
epics>
```
This PR checks whether IOCSH_STARTUP_SCRIPT has been set before setting it.
Result:
```shell
$ ~/workspace/epics-base/bin/linux-x86_64/softIocPVA st.cmd
iocshLoad("111.iocsh")
iocshLoad("222.iocsh")
dbLoadRecords("a.db")
iocInit
Starting iocInit
############################################################################
## EPICS R7.0.8.2-DEV
## Rev. 17b4df528703f06d635b
## Rev. Date Git: 2024-09-20 12:38:10 +0900
############################################################################
iocRun: All initialization complete
epics> epicsEnvShow IOCSH_STARTUP_SCRIPT
IOCSH_STARTUP_SCRIPT=st.cmd
epics>
```