### PR TITLE
CP link RPRO

### DIFF
--- a/modules/database/src/ioc/db/dbCaPvt.h
+++ b/modules/database/src/ioc/db/dbCaPvt.h
@@ -31,6 +31,7 @@
 #define CA_MONITOR_STRING       0x20
 #define CA_GET_ATTRIBUTES       0x40
 #define CA_SYNC                 0x1000
+#define CA_DBPROCESS            0x2000
 /* write type */
 #define CA_PUT          0x1
 #define CA_PUT_CALLBACK 0x2

--- a/modules/database/src/ioc/db/db_access.c
+++ b/modules/database/src/ioc/db/db_access.c
@@ -1029,3 +1029,17 @@ int db_put_process(processNotify *ppn, notifyPutType type,
         ppn->status = notifyError;
     return 1;
 }
+
+void db_process(struct dbCommon *prec)
+{
+    if (prec->pact) {
+        if (dbAccessDebugPUTF && prec->tpro)
+            printf("%s: dbPutField to Active '%s', setting RPRO=1\n",
+                   epicsThreadGetNameSelf(), prec->name);
+        prec->rpro = TRUE;
+    } else {
+        /* indicate that dbPutField called dbProcess */
+        prec->putf = TRUE;
+        (void)dbProcess(prec);
+    }
+}

--- a/modules/database/src/ioc/db/db_access_routines.h
+++ b/modules/database/src/ioc/db/db_access_routines.h
@@ -22,6 +22,8 @@ extern "C" {
 
 #include "dbCoreAPI.h"
 
+struct dbCommon;
+
 DBCORE_API extern struct dbBase *pdbbase;
 DBCORE_API extern volatile int interruptAccept;
 
@@ -36,7 +38,9 @@ DBCORE_API int dbChannel_put(struct dbChannel *chan, int src_type,
     const void *psrc, long no_elements);
 DBCORE_API int dbChannel_get_count(struct dbChannel *chan,
     int buffer_type, void *pbuffer, long *nRequest, void *pfl);
-
+#ifdef EPICS_DBCA_PRIVATE_API
+DBCORE_API void db_process(struct dbCommon *prec);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Attempt to address #557 by setting PUTF/RPRO for CP link processing resulting from a libca event.

~~Add `scanOnceCallback4()` with flag field and flag `SCAN_ONCE_PUTF` to accomplish this.~~

Move `dbProcess()` to dbCa worker.