### PR TITLE
docs: Channel Access CLI reference

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -138,6 +138,7 @@ RTD_SRC = $(COMMON_DIR)/rtd-src
 
 DOCS += README.md
 DOCS += RELEASE_NOTES.md
+DOCS += ca-cli.md
 
 include $(TOP)/configure/RULES
 

--- a/documentation/ca-cli.md
+++ b/documentation/ca-cli.md
@@ -5,4 +5,5 @@
 :caption: Tools
 
 caget
+cainfo
 ```

--- a/documentation/ca-cli.md
+++ b/documentation/ca-cli.md
@@ -18,4 +18,5 @@ acctst
 catime
 casw
 caEventRate
+ca_test
 ```

--- a/documentation/ca-cli.md
+++ b/documentation/ca-cli.md
@@ -15,4 +15,5 @@ caput
 :caption: Utilities
 
 acctst
+catime
 ```

--- a/documentation/ca-cli.md
+++ b/documentation/ca-cli.md
@@ -7,4 +7,5 @@
 caget
 cainfo
 camonitor
+caput
 ```

--- a/documentation/ca-cli.md
+++ b/documentation/ca-cli.md
@@ -16,4 +16,5 @@ caput
 
 acctst
 catime
+casw
 ```

--- a/documentation/ca-cli.md
+++ b/documentation/ca-cli.md
@@ -1,0 +1,8 @@
+# Channel Access command-line interface
+
+``` {toctree}
+:titlesonly:
+:caption: Tools
+
+caget
+```

--- a/documentation/ca-cli.md
+++ b/documentation/ca-cli.md
@@ -9,3 +9,10 @@ cainfo
 camonitor
 caput
 ```
+
+``` {toctree}
+:titlesonly:
+:caption: Utilities
+
+acctst
+```

--- a/documentation/ca-cli.md
+++ b/documentation/ca-cli.md
@@ -17,4 +17,5 @@ caput
 acctst
 catime
 casw
+caEventRate
 ```

--- a/documentation/ca-cli.md
+++ b/documentation/ca-cli.md
@@ -6,4 +6,5 @@
 
 caget
 cainfo
+camonitor
 ```

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -21,6 +21,12 @@ EPICS Base Documentation
    ComponentReference
 
 .. toctree::
+   :titlesonly:
+   :caption: Command Line Reference
+
+   msi
+
+.. toctree::
    :maxdepth: 1
    :caption: C/C++ Headers
 

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -24,6 +24,7 @@ EPICS Base Documentation
    :titlesonly:
    :caption: Command Line Reference
 
+   ca-cli
    msi
 
 .. toctree::

--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -12,6 +12,7 @@ TOP = ../../../..
 include $(TOP)/configure/CONFIG
 
 HTMLS += CAref.html
+DOCS += acctst.md
 
 #
 #	includes to install from this subproject

--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -13,6 +13,7 @@ include $(TOP)/configure/CONFIG
 
 HTMLS += CAref.html
 DOCS += acctst.md
+DOCS += catime.md
 
 #
 #	includes to install from this subproject

--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -15,6 +15,7 @@ HTMLS += CAref.html
 DOCS += acctst.md
 DOCS += catime.md
 DOCS += casw.md
+DOCS += caEventRate.md
 
 #
 #	includes to install from this subproject

--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -14,6 +14,7 @@ include $(TOP)/configure/CONFIG
 HTMLS += CAref.html
 DOCS += acctst.md
 DOCS += catime.md
+DOCS += casw.md
 
 #
 #	includes to install from this subproject

--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -16,6 +16,7 @@ DOCS += acctst.md
 DOCS += catime.md
 DOCS += casw.md
 DOCS += caEventRate.md
+DOCS += ca_test.md
 
 #
 #	includes to install from this subproject

