### PR TITLE
Propagate AMSG through MSS links

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -22,6 +22,16 @@ should also be read to understand what has changed since earlier releases:
 
 ## Changes made on the 7.0 branch since 7.0.8.1
 
+### The AMSG error message propagates through MSS links
+
+A database link with the MSS attribute will now propagate not only SEVR and
+STAT, but also AMSG. This field contains additional information that complements
+STAT. Links with MS or MSI attributes do not propagate STAT, and therefore do
+not propagate AMSG, either.
+
+Channel Access links do not propagate AMSG, regardless of the MSS attribute,
+because the message is not available over Channel Access.
+
 ### DBE_PROPERTY event rate changed
 
 Updating property fields now only post DBE_PROPERTY events if the

--- a/modules/database/src/ioc/db/dbDbLink.c
+++ b/modules/database/src/ioc/db/dbDbLink.c
@@ -226,9 +226,10 @@ static long dbDbGetValue(struct link *plink, short dbrType, void *pbuffer,
     }
 
     if (!status && precord != dbChannelRecord(chan))
-        recGblInheritSevr(plink->value.pv_link.pvlMask & pvlOptMsMode,
+        recGblInheritSevrMsg(plink->value.pv_link.pvlMask & pvlOptMsMode,
             plink->precord,
-            dbChannelRecord(chan)->stat, dbChannelRecord(chan)->sevr);
+            dbChannelRecord(chan)->stat, dbChannelRecord(chan)->sevr,
+            dbChannelRecord(chan)->amsg);
     return status;
 }
 
@@ -376,8 +377,8 @@ static long dbDbPutValue(struct link *plink, short dbrType,
     dbCommon *pdest = dbChannelRecord(chan);
     long status = dbPut(paddr, dbrType, pbuffer, nRequest);
 
-    recGblInheritSevr(ppv_link->pvlMask & pvlOptMsMode, pdest, psrce->nsta,
-        psrce->nsev);
+    recGblInheritSevrMsg(ppv_link->pvlMask & pvlOptMsMode, pdest, psrce->nsta,
+        psrce->nsev, psrce->namsg);
     if (status)
         return status;
 

--- a/modules/database/src/ioc/db/recGbl.c
+++ b/modules/database/src/ioc/db/recGbl.c
@@ -259,8 +259,8 @@ int recGblSetSevr(void *precord, epicsEnum16 new_stat, epicsEnum16 new_sevr)
     return recGblSetSevrMsg(precord, new_stat, new_sevr, NULL);
 }
 
-void recGblInheritSevr(int msMode, void *precord, epicsEnum16 stat,
-    epicsEnum16 sevr)
+void recGblInheritSevrMsg(int msMode, void *precord, epicsEnum16 stat,
+    epicsEnum16 sevr, const char *msg)
 {
     switch (msMode) {
     case pvlOptNMS:
@@ -273,11 +273,17 @@ void recGblInheritSevr(int msMode, void *precord, epicsEnum16 stat,
         recGblSetSevr(precord, LINK_ALARM, sevr);
         break;
     case pvlOptMSS:
-        recGblSetSevr(precord, stat, sevr);
+        /* Only MSS inherits msg */
+        recGblSetSevrMsg(precord, stat, sevr, "%s", msg);
         break;
     }
 }
 
+void recGblInheritSevr(int msMode, void *precord, epicsEnum16 stat,
+    epicsEnum16 sevr)
+{
+    recGblInheritSevrMsg(msMode, precord, stat, sevr, NULL);
+}
 
 void recGblFwdLink(void *precord)
 {

--- a/modules/database/src/ioc/db/recGbl.h
+++ b/modules/database/src/ioc/db/recGbl.h
@@ -73,6 +73,8 @@ DBCORE_API int recGblSetSevr(void *precord, epicsEnum16 new_stat,
     epicsEnum16 new_sevr);
 DBCORE_API void recGblInheritSevr(int msMode, void *precord, epicsEnum16 stat,
     epicsEnum16 sevr);
+DBCORE_API void recGblInheritSevrMsg(int msMode, void *precord, epicsEnum16 stat,
+    epicsEnum16 sevr, const char *msg);
 DBCORE_API int recGblSetSevrMsg(void *precord, epicsEnum16 new_stat,
                                 epicsEnum16 new_sevr,
                                 EPICS_PRINTF_FMT(const char *msg), ...) EPICS_PRINTF_STYLE(4,5);


### PR DESCRIPTION
Fixes #567

MS and MSI links do not propagate STAT and therefore do not propagate AMSG, either. CA, CP and CPP links also do not propagate AMSG, but the reason is technical: the message is not available over Channel Access. Apparently, it is available over PVA (`pvmonitor` shows it without doing anything special) so it should be possible to propagate it over PVA links, but unless I'm mistaken that belongs into the pvxs module.

The new `recGblInheritSevrMsg()` function is not a formatting function (unlike `recGblSetSevrMsg()`) because it is supposed to be used only for inheriting the already rendered message and nothing else.