### PR TITLE
Add EPICS_DIAGNOSE_AS

### DIFF
--- a/modules/libcom/src/misc/epicsString.h
+++ b/modules/libcom/src/misc/epicsString.h
@@ -91,24 +91,28 @@ LIBCOM_API size_t epicsStrnEscapedFromRawSize(const char *buf, size_t len);
  *
  * Implements strcmp from the C standard library, except is case insensitive
  */
+EPICS_DIAGNOSE_AS_STRCASECMP(1, 2)
 LIBCOM_API int epicsStrCaseCmp(const char *s1, const char *s2);
 
 /** \brief Does case-insensitive comparision of two strings
  *
  * Implements strncmp from the C standard library, except is case insensitive
  */
+EPICS_DIAGNOSE_AS_STRNCASECMP(1, 2, 3)
 LIBCOM_API int epicsStrnCaseCmp(const char *s1, const char *s2, size_t len);
 
 /** \brief Duplicates a string
  *
  * Implements strdup from the C standard library.  Calls mallocMustSucceed() to allocate memory
  */
+EPICS_DIAGNOSE_AS_STRDUP(1)
 LIBCOM_API char * epicsStrDup(const char *s);
 
 /** \brief Duplicates a string
  *
  * implements strndup from the C standard library. Calls mallocMustSucceed() to allocate memory
  */
+EPICS_DIAGNOSE_AS_STRNDUP(1, 2)
 LIBCOM_API char * epicsStrnDup(const char *s, size_t len);
 
 /** \brief Prints escaped version of string

--- a/modules/libcom/src/osi/compiler/clang/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/clang/compilerSpecific.h
@@ -30,6 +30,48 @@
 /* Expands to a 'const char*' which describes the name of the current function scope */
 #define EPICS_FUNCTION __PRETTY_FUNCTION__
 
+/*
+ * Allows the compiler to apply fortify diagnostics to marked functions.
+ * Introduced in clang 14.
+ * Ref: https://clang.llvm.org/docs/AttributeReference.html#diagnose-as-builtin
+ */
+#if __has_attribute(diagnose_as_builtin)
+#define EPICS_DIAGNOSE_AS(...) __attribute__((diagnose_as_builtin(__VA_ARGS__)))
+
+#if __has_builtin(__builtin_strncasecmp)
+#define EPICS_DIAGNOSE_AS_STRNCASECMP(_1, _2, _3) EPICS_DIAGNOSE_AS(__builtin_strncasecmp, _1, _2, _3)
+#endif
+
+#if __has_builtin(__builtin_strdup)
+#define EPICS_DIAGNOSE_AS_STRDUP(_1) EPICS_DIAGNOSE_AS(__builtin_strdup, _1)
+#endif
+
+#if __has_builtin(__builtin_strndup)
+#define EPICS_DIAGNOSE_AS_STRNDUP(_1, _2) EPICS_DIAGNOSE_AS(__builtin_strndup, _1, _2)
+#endif
+
+#if __has_builtin(__builtin_snprintf)
+#define EPICS_DIAGNOSE_AS_SNPRINTF(_1, _2, _3) EPICS_DIAGNOSE_AS(__builtin_snprintf, _1, _2, _3)
+#endif
+
+#if __has_builtin(__builtin_vsnprintf)
+#define EPICS_DIAGNOSE_AS_VSNPRINTF(_1, _2, _3, _4) EPICS_DIAGNOSE_AS(__builtin_vsnprintf, _1, _2, _3, _4)
+#endif
+
+#if __has_builtin(__builtin_strcasecmp)
+#define EPICS_DIAGNOSE_AS_STRCASECMP(_1, _2) EPICS_DIAGNOSE_AS(__builtin_strcasecmp, _1, _2)
+#endif
+
+#if __has_builtin(__builtin_printf)
+#define EPICS_DIAGNOSE_AS_PRINTF(_1) EPICS_DIAGNOSE_AS(__builtin_printf, _1)
+#endif
+
+#if __has_builtin(__builtin_vprintf)
+#define EPICS_DIAGNOSE_AS_VPRINTF(_1, _2) EPICS_DIAGNOSE_AS(__builtin_vprintf, _1, _2)
+#endif
+
+#endif /* __has_attribute(diagnose_as_builtin) */
+
 #ifdef __cplusplus
 
 /*

--- a/modules/libcom/src/osi/compilerDependencies.h
+++ b/modules/libcom/src/osi/compilerDependencies.h
@@ -52,6 +52,45 @@
 #   define EPICS_UNUSED
 #endif
 
+/*
+ * Clang fortify diagnostics
+ */
+#ifndef EPICS_DIAGNOSE_AS
+#   define EPICS_DIAGNOSE_AS(...)
+#endif
+
+#ifndef EPICS_DIAGNOSE_AS_STRNCASECMP
+#   define EPICS_DIAGNOSE_AS_STRNCASECMP(_1, _2, _3)
+#endif
+
+#ifndef EPICS_DIAGNOSE_AS_STRDUP
+#   define EPICS_DIAGNOSE_AS_STRDUP(_1)
+#endif
+
+#ifndef EPICS_DIAGNOSE_AS_STRNDUP
+#   define EPICS_DIAGNOSE_AS_STRNDUP(_1, _2)
+#endif
+
+#ifndef EPICS_DIAGNOSE_AS_SNPRINTF
+#   define EPICS_DIAGNOSE_AS_SNPRINTF(_1, _2_, _3)
+#endif
+
+#ifndef EPICS_DIAGNOSE_AS_VSNPRINTF
+#   define EPICS_DIAGNOSE_AS_VSNPRINTF(_1, _2, _3, _4)
+#endif
+
+#ifndef EPICS_DIAGNOSE_AS_STRCASECMP
+#   define EPICS_DIAGNOSE_AS_STRCASECMP(_1, _2)
+#endif
+
+#ifndef EPICS_DIAGNOSE_AS_PRINTF
+#   define EPICS_DIAGNOSE_AS_PRINTF(_1)
+#endif
+
+#ifndef EPICS_DIAGNOSE_AS_VPRINTF
+#   define EPICS_DIAGNOSE_AS_VPRINTF(_1, _2)
+#endif
+
 #ifndef EPICS_FUNCTION
 #if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901)) || (defined(__cplusplus) && __cplusplus>=201103L)
 #  define EPICS_FUNCTION __func__