--- a/modules/ca/src/client/acctst.md
+++ b/modules/ca/src/client/acctst.md
@@ -1,0 +1,18 @@
+# acctst
+
+    acctst <PV name> [progress logging level] [channel duplication count]
+                     [test repetition count] [enable preemptive callback]
+
+## Description
+
+Channel Access Client Library regression test.
+
+The PV used with the test must be native type `DBR_DOUBLE` or `DBR_FLOAT`,
+and modified only by acctst while the test is running. Therefore,
+periodically scanned hardware attached analog input records do not work
+well. Test failure is indicated if the program stops prior to printing
+"test complete". If unspecified the progress logging level is zero,
+and no messages are printed while the test is progressing. If
+unspecified, the channel duplication count is 20000. If unspecified, the
+test repetition count is once only. If unspecified, preemptive callback
+is disabled.

--- a/modules/ca/src/client/caEventRate.md
+++ b/modules/ca/src/client/caEventRate.md
@@ -1,0 +1,10 @@
+# caEventRate
+
+    caEventRate <PV name> [subscription count]
+
+## Description
+
+Connect to the specified PV, subscribe for monitor updates the specified
+number of times (default once), and periodically log the current sampled
+event rate, average event rate, and the standard deviation of the event
+rate in Hertz to standard out.

--- a/modules/ca/src/client/ca_test.md
+++ b/modules/ca/src/client/ca_test.md
@@ -1,0 +1,10 @@
+# ca_test
+
+    ca_test <PV name> [value to be written]
+
+## Description
+
+If a value is specified it is written to the PV. Next, the current value
+of the PV is converted to each of the many external data type that can
+be specified at the CA client library interface, and each of these is
+formated and then output to the console.

--- a/modules/ca/src/client/casw.md
+++ b/modules/ca/src/client/casw.md
@@ -1,0 +1,26 @@
+# casw
+
+    casw [-i <interest level>]
+
+## Description
+
+CA server "beacon anomaly" logging.
+
+CA server beacon anomalies occur when a new server joins the network, a
+server is rebooted, network connectivity to a server is reestablished,
+or if a server's CPU exits a CPU load saturated state.
+
+CA clients with unresolved channels reset their search request
+scheduling timers whenever they see a beacon anomaly.
+
+This program can be used to detect situations where there are too many
+beacon anomalies. IP routing configuration problems may result in false
+beacon anomalies that might cause CA clients to use unnecessary
+additional network bandwidth and server CPU load when searching for
+unresolved channels.
+
+If there are no new CA servers appearing on the network, and network
+connectivity remains constant, then casw should print no messages at
+all. At higher interest levels the program prints a message for every
+beacon that is received, and anomalous entries are flagged with a star.
+

--- a/modules/ca/src/client/catime.md
+++ b/modules/ca/src/client/catime.md
@@ -1,0 +1,15 @@
+# catime
+
+    catime <PV name> [channel count] [append number to pv name if true]
+
+## Description
+
+Channel Access Client Library performance test.
+
+If unspecified, the channel count is 10000. If the "append number to pv
+name if true" argument is specified and it is greater than zero then
+the channel names in the test are numbered as follows.
+
+    <PV name>000000, <PV name>000001, ... <PV name>nnnnnn
+
+

--- a/modules/ca/src/tools/Makefile
+++ b/modules/ca/src/tools/Makefile
@@ -27,5 +27,6 @@ PROD_LIBS = ca Com
 DOCS += caget.md
 DOCS += cainfo.md
 DOCS += camonitor.md
+DOCS += caput.md
 
 include $(TOP)/configure/RULES

--- a/modules/ca/src/tools/Makefile
+++ b/modules/ca/src/tools/Makefile
@@ -25,5 +25,6 @@ cainfo_SRCS = cainfo.c
 PROD_LIBS = ca Com
 
 DOCS += caget.md
+DOCS += cainfo.md
 
 include $(TOP)/configure/RULES

--- a/modules/ca/src/tools/Makefile
+++ b/modules/ca/src/tools/Makefile
@@ -26,5 +26,6 @@ PROD_LIBS = ca Com
 
 DOCS += caget.md
 DOCS += cainfo.md
