### PR TITLE
Post monitors from compress record when resetting it

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -22,6 +22,11 @@ should also be read to understand what has changed since earlier releases:
 
 ## Changes made on the 7.0 branch since 7.0.8.1
 
+### Post monitors from compress record when it's reset
+
+Writing into a compress record's `RES` field now posts a monitor event instead
+of only changing `VAL`. Monitor clients will therefore receive an empty array.
+
 ### The AMSG error message propagates through MSS links
 
 A database link with the MSS attribute will now propagate not only SEVR and

--- a/modules/database/src/std/rec/compressRecord.c
+++ b/modules/database/src/std/rec/compressRecord.c
@@ -384,6 +384,7 @@ static long special(DBADDR *paddr, int after)
 
     if (special_type == SPC_RESET) {
         reset(prec);
+        monitor(prec);
         return 0;
     }
 


### PR DESCRIPTION
This way clients receive updates with an empty array after writing into the RES field.