### PR TITLE
Fix compile error in tsSLList.h

### DIFF
--- a/modules/libcom/src/cxxTemplates/tsSLList.h
+++ b/modules/libcom/src/cxxTemplates/tsSLList.h
@@ -311,13 +311,13 @@ inline bool tsSLIterConst<T>::valid () const
 template < class T >
 inline bool tsSLIterConst<T>::operator == ( const tsSLIterConst<T> &rhs ) const
 {
-    return this->pEntry == rhs.pConstEntry;
+    return this->pEntry == rhs.pEntry;
 }
 
 template < class T >
 inline bool tsSLIterConst<T>::operator != (const tsSLIterConst<T> &rhs) const
 {
-    return this->pEntry != rhs.pConstEntry;
+    return this->pEntry != rhs.pEntry;
 }
 
 template < class T >


### PR DESCRIPTION
Fixes the following build error in `tsSLIterConst` with clang 19.
```
clang++  -D_GNU_SOURCE -D_DEFAULT_SOURCE          -D_X86_64_ -DUNIX  -Dlinux   -DBUILDING_libCom_API   -O3 -g   -Wall      -mtune=generic     -m64  -fPIC -I. -I../O.Common -I. -I../osi/compiler/clang -I../osi/compiler/default -I. -I../osi/os/Linux -I../osi/os/posix -I../osi/os/default -I.. -I../as -I../bucketLib -I../calc -I../cvtFast -I../cppStd -I../cxxTemplates -I../dbmf -I../ellLib -I../env -I../error -I../fdmgr -I../flex -I../freeList -I../gpHash -I../iocsh -I../log -I../macLib -I../misc -I../osi -I../pool -I../ring -I../taskwd -I../timer -I../yacc -I../yacc -I../yajl -I../../../../include/compiler/clang -I../../../../include/os/Linux -I../../../../include         -c ../cxxTemplates/resourceLib.cpp
In file included from ../cxxTemplates/resourceLib.cpp:15:
In file included from ../cxxTemplates/resourceLib.h:43:
../cxxTemplates/tsSLList.h:314:32: error: no member named 'pConstEntry' in 'tsSLIterConst<T>'
  314 |     return this->pEntry == rhs.pConstEntry;
      |                            ~~~ ^
../cxxTemplates/tsSLList.h:320:32: error: no member named 'pConstEntry' in 'tsSLIterConst<T>'
  320 |     return this->pEntry != rhs.pConstEntry;
      |                            ~~~ ^
2 errors generated.
```

Seems to have been introduced in 3fb814777176e1d09e82684564f6926ad2689e8e way back in 2001. Not sure why clang is all of a sudden evaluating that operator.