+DOCS += camonitor.md
 
 include $(TOP)/configure/RULES

--- a/modules/ca/src/tools/Makefile
+++ b/modules/ca/src/tools/Makefile
@@ -24,4 +24,6 @@ cainfo_SRCS = cainfo.c
 
 PROD_LIBS = ca Com
 
+DOCS += caget.md
+
 include $(TOP)/configure/RULES

--- a/modules/ca/src/tools/caget.md
+++ b/modules/ca/src/tools/caget.md
@@ -1,0 +1,172 @@
+# caget
+
+``` {program} caget
+```
+
+    caget [options] <PV name> ...
+
+## Description
+
+Get and print value for PV(s).
+
+The values for one or multiple PVs are read and printed to stdout. The
+`DBR_...` format in which the data is read, the output format, and a
+number of details of how integer and float values are represented can be
+controlled using command line options.
+
+When getting multiple PVs, their order on the command line is retained
+in the output.
+
+## Options
+
+::: {option} -h
+Print usage information
+:::
+
+### Channel access options
+
+::: {option} -w <sec>
+Wait time, specifies longer CA timeout, default is 1.0 second.
+:::
+
+::: {option} -c
+Asynchronous get (use ca_get_callback instead of ca_get).
+:::
+
+::: {option} -p <prio>
+CA priority (0--99, default 0=lowest)
+:::
+
+### Format and data type options
+
+Default output format is `name value`
+
+::: {option} -t
+Terse mode --- print only value, without name.
+:::
+
+::: {option} -a
+Wide mode `name timestamp value stat sevr` (read PVs as `DBR_TIME_xxx`)
+:::
+
+::: {option} -d <type>
+Request specific dbr type; use   string (`DBR_` prefix may be omitted)
+or number of one of the following types:
+
+:STRING: 0
+:INT: 1
+:SHORT: 1
+:FLOAT: 2
+:ENUM: 3
+:CHAR: 4
+:LONG: 5
+:DOUBLE: 6
+:STS_STRING: 7
+:STS_INT: 8
+:STS_SHORT: 8
+:STS_FLOAT: 9
+:STS_ENUM: 10
+:STS_CHAR: 11
+:STS_LONG: 12
+:STS_DOUBLE: 13
+:TIME_STRING: 14
+:TIME_INT: 15
+:TIME_SHORT: 15
+:TIME_FLOAT: 16
+:TIME_ENUM: 17
+:TIME_CHAR: 18
+:TIME_LONG: 19
+:TIME_DOUBLE: 20
+:GR_STRING: 21
+:GR_INT: 22
+:GR_SHORT: 22
+:GR_FLOAT: 23
+:GR_ENUM: 24
+:GR_CHAR: 25
+:GR_LONG: 26
+:GR_DOUBLE: 27
+:CTRL_STRING: 28
+:CTRL_INT: 29
+:CTRL_SHORT: 29
+:CTRL_FLOAT: 30
+:CTRL_ENUM: 31
+:CTRL_CHAR: 32
+:CTRL_LONG: 33
+:CTRL_DOUBLE: 34
+:STSACK_STRING: 37
+:CLASS_NAME: 38
+:::
+
+### Enum format
+
+::: {option} -n
+Print `DBF_ENUM` value as number (default is enum string)
+:::
+
+### Arrays
+
+Value format: Print number of requested values, then list of values.
+
+By default: print all values.
+
+::: {option} -# <count>
+Print first \<count\> elements of an array.
+:::
+
+::: {option} -S
+Print array of char as a string (long string).
+:::
+
+### Floating point type format
+
+By default: use `%g` format.
+
+::: {option} -e <nr>
+Use `%e` format, with a precision of \<nr\> digits.
+:::
+
+::: {option} -f <nr>
+Use `%f` format, with a precision of \<nr\> digits.
+:::
+
+::: {option} -g <nr>
+Use `%g` format, with a precision of \<nr\> digits.
+:::
+
+::: {option} -s
+Get value as string (honors server-side precision).
+:::
+
+::: {option} -lx
+Round to long integer and print as hex number.
+:::
+
+::: {option} -lo
+Round to long integer and print as octal number.
+:::
+
+::: {option} -lb
+Round to long integer and print as binary number.
+:::
+
+### Integer number format
+
+By default: print as decimal number.
+
+::: {option} -0x
+Print as hex number.
+:::
+
+::: {option} -0o
+Print as octal number.
+:::
+
+::: {option} -0b
+Print as binary number.
+:::
+
+### Alternate output field separator
+
+::: {option} -F <ofs>
+Use \<ofs\> as an alternate output field separator.
+:::

