### PR TITLE
Add dbServerStats() API

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -18,6 +18,13 @@ __This version of EPICS has not been released yet.__
 
 __Add new items below here__
 
+### New `dbServerStats()` API for iocStats
+
+A new routine provides the ability to request channel and client counts from
+name server layers that implement the `stats()` method. A preprocessor macro
+`HAS_DBSERVER_STATS` macro is defined in the `dbServer.h` header file to
+simplify code that needs to support older versions of Base as well.
+
 -----
 
 ## EPICS Release 7.0.9

--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -21,7 +21,8 @@ __Add new items below here__
 ### New `dbServerStats()` API for iocStats
 
 A new routine provides the ability to request channel and client counts from
-name server layers that implement the `stats()` method. A preprocessor macro
+named server layers that implement the `stats()` method, or to get a summary
+of the counts from all registered server layers. A preprocessor macro
 `HAS_DBSERVER_STATS` macro is defined in the `dbServer.h` header file to
 simplify code that needs to support older versions of Base as well.
 

--- a/modules/database/src/ioc/db/dbServer.c
+++ b/modules/database/src/ioc/db/dbServer.c
@@ -127,6 +127,26 @@ int dbServerClient(char *pBuf, size_t bufSize)
     return -1;
 }
 
+int dbServerStats(const char *name, unsigned *channels, unsigned *clients)
+{
+    dbServer *psrv = (dbServer *)ellFirst(&serverList);
+
+    if (state != running || !psrv)
+        return -1;
+
+    while (psrv) {
+        if (strcmp(name, psrv->name) == 0) {
+            if (!psrv->stats)
+                return -1;
+
+            psrv->stats(channels, clients);
+            return 0;
+        }
+        psrv = (dbServer *)ellNext(&psrv->node);
+    }
+    return -1;
+}
+
 #define STARTSTOP(routine, method, newState) \
 void routine(void) \
 { \

--- a/modules/database/src/ioc/db/dbServer.c
+++ b/modules/database/src/ioc/db/dbServer.c
@@ -131,7 +131,7 @@ int dbServerStats(const char *name, unsigned *channels, unsigned *clients)
 {
     dbServer *psrv = (dbServer *)ellFirst(&serverList);
 
-    if (state != running || !psrv)
+    if (!name || state != running || !psrv)
         return -1;
 
     while (psrv) {

--- a/modules/database/src/ioc/db/dbServer.h
+++ b/modules/database/src/ioc/db/dbServer.h
@@ -142,6 +142,11 @@ DBCORE_API void dbsr(unsigned level);
  */
 DBCORE_API int dbServerClient(char *pBuf, size_t bufSize);
 
+/** @brief CPP Macro indicating the dbServerStats() routine exists.
+ * @since UNRELEASED
+ */
+#define HAS_DBSERVER_STATS
+
 /** @brief Fetch statistics from named server.
  *
  * This is an API for iocStats and similar to fetch the number of channels
@@ -151,6 +156,8 @@ DBCORE_API int dbServerClient(char *pBuf, size_t bufSize);
  * @param clients Where to return the client count
  * @returns 0 on success; -1 if IOC isn't running, no such named server,
  *  or that server doesn't implement the stats method.
+ *
+ * @since UNRELEASED
  */
 DBCORE_API int dbServerStats(const char *name, unsigned *channels, unsigned *clients);
 

--- a/modules/database/src/ioc/db/dbServer.h
+++ b/modules/database/src/ioc/db/dbServer.h
@@ -151,9 +151,11 @@ DBCORE_API int dbServerClient(char *pBuf, size_t bufSize);
  *
  * This is an API for iocStats and similar to fetch the number of channels
  *  and clients connected to the named server layer.
+ *  If the name given is NULL the statistics returned are the totals for
+ *  all the registered server layers.
  * @param name Server name
- * @param channels Where to return the channel count
- * @param clients Where to return the client count
+ * @param channels NULL, or where to return the channel count
+ * @param clients NULL or where to return the client count
  * @returns 0 on success; -1 if IOC isn't running, no such named server,
  *  or that server doesn't implement the stats method.
  *

--- a/modules/database/src/ioc/db/dbServer.h
+++ b/modules/database/src/ioc/db/dbServer.h
@@ -17,9 +17,6 @@
  * the dbServer interface provides allow the IOC to start, pause and stop
  * the servers together, and to provide status and debugging information
  * to the IOC user/developer through a common set of commands.
- *
- * @todo No API is provided yet for calling stats() methods.
- * Nothing in the IOC calls dbStopServers(), not sure where it should go.
  */
 
 #ifndef INC_dbServer_H
@@ -144,6 +141,18 @@ DBCORE_API void dbsr(unsigned level);
  *  the record is subsequently processed.
  */
 DBCORE_API int dbServerClient(char *pBuf, size_t bufSize);
+
+/** @brief Fetch statistics from named server.
+ *
+ * This is an API for iocStats and similar to fetch the number of channels
+ *  and clients connected to the named server layer.
+ * @param name Server name
+ * @param channels Where to return the channel count
+ * @param clients Where to return the client count
+ * @returns 0 on success; -1 if IOC isn't running, no such named server,
+ *  or that server doesn't implement the stats method.
+ */
+DBCORE_API int dbServerStats(const char *name, unsigned *channels, unsigned *clients);
 
 /** @brief Initialize all registered servers.
  *

--- a/modules/database/src/ioc/db/dbServer.h
+++ b/modules/database/src/ioc/db/dbServer.h
@@ -56,8 +56,8 @@ typedef struct dbServer {
 
     /** @brief Get number of channels and clients currently connected.
      *
-     * @param channels NULL or pointer for returning channel count.
-     * @param clients NULL or pointer for returning client count.
+     * @param channels @c NULL or pointer for returning channel count.
+     * @param clients @c NULL or pointer for returning client count.
      */
     void (* stats) (unsigned *channels, unsigned *clients);
 
@@ -147,21 +147,24 @@ DBCORE_API int dbServerClient(char *pBuf, size_t bufSize);
  */
 #define HAS_DBSERVER_STATS
 
-/** @brief Fetch statistics from named server.
+/** @brief Fetch statistics from server layers.
  *
  * This is an API for iocStats and similar to fetch the number of channels
- *  and clients connected to the named server layer.
- *  If the name given is NULL the statistics returned are the totals for
- *  all the registered server layers.
+ *  and clients connected to the registered server layers.
+ *  If the name given is NULL the statistics returned are the totals from
+ *  all registered server layers, otherwise just from the named server.
  * @param name Server name
  * @param channels NULL, or where to return the channel count
  * @param clients NULL or where to return the client count
- * @returns 0 on success; -1 if IOC isn't running, no such named server,
- *  or that server doesn't implement the stats method.
+ * @returns -1 if the IOC isn't running or no servers are registered, without
+ *  writing to the statistics variables. Otherwise it writes to the statistics
+ *  variables and returns the number of dbServer::stats() methods called,
+ *  0 if a named server wasn't found or doesn't have a stats() method.
  *
  * @since UNRELEASED
  */
-DBCORE_API int dbServerStats(const char *name, unsigned *channels, unsigned *clients);
+DBCORE_API int dbServerStats(const char *name, unsigned *channels,
+    unsigned *clients);
 
 /** @brief Initialize all registered servers.
  *

--- a/modules/database/test/ioc/db/dbServerTest.c
+++ b/modules/database/test/ioc/db/dbServerTest.c
@@ -40,6 +40,8 @@ void oneReport(unsigned level)
 void oneStats(unsigned *channels, unsigned *clients)
 {
     oneState = STATS_CALLED;
+    *channels = 2;
+    *clients = 1;
 }
 
 int oneClient(char *pbuf, size_t len)
@@ -128,8 +130,9 @@ MAIN(dbServerTest)
     char name[16];
     char *theName = "The One";
     int status;
+    unsigned ch=0, cl=0;
 
-    testPlan(25);
+    testPlan(29);
 
     /* Prove that we handle substring names properly */
     epicsEnvSet("EPICS_IOC_IGNORE_SERVERS", "none ones");
@@ -163,7 +166,12 @@ MAIN(dbServerTest)
 
     testDiag("Checking server methods called");
     dbsr(0);
-    testOk(oneState == REPORT_CALLED, "dbsr called report()");
+    testOk(oneState == REPORT_CALLED, "dbsr called one::report()");
+    testOk(dbServerStats("none", &ch, &cl) != 0, "Stats: unknown name rejected");
+    testOk(dbServerStats("no-routines", &ch, &cl) != 0, "Stats: no-routine rejected");
+    testOk(dbServerStats("one", &ch, &cl) == 0 && oneState == STATS_CALLED,
+        "dbServerStats('one') called one::stats()");
+    testOk(ch == 2 && cl == 1, "Stats: counts returned as expected");
 
     oneSim = NULL;
     name[0] = 0;

--- a/modules/database/test/ioc/db/dbServerTest.c
+++ b/modules/database/test/ioc/db/dbServerTest.c
@@ -40,8 +40,8 @@ void oneReport(unsigned level)
 void oneStats(unsigned *channels, unsigned *clients)
 {
     oneState = STATS_CALLED;
-    *channels = 2;
-    *clients = 1;
+    if (channels) *channels = 2;
+    if (clients)  *clients = 1;
 }
 
 int oneClient(char *pbuf, size_t len)
@@ -132,7 +132,7 @@ MAIN(dbServerTest)
     int status;
     unsigned ch=0, cl=0;
 
-    testPlan(29);
+    testPlan(32);
 
     /* Prove that we handle substring names properly */
     epicsEnvSet("EPICS_IOC_IGNORE_SERVERS", "none ones");
@@ -167,12 +167,22 @@ MAIN(dbServerTest)
     testDiag("Checking server methods called");
     dbsr(0);
     testOk(oneState == REPORT_CALLED, "dbsr called one::report()");
+
+    testDiag("Checking stats functionality");
     testOk(dbServerStats("none", &ch, &cl) != 0, "Stats: unknown name rejected");
     testOk(dbServerStats("no-routines", &ch, &cl) != 0, "Stats: no-routine rejected");
     testOk(dbServerStats("one", &ch, &cl) == 0 && oneState == STATS_CALLED,
         "dbServerStats('one') called one::stats()");
-    testOk(ch == 2 && cl == 1, "Stats: counts returned as expected");
+    testOk(ch == 2 && cl == 1, "Stats: ch==%d, cl==%d (expected 2, 1)", ch, cl);
 
+    ch = 10; cl = 10; oneState = NOTHING_CALLED;
+    testOk(dbServerStats(NULL, NULL, &cl) == 0 && oneState == STATS_CALLED,
+        "dbServerStats(NULL, &cl) called one::stats()");
+    testOk(dbServerStats(NULL, &ch, NULL) == 0 && oneState == STATS_CALLED,
+        "dbServerStats(NULL, &ch) called one::stats()");
+    testOk(ch == 2 && cl == 1, "Stats: ch==%d, cl==%d (expected 2, 1)", ch, cl);
+
+    testDiag("Checking client identification");
     oneSim = NULL;
     name[0] = 0;
     status = dbServerClient(name, sizeof(name));


### PR DESCRIPTION
This adds a routine `dbServerStats()` for getting channel and client counts from a named server layer that registered with the IOC's dbServer API and provided a `stats()` method.

The IOC's Channel Access server registers using the name `rsrv`, the pvxs server as `qsrv2` (the registered name appears in the output from the iocsh `dbsr` command).

Code in modules such as iocStats can use `#ifdef HAS_DBSERVER_STATS` to detect Base versions which provide this routine.