### PR TITLE
Test cross linux-arm with QEMU user mode

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -204,7 +204,7 @@ jobs:
     - name: "apt-get install"
       run: |
         sudo apt-get update
-        sudo apt-get -y install qemu-system-x86 g++-mingw-w64-x86-64 gdb
+        sudo apt-get -y install qemu-system-x86 qemu-user g++-mingw-w64-x86-64 gdb
       if: runner.os == 'Linux'
     - name: Prepare and compile dependencies
       run: python .ci/cue.py prepare

--- a/configure/os/CONFIG_SITE.linux-x86.linux-arm
+++ b/configure/os/CONFIG_SITE.linux-x86.linux-arm
@@ -30,3 +30,7 @@ GNU_DIR = /usr/local/vw/zynq-2016.1/gnu/arm/lin
 # See CONFIG_SITE.Common.linux-arm for other COMMANDLINE_LIBRARY values
 #COMMANDLINE_LIBRARY = READLINE
 
+# If you're building this architecture you _probably_ want to
+# run the tests for it under QEMU, but if not you can turn
+# them off here by commenting out this line:
+CROSS_COMPILER_RUNTEST_ARCHS += $(T_A)

--- a/src/tools/makeTestfile.pl
+++ b/src/tools/makeTestfile.pl
@@ -65,6 +65,10 @@ elsif ($TA =~ /^RTEMS-/) {
     # Explicitly fail for other RTEMS targets
     die "$tool: I don't know how to create scripts for testing $TA on $HA\n";
 }
+elsif ($HA =~ /^linux-x86/ && $TA =~ /^linux-arm/) {
+    $exec = "qemu-arm-static -L /usr/arm-linux-gnueabihf $exe";
+    $error= "qemu-arm-static ... $exe";
+}
 else {
     # Assume it's directly executable on other targets
     $error = $exec = "./$exe";


### PR DESCRIPTION
It seems like as of QEMU 9.2, the Linux process emulation now covers the necessary `ioctl()` for Base unit tests, and even softIoc.  In part I think this is because the Linux version of `osiSockDiscoverBroadcastAddresses()` now uses `getifaddrs()` (which in turn uses netlink) instead of the `ioctl()` interface.

The `IP_MULTICAST_ALL` socket option isn't working, but that isn't essential.

```
$ qemu-arm-static -L /usr/arm-linux-gnueabihf  ./bin/linux-arm/softIoc -d tick.db 
Starting iocInit
############################################################################
## EPICS R7.0.8.2-DEV
## Rev. R7.0.8.1-179-gcdce2db211cbb8d47b03
## Rev. Date Git: 2025-01-10 18:52:54 -0800
############################################################################
Warning: Unable to clear IP_MULTICAST_ALL (err=92).  This may cause problems on multi-homed hosts.
CAS: CA beacon send to 192.168.71.255:5065 ERROR: Operation not permitted
iocRun: All initialization complete
CAS: CA beacon send to 10.234.10.255:5065 ERROR: Operation not permitted
epics> dbl
cnt
epics>
```

A draft because I'm not sure this is a useful addition, and because setting CROSS_COMPILER_RUNTEST_ARCHS isn't having the desired effect in the GHA builds.