--- a/modules/ca/src/tools/cainfo.md
+++ b/modules/ca/src/tools/cainfo.md
@@ -1,0 +1,40 @@
+# cainfo
+
+``` {program} cainfo
+```
+
+    cainfo [options] <PV name> ...
+
+## Description
+
+Get and print channel and connection information for PV(s).
+
+All available Channel Access related information about PV(s) is printed
+to stdout.
+
+The {option}`-s` option allows to specify an interest level for calling Channel
+Access' internal report function `ca_client_status()`, that prints lots
+of internal informations on stdout, including environment settings, used
+CA ports etc.
+
+## Options
+
+::: {option} -h
+Print usage information
+:::
+
+### CA options
+
+::: {option} -w <sec>
+Wait time, specifies longer CA timeout, default is 1.0 second.
+:::
+
+::: {option} -s <level>
+Call ca_client_status with the specified interest level
+:::
+
+::: {option} -p <prio>
+CA priority (0--99, default 0=lowest)
+:::
+
+

--- a/modules/ca/src/tools/camonitor.md
+++ b/modules/ca/src/tools/camonitor.md
@@ -1,0 +1,122 @@
+# camonitor
+
+``` {program} camonitor
+```
+
+    camonitor [options] <PV name> ...
+
+## Description
+
+Subscribe to and print value updates for PV(s).
+
+## Options
+
+::: {option} -h
+Print usage information
+:::
+
+### CA options
+
+::: {option} -w <sec>
+Wait time, specifies longer CA timeout, default is 1.0 second.
+:::
+
+::: {option} -m <msk>
+Specify CA event mask to use.
+
+\<msk\> is any combination of `v` (value), `a` (alarm), `l` (log/archive),
+`p` (property).
+
+Default event mask is `va`
+:::
+
+::: {option} -p <prio>
+CA priority (0--99, default 0=lowest)
+:::
+
+### Timestamps
+
+Default: Print absolute timestamps (as reported by CA server)
+
+::: {option} -t <key>
+Specify timestamp source(s) and type, with \<key\> containing:
+
+`s` = CA server (remote) timestamps\
+`c` = CA client (local) timestamps (shown in `()`s)\
+`n` = no timestamps\
+`r` = relative timestamps (time elapsed since start of program)\
+`i` = incremental timestamps (time elapsed since last update)\
+`I` = incremental timestamps (time since last update, by channel)\
+
+`r`, `i` or `I` require `s` or `c` to select the time source.
+:::
+
+### Enum format
+
+::: {option} -n
+Print `DBF_ENUM` values as number (default is enum string)
+:::
+
+### Arrays
+
+Array values: Print number of elements, then list of values.
+
+By default: request and print all elements (dynamic arrays supported).
+
+::: {option} -# <count>
+Request and print first \<count\> elements of an array.
+:::
+
+::: {option} -S
+Print array of char as a string (long string).
+:::
+
+### Floating point format
+
+By default: use `%g` format.
+
+::: {option} -e <nr>
+Use `%e` format, with a precision of \<nr\> digits.
+:::
+
+::: {option} -f <nr>
+Use `%f` format, with a precision of \<nr\> digits.
+:::
+
+::: {option} -g <nr>
+Use `%g` format, with a precision of \<nr\> digits.
+:::
+
+::: {option} -s
+Get value as string (honors server-side precision).
+:::
+
+::: {option} -lx
+Round to long integer and print as hex number.
+:::
+
+::: {option} -lo
+Round to long integer and print as octal number.
+:::
+
+::: {option} -lb
+Round to long integer and print as binary number.
+:::
+
+### Integer number format
+
+By default: print as decimal number.
+
+::: {option} -0x
+Print as hex number.
+:::
+
+::: {option} -0o
+Print as octal number.
+:::
+
+::: {option} -0b
+Print as binary number.
+:::
+
+