--- a/modules/libcom/src/osi/epicsStdio.h
+++ b/modules/libcom/src/osi/epicsStdio.h
@@ -129,6 +129,7 @@ extern "C" {
  * that would be written to `str` if it was large enough to hold them all; the
  * output has been truncated if the return value is `size` or more.
  */
+EPICS_DIAGNOSE_AS_SNPRINTF(1, 2, 3)
 LIBCOM_API int epicsStdCall epicsSnprintf(
     char *str, size_t size, EPICS_PRINTF_FMT(const char *format), ...
 ) EPICS_PRINTF_STYLE(3,4);
@@ -160,6 +161,7 @@ LIBCOM_API int epicsStdCall epicsSnprintf(
  * that would be written to `str` if it was large enough to hold them all; the
  * output has been truncated if the return value is `size` or more.
  */
+EPICS_DIAGNOSE_AS_VSNPRINTF(1, 2, 3, 4)
 LIBCOM_API int epicsStdCall epicsVsnprintf(
     char *str, size_t size, const char *format, va_list ap);
 
@@ -186,8 +188,10 @@ LIBCOM_API void  epicsStdCall epicsSetThreadStdin(FILE *);
 LIBCOM_API void  epicsStdCall epicsSetThreadStdout(FILE *);
 LIBCOM_API void  epicsStdCall epicsSetThreadStderr(FILE *);
 
+EPICS_DIAGNOSE_AS_PRINTF(1)
 LIBCOM_API int epicsStdCall epicsStdoutPrintf(
     const char *pformat, ...) EPICS_PRINTF_STYLE(1,2);
+EPICS_DIAGNOSE_AS_VPRINTF(1, 2)
 LIBCOM_API int epicsStdCall epicsStdoutVPrintf(
     const char *pformat, va_list ap);
 LIBCOM_API int epicsStdCall epicsStdoutPuts(const char *str);


### PR DESCRIPTION
* Added `EPICS_DIAGNOSE_AS` for clang's `diagnose_as_builtin` attribute. https://clang.llvm.org/docs/AttributeReference.html#diagnose-as-builtin. This will allow the compiler to produce fortify diagnostics for the marked declarations. 
* Applied `EPICS_DIAGNOSE_AS` to various `epicsStdio.h` and `epicsString.h` functions.
