### PR TITLE
Add SHRLIB_INSTALLS mechanism

### DIFF
--- a/configure/CONFIG_ADDONS
+++ b/configure/CONFIG_ADDONS
@@ -68,8 +68,9 @@
 #    OBJS_HOST     host system object files to build and install
 #    OBJS_IOC      ioc system object files to build and install
 #    USR_INCLUDES  include directories
-#    BIN_INSTALLS  binaries to install
-#    LIB_INSTALLS  library binaries to install
+#    BIN_INSTALLS      binaries to install
+#    LIB_INSTALLS      library binaries to install
+#    SHRLIB_INSTALLS   shared library binaries to install
 #    RCS           win32 resource files for building libraries and prods
 #    PROD_RCS      win32 resource files for building prods
 #    LIB_RCS       win32 resource files for building libraries
@@ -227,6 +228,14 @@ LIB_INSTALLS+=$(subst -nil-,,$(LIB_INSTALLS_$(OS_CLASS)))
 else
 ifdef LIB_INSTALLS_DEFAULT
 LIB_INSTALLS+=$(LIB_INSTALLS_DEFAULT)
+endif
+endif
+
+ifneq ($(strip $(SHRLIB_INSTALLS_$(OS_CLASS))),)
+SHRLIB_INSTALLS+=$(subst -nil-,,$(SHRLIB_INSTALLS_$(OS_CLASS)))
+else
+ifdef SHRLIB_INSTALLS_DEFAULT
+SHRLIB_INSTALLS+=$(SHRLIB_INSTALLS_DEFAULT)
 endif
 endif
 

--- a/configure/CONFIG_COMMON
+++ b/configure/CONFIG_COMMON
@@ -402,6 +402,7 @@ INSTALL_CONFIGS = $(CONFIGS:%= $(INSTALL_CONFIG)/%)
 
 INSTALL_BIN_INSTALLS = $(addprefix $(INSTALL_BIN)/,$(notdir $(BIN_INSTALLS)))
 INSTALL_LIB_INSTALLS = $(addprefix $(INSTALL_LIB)/,$(notdir $(LIB_INSTALLS)))
+INSTALL_SHRLIB_INSTALLS = $(addprefix $(INSTALL_SHRLIB)/,$(notdir $(SHRLIB_INSTALLS)))
 
 #---------------------------------------------------------------
 # Installed file permissions

--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -196,8 +196,8 @@ endif
 $(sort $(DIRECTORY_TARGETS)):
 	$(MKDIR) $@
 
-# Install LIB_INSTALLS libraries before linking executables
-$(TESTPRODNAME) $(PRODNAME): | $(INSTALL_LIB_INSTALLS)
+# Install LIB_INSTALLS and SHRLIB_INSTALLS libraries before linking executables
+$(TESTPRODNAME) $(PRODNAME): | $(INSTALL_LIB_INSTALLS) $(INSTALL_SHRLIB_INSTALLS)
 
 # Install built libraries too, unless Makefile says to wait
 ifneq ($(DELAY_INSTALL_LIBS),YES)
@@ -454,7 +454,7 @@ $(COMMON_DIR)/$(GENVERSION): FORCE
 endif
 
 #---------------------------------------------------------------
-# Install rules for BIN_INSTALLS and LIB_INSTALLS
+# Install rules for BIN_INSTALLS, LIB_INSTALLS and SHRLIB_INSTALLS
 
 define  BIN_INSTALLS_template
 $$(INSTALL_BIN)/$$(notdir $(1)): $(1)
@@ -469,6 +469,13 @@ $$(INSTALL_LIB)/$$(notdir $(1)): $(1)
 	@$$(INSTALL) -d -m $$(LIB_PERMISSIONS) $$^ $$(INSTALL_LIB)
 endef
 $(foreach file, $(LIB_INSTALLS), $(eval $(call LIB_INSTALLS_template, $(file))))
+
+define  SHRLIB_INSTALLS_template
+$$(INSTALL_SHRLIB)/$$(notdir $(1)): $(1)
+        $(ECHO) "Installing $$(<F)"
+        @$$(INSTALL) -d -m $$(SHRLIB_PERMISSIONS) $$^ $$(INSTALL_SHRLIB)
+endef
+$(foreach file, $(SHRLIB_INSTALLS), $(eval $(call SHRLIB_INSTALLS_template, $(file))))
 
 #---------------------------------------------------------------
 

--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -22,6 +22,12 @@ should also be read to understand what has changed since earlier releases:
 
 ## Changes made on the 7.0 branch since 7.0.8.1
 
+### Use SHRLIB_INSTALLS to install shared libraries
+
+Analog to BIN_INSTALLS and LIB_INSTALLS,
+a Makefile mechanism to install shared libraries was added,
+using the apropriate file permissions and install location.
+
 ### The AMSG error message propagates through MSS links
 
 A database link with the MSS attribute will now propagate not only SEVR and


### PR DESCRIPTION
@henriquesimoes found in ralphlange/opcua-binary-builder#1 that the existing mechanisms for `BIN_INSTALLS` and `LIB_INSTALLS` do not use the correct file permissions and/or install locations for shared libraries.

This PR adds a new setting `SHRLIB_INSTALLS` for shared libraries.