--- a/modules/ca/src/tools/caput.md
+++ b/modules/ca/src/tools/caput.md
@@ -1,0 +1,85 @@
+# caput
+
+``` {program} caput
+```
+
+    caput [options] <PV name> <value> ...
+    caput -a [options] <PV name> <no of elements> <value> ...
+
+## Description
+
+Put value to a PV.
+
+The specified value is written to the PV (as a string). The PV's value is read
+before and after the write operation and printed as "Old" and "New" values on
+stdout.
+
+There are two variants to the arguments for this command. For the scalar
+variant without the {option}`-a` flag, all the value arguments provided after
+the PV name are concatenated with a single space character between them, and
+the resulting string (up to 40 characters long unless the {option}`-S` flag is
+given) is written to the specified PV.
+
+The array variant with the {option}`-a` flag writes an array of string values
+to the specified PV. The numeric argument giving the number of array elements
+is actually ignored, the array length to be written is actually controlled by
+the number of values provided on the command line.
+
+## Options
+
+::: {option} -h
+Print usage information
+:::
+
+### CA options
+
+::: {option} -w <sec>
+Wait time, specifies longer CA timeout, default is 1.0 second.
+:::
+
+::: {option} -c
+Asynchronous get (use ca_get_callback instead of ca_get).
+:::
+
+::: {option} -p <prio>
+CA priority (0--99, default 0=lowest)
+:::
+
+### Format options
+
+::: {option} -t
+Terse mode --- print only successfully written value, without name.
+:::
+
+::: {option} -l
+Long mode `name timestamp value stat sevr` (read PVs as `DBR_TIME_xxx`)
+:::
+
+### Enum Format
+
+By default: Auto --- try value as ENUM string, then as index number
+
+::: {option} -n
+Force interpretation of values as numbers
+:::
+
+::: {option} -s
+Force interpretation of values as strings
+:::
+
+### Arrays
+
+By default: put scalar
+
+Value format: all value arguments concatenated with spaces
+
+::: {option} -S
+Put string as an array of chars (long string)
+:::
+
+::: {option} -a
+Put array
+
+Value format: number of values, then list of values
+:::
+

--- a/modules/database/src/ioc/dbtemplate/msi.md
+++ b/modules/database/src/ioc/dbtemplate/msi.md
@@ -1,5 +1,8 @@
 # msi: Macro Substitution and Include Tool
 
+``` {program} msi
+```
+
 (msitool)=
 ## Introduction
 
@@ -18,7 +21,9 @@ substitution files accepted by the EPICS IOC's dbLoadTemplate command.
 
 ## Command Syntax
 
-`msi -V -g -o outfile -I dir -M subs -S subfile template`
+``` bash
+msi -V -g -o outfile -I dir -M subs -S subfile template
+```
 
 All parameters are optional. The -o, -I, -M, and -S switches may be
 separated from their associated value string by spaces if desired.
@@ -26,80 +31,89 @@ Output will be written to stdout unless the -o option is given.
 
 Switches have the following meanings:
 
-- **-V**
+::: {option} -V
+Verbose warnings; if this parameter is specified then any undefined
+macro discovered in the template file which does not have an
+associated default value is considered an error. An error message is
+generated, and when msi terminates it will do so with an exit status
+of 2.
+:::
 
