### PR TITLE
initHookRegister() make idempotent and MustSucceed

### DIFF
--- a/modules/libcom/src/iocsh/initHooks.h
+++ b/modules/libcom/src/iocsh/initHooks.h
@@ -163,7 +163,11 @@ typedef void (*initHookFunction)(initHookState state);
  *
  * Registers \p func for initHook notifications
  * \param func Pointer to application's notification function.
- * \return 0 if Ok, -1 on error (memory allocation failure).
+ * \return Always zero.  (before UNRELEASED could return -1 on allocation failure)
+ *
+ * \since UNRELEASED initHookRegister is idempotent.
+ *        Previously, repeated registrations would result
+ *        in duplicate calls to the hook function.
  */
 LIBCOM_API int initHookRegister(initHookFunction func);
 


### PR DESCRIPTION
From looking at #558 and asking whether a `first_use` flag around `initHookRegister()` is necessary.  It is now, but imo. should not be.  So this PR changes `initHookRegister()` to ignore duplicate registrations.  This is in line with the `iocshRegister()` calls often found alongside.  I also opt to change to a MustSucceed allocation on the theory that memory exhaustion would become even less likely.