### PR TITLE
Clear NAMSG together with NSTAT and NSEV

### DIFF
--- a/modules/database/src/ioc/db/recGbl.c
+++ b/modules/database/src/ioc/db/recGbl.c
@@ -190,6 +190,7 @@ unsigned short recGblResetAlarms(void *precord)
 
     if(strcmp(pdbc->namsg, pdbc->amsg)!=0) {
         strcpy(pdbc->amsg, pdbc->namsg);
+        pdbc->namsg[0] = '\0';
         stat_mask = DBE_ALARM;
     }
 


### PR DESCRIPTION
Previously, there was no way to clear AMSG when setting a no-alarm status: it kept the last error message, and it is strange to have a record that has no alarm while showing an error. With this change, the NAMSG field is treated the same as NSTA and NSEV: they are cleared when their content is moved to STAT, SEVR, and AMSG.