-    Verbose warnings; if this parameter is specified then any undefined
-    macro discovered in the template file which does not have an
-    associated default value is considered an error. An error message is
-    generated, and when msi terminates it will do so with an exit status
-    of 2.
-- **-g**
+::: {option} -g
+When this flag is given all macros defined in a substitution file
+will have global scope and thus their values will persist until a
+new value is given for this macro. This flag is provided for
+backwards compatibility as this was the behavior of previous
+versions of msi, but it does not follow common scoping rules and is
+discouraged.
+:::
 
-    When this flag is given all macros defined in a substitution file
-    will have global scope and thus their values will persist until a
-    new value is given for this macro. This flag is provided for
-    backwards compatibility as this was the behavior of previous
-    versions of msi, but it does not follow common scoping rules and is
-    discouraged.
-- **-o _file_**
+::: {option} -o <file>
+Output will be written to the specifed \<file\> rather than to the
+standard output.
+:::
 
-    Output will be written to the specifed file rather than to the
-    standard output.
-- **-I _dir_**
+::: {option} -I <dir>
+This parameter, which may be repeated or contain a colon-separated
+(or semi-colon separated on Windows) list of directory paths,
+specifies a search path for include commands. For example:
 
-    This parameter, which may be repeated or contain a colon-separated
-    (or semi-colon separated on Windows) list of directory paths,
-    specifies a search path for include commands. For example:
+``` bash
+msi -I /home/mrk/examples:. -I.. template
+```
 
-        msi -I /home/mrk/examples:. -I.. template
+specifies that all named files should be searched for in the following locations,
+in the order given:
 
-    specifies that all named files should be searched for in the following locations, 
-    in the order given:
+1.  `/home/mrk/examples`
+2.  `.` (the current directory)
+3.  `..` (the parent of the current directory)
 
-     1. /home/mrk/examples
-     2. . (the current directory)
-     3. .. (the parent of the current directory)
+Note that relative path searching is handled as
 
-    Note that relative path searching is handled as
-    
-        $ cat foo.substitutions
-        file rel/path/bar.template {
-          # contents
-        }
-        $ msi -I . -I /some/path foo.substitutions
-    
-    which will try to find `bar.template` at the path `./rel/path/` followed by
-    `/some/path/rel/path`.
+    $ cat foo.substitutions
+    file rel/path/bar.template {
+      # contents
+    }
+    $ msi -I . -I /some/path foo.substitutions
 
+which will try to find `bar.template` at the path `./rel/path/` followed by
+`/some/path/rel/path`.
+:::
 
-- **-M _substitutions_**
+::: {option} -M <substitutions>
+This parameter specifies macro values for the template instance.
+Multiple macro values can be specified in one substitution
+parameter, or in multiple -M parameters. For example:
 
-    This parameter specifies macro values for the template instance.
-    Multiple macro values can be specified in one substitution
-    parameter, or in multiple -M parameters. For example:
+``` bash
+msi -M "a=aval,b=bval" -Mc=cval template
+```
 
-        msi -M "a=aval,b=bval" -Mc=cval template
+specifies that in the template file each occurrence of:
 
-    specifies that in the template file each occurrence of:
+- `$(a)` or `${a}` is replaced by _aval_
+- `$(b)` or `${b}` is replaced by _bval_
+- `$(c)` or `${c}` is replaced by _cval_
+:::
 
-    - `$(a)` or `${a}` is replaced by _aval_
-    - `$(b)` or `${b}` is replaced by _bval_
-    - `$(c)` or `${c}` is replaced by _cval_
+::: {option} -S <subfile>
+The substitution file. See below for format.
+:::
 
-- **-S _subfile_**
-
-    The substitution file. See below for format.
-- **_template_**
-
-    The input file. If no file is specified then input is taken from
-    stdin, i.e. msi can be used as a filter. See below for a description
-    of commands that can be embedded in the template file.
+::: {option} <template>
+The input file. If no file is specified then input is taken from
+stdin, i.e. msi can be used as a filter. See below for a description
+of commands that can be embedded in the template file.
+:::
 
 It is not possible to display usage by just typing msi since executing
 the command with no arguments is a valid command. To show usage specify
 an illegal switch, e.g.
 
