### PR TITLE
Improve relative path check for msi

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -27,6 +27,30 @@ should also be read to understand what has changed since earlier releases:
 Updating property fields now only post DBE_PROPERTY events if the
 field actually changed.
 
+### Changes to msi related to include paths
+
+There are two changes to `msi` included here.
+
+`msi` now treats files included by .template or .substutiions files in a more
+consistent way: for relative paths, it will always look relative to the current
+working directory if no `-I` flags are passed, and if they are passed then it
+will search for the _relative_ path from each of those flags. That is, the
+following will now find the file `bar.template` located at
+`/some/path/rel/path/bar.template`
+```
+$ cat foo.substitutions
+file rel/path/bar.template {
+ # contents
+}
+$ msi -I /some/path foo.substitutions
+```
+
+Note that this does provide one change from previous behaviour: when opening a
+file from the command line, `msi` will not use the `-I`-specified paths to
+search for the file, but will only work relative to the current working
+directory, consistent with most commandline utilities.
+
+
 ### Allow users to delete previously created records from the database
 
 From this release, record instances and aliases that have already been loaded

--- a/modules/database/src/ioc/dbtemplate/Makefile
+++ b/modules/database/src/ioc/dbtemplate/Makefile
@@ -14,6 +14,7 @@ SRC_DIRS += $(IOCDIR)/dbtemplate
 PROD_HOST += msi
 
 msi_SRCS = msi.cpp
+msi_SYS_LIBS_WIN32 = shlwapi
 DOCS += msi.md
 
 INC += dbLoadTemplate.h

--- a/modules/database/src/ioc/dbtemplate/msi.cpp
+++ b/modules/database/src/ioc/dbtemplate/msi.cpp
@@ -65,7 +65,7 @@ typedef struct inputData inputData;
 static void inputConstruct(inputData **ppvt);
 static void inputDestruct(inputData * const pvt);
 static void inputAddPath(inputData * const pvt, const char * const pval);
-static void inputBegin(inputData * const pvt, const char * const fileName);
+static void inputBegin(inputData * const pvt, const char * const fileName, bool fromCmdLine);
 static char *inputNextLine(inputData * const pvt);
 static void inputNewIncludeFile(inputData * const pvt, const char * const name);
 static void inputErrPrint(const inputData * const pvt);
@@ -87,7 +87,8 @@ static void addMacroReplacements(MAC_HANDLE * const macPvt,
                                  const char * const pval);
 static void makeSubstitutions(inputData * const inputPvt,
                               MAC_HANDLE * const macPvt,
-                              const char * const templateName);
+                              const char * const templateName,
+                              bool fromCmdLine);
 
 /*Global variables */
 static int opt_V = 0;
@@ -175,7 +176,7 @@ int main(int argc,char **argv)
 
     if (substitutionName.empty()) {
         STEP("Single template+substitutions file");
-        makeSubstitutions(inputPvt, macPvt, templateName);
+        makeSubstitutions(inputPvt, macPvt, templateName, true);
     }
     else {
         subInfo *substitutePvt;
@@ -207,7 +208,7 @@ int main(int argc,char **argv)
                         macPushScope(macPvt);
 
                     addMacroReplacements(macPvt, macStr);
-                    makeSubstitutions(inputPvt, macPvt, filename);
+                    makeSubstitutions(inputPvt, macPvt, filename, false);
 
                     if (localScope)
                         macPopScope(macPvt);
@@ -280,14 +281,15 @@ static const char *cmdNames[] = {"include","substitute"};
 
 static void makeSubstitutions(inputData * const inputPvt,
                               MAC_HANDLE * const macPvt,
-                              const char * const templateName)
+                              const char * const templateName,
+                              bool fromCmdLine)
 {
     char *input;
     static char buffer[MAX_BUFFER_SIZE];
     int  n;
 
     ENTER;
-    inputBegin(inputPvt, templateName);
+    inputBegin(inputPvt, templateName, fromCmdLine);
     while ((input = inputNextLine(inputPvt))) {
         int     expand=1;
         char    *p;
@@ -382,7 +384,7 @@ struct inputData {
     inputData() { memset(inputBuffer, 0, sizeof(inputBuffer) * sizeof(inputBuffer[0])); };
 };
 
-static void inputOpenFile(inputData *pinputData, const char * const filename);
+static void inputOpenFile(inputData *pinputData, const char * const filename, bool fromCmdLine);
 static void inputCloseFile(inputData *pinputData);
 static void inputCloseAllFiles(inputData *pinputData);
 
@@ -435,11 +437,11 @@ static void inputAddPath(inputData * const pinputData, const char * const path)
     EXIT;
 }
 
-static void inputBegin(inputData * const pinputData, const char * const fileName)
+static void inputBegin(inputData * const pinputData, const char * const fileName, bool fromCmdLine)
 {
     ENTER;
     inputCloseAllFiles(pinputData);
-    inputOpenFile(pinputData, fileName);
+    inputOpenFile(pinputData, fileName, fromCmdLine);
     EXIT;
 }
 
@@ -466,7 +468,7 @@ static void inputNewIncludeFile(inputData * const pinputData,
                                 const char * const name)
 {
     ENTER;
-    inputOpenFile(pinputData,name);
+    inputOpenFile(pinputData, name, false);
     EXIT;
 }
 
@@ -505,7 +507,7 @@ static int isPathRelative(const char * const path) {
 #endif
 }
 
-static void inputOpenFile(inputData *pinputData, const char * const filename)
+static void inputOpenFile(inputData *pinputData, const char * const filename, bool fromCmdLine)
 {
     std::list<std::string>& pathList = pinputData->pathList;
     std::list<std::string>::iterator pathIt = pathList.end();
@@ -517,7 +519,7 @@ static void inputOpenFile(inputData *pinputData, const char * const filename)
         STEP("Using stdin");
         fp = stdin;
     }
-    else if (pathList.empty() || !isPathRelative(filename)){
+    else if (fromCmdLine || pathList.empty() || !isPathRelative(filename)){
         STEPS("Opening ", filename);
         fp = fopen(filename, "r");
     }

--- a/modules/database/src/ioc/dbtemplate/msi.cpp
+++ b/modules/database/src/ioc/dbtemplate/msi.cpp
@@ -27,6 +27,10 @@
 #include <osiFileName.h>
 #include <osiUnistd.h>
 
+#ifdef _WIN32
+#include <shlwapi.h>
+#endif
+
 #define MAX_BUFFER_SIZE 4096
 #define MAX_DEPS 1024
 
@@ -493,6 +497,14 @@ static void inputErrPrint(const inputData *const pinputData)
     EXIT;
 }
 
+static int isPathRelative(const char * const path) {
+#ifdef _WIN32
+    return path && PathIsRelativeA(path);
+#else
+    return path && path[0] != '/';
+#endif
+}
+
 static void inputOpenFile(inputData *pinputData, const char * const filename)
 {
     std::list<std::string>& pathList = pinputData->pathList;
@@ -505,7 +517,7 @@ static void inputOpenFile(inputData *pinputData, const char * const filename)
         STEP("Using stdin");
         fp = stdin;
     }
-    else if (pathList.empty() || strchr(filename, '/')){
+    else if (pathList.empty() || !isPathRelative(filename)){
         STEPS("Opening ", filename);
         fp = fopen(filename, "r");
     }

--- a/modules/database/src/ioc/dbtemplate/msi.md
+++ b/modules/database/src/ioc/dbtemplate/msi.md
@@ -60,6 +60,18 @@ Switches have the following meanings:
      2. . (the current directory)
      3. .. (the parent of the current directory)
 
+    Note that relative path searching is handled as
+    
+        $ cat foo.substitutions
+        file rel/path/bar.template {
+          # contents
+        }
+        $ msi -I . -I /some/path foo.substitutions
+    
+    which will try to find `bar.template` at the path `./rel/path/` followed by
+    `/some/path/rel/path`.
+
+
 - **-M _substitutions_**
 
     This parameter specifies macro values for the template instance.

--- a/modules/database/test/ioc/dbtemplate/msi.plt
+++ b/modules/database/test/ioc/dbtemplate/msi.plt
@@ -12,7 +12,7 @@
 use strict;
 use Test;
 
-BEGIN {plan tests => 12}
+BEGIN {plan tests => 14}
 
 # Check include/substitute command model
 ok(msi('-I .. ../t1-template.txt'),             slurp('../t1-result.txt'));
@@ -55,6 +55,12 @@ my %envs = (TEST_NO => 12, PREFIX => 't');
 @ENV{ keys %envs } = values %envs;
 ok(msi('-I. -I.. -S ../t12-substitute.txt'), slurp('../t12-result.txt'));
 delete @ENV{ keys %envs };  # Not really needed
+
+# Substitution file, relative path includes
+ok(msi('-I @TOP@/modules -S ../t13-substitute.txt'), slurp('../t13-result.txt'));
+
+# Template file, relative path includes
+ok(msi('-I @TOP@/modules ../t14-template.txt'), slurp('../t14-result.txt'));
 
 # Test support routines
 

--- a/modules/database/test/ioc/dbtemplate/t13-result.txt
+++ b/modules/database/test/ioc/dbtemplate/t13-result.txt
@@ -1,0 +1,2 @@
+# comment line
+a=foo

--- a/modules/database/test/ioc/dbtemplate/t13-substitute.txt
+++ b/modules/database/test/ioc/dbtemplate/t13-substitute.txt
@@ -1,0 +1,3 @@
+file database/test/ioc/dbtemplate/t13-template.txt {
+    { a=foo }
+}

--- a/modules/database/test/ioc/dbtemplate/t13-template.txt
+++ b/modules/database/test/ioc/dbtemplate/t13-template.txt
@@ -1,0 +1,2 @@
+# comment line
+a=$(a)

--- a/modules/database/test/ioc/dbtemplate/t14-include.txt
+++ b/modules/database/test/ioc/dbtemplate/t14-include.txt
@@ -1,0 +1,1 @@
+I'm a file!

--- a/modules/database/test/ioc/dbtemplate/t14-result.txt
+++ b/modules/database/test/ioc/dbtemplate/t14-result.txt
@@ -1,0 +1,5 @@
+This is t14-template.txt
+
+I'm a file!
+
+End of t14-template.txt

--- a/modules/database/test/ioc/dbtemplate/t14-template.txt
+++ b/modules/database/test/ioc/dbtemplate/t14-template.txt
@@ -1,0 +1,5 @@
+This is t14-template.txt
+
+include "database/test/ioc/dbtemplate/t14-include.txt"
+
+End of t14-template.txt


### PR DESCRIPTION
For posix-ish systems, we previously checked that a path was relative by simpy checking if it included a '/' character. This meant that you could not, for example, do
```
$ cat foo.substitutions
file rel/to/bar.template {
}

$ msi -I /some/path foo.substitutions
```
where our template file is located at `/some/path/rel/to/bar.template`.

Note that relateive paths work differently on Windows, so we carve out an exception there.

Closes https://github.com/epics-base/epics-base/issues/529