-    msi -help
+``` bash
+msi -help
+```
 
 
 ## Exit Status
@@ -167,9 +181,9 @@ template file itself. These commands are:
 
 Lines containing commands must be in one of these forms:
 
-  - include "_filename_"
+-   {samp}`include "{filename}"`
 
-  - substitute "_name1=value1, name2=value2, ..._"
+-   {samp}`substitute "{name1=value1, name2=value2, ...}"`
 
 White space is allowed before and after the command verb, and after the
 quoted string. If embedded quotes are needed, the backslash character \
@@ -227,11 +241,11 @@ dbTemplate format. We will discuss each separately.
 ### Regular format
 
     global {gbl_var1=gbl_val1, gbl_var2=gbl_val2, ...}
-    {var1=set1_val1, var2=set1_val2, ...}
-    {var2=set2_val2, var1=set2_val1, ...}
+        {var1=set1_val1, var2=set1_val2, ...}
+        {var2=set2_val2, var1=set2_val1, ...}
     global {gbl_var1=gbl_val3, gbl_var2=gbl_val4, ...}
-    {var1=set3_val1, var2=set3_val2, ...}
-    {var2=set4_val2, var1=set4_val1, ...}
+        {var1=set3_val1, var2=set3_val2, ...}
+        {var2=set4_val2, var1=set4_val1, ...}
 
 The template file is output with macro substitutions performed once for
 each set of braces containing macro replacement values.
@@ -241,12 +255,12 @@ each set of braces containing macro replacement values.
 
     global {gbl_var1=gbl_val1, gbl_var2=gbl_val2, ...}
     pattern {var1, var2, ...}
-    {set1_val1, set1_val2, ...}
-    {set2_val1, set2_val2, ...}
+        {set1_val1, set1_val2, ...}
+        {set2_val1, set2_val2, ...}
     pattern {var2, var1, ...}
     global {gbl_var1=gbl_val3, gbl_var2=gbl_val4, ...}
-    {set3_val2, set3_val1, ...}
-    {set4_val2, set4_val2, ...}
+        {set3_val2, set3_val1, ...}
+        {set4_val2, set4_val2, ...}
 
 This produces the same result as the regular format example above.
 
@@ -320,8 +334,8 @@ The file template contains
 and the file `substitute` is
 
     global {family=Kraimer}
-    {first=Marty}
-    {first=Irma}
+        {first=Marty}
+        {first=Irma}
 
 The following is the output produced:
 
@@ -340,8 +354,8 @@ Let the command be:
 The file pattern contains
 
     pattern {first,last}
-    {Marty,Kraimer}
-    {Irma,Kraimer}
+        {Marty,Kraimer}
+        {Irma,Kraimer}
 
 and template is the same as the previous example:
 
@@ -365,16 +379,16 @@ Let the command be
 `xxx.substitutions` is
 
     file template {
-    pattern {first,last}
-    {Marty,Kraimer}
-    {Irma,Kraimer}
-    pattern {last,first}
-    {Smith,Bill}
-    {Smith,Mary}
+        pattern {first,last}
+            {Marty,Kraimer}
+            {Irma,Kraimer}
+        pattern {last,first}
+            {Smith,Bill}
+            {Smith,Mary}
     }
     file template {
-    {first=Marty,last=Kraimer}
-    {first=Irma,last=Kraimer}
+        {first=Marty,last=Kraimer}
+        {first=Irma,last=Kraimer}
     }
 
 `template` is the same as in the previous example.


### PR DESCRIPTION
Follow-up on #588, imported the CLI reference from `CAref.html` into their own Markdown files, next to the source code, so that they have a higher chance of being updated if the source code is changed.

Also added `msi.md` to the index (with some light changes), since it was already here.

Link to the PR built by ReadTheDocs: https://epics--590.org.readthedocs.build/projects/base/en/590/ca-cli.html