### PR TITLE
make casStatsFetch() safe-ish when RSRV not initialized

### DIFF
--- a/modules/database/src/ioc/rsrv/camsgtask.c
+++ b/modules/database/src/ioc/rsrv/camsgtask.c
@@ -163,6 +163,8 @@ void camsgtask ( void *pParm )
 
 int casClientInitiatingCurrentThread ( char * pBuf, size_t bufSize )
 {
+    if ( ! rsrvCurrentClient )
+        return RSRV_ERROR; /* not yet initialized, or disabled via dbServer */
     struct client * pClient = ( struct client * )
         epicsThreadPrivateGet ( rsrvCurrentClient );
 

--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -1536,6 +1536,13 @@ struct client *create_tcp_client (SOCKET sock , const osiSockAddr *peerAddr)
 
 void casStatsFetch ( unsigned *pChanCount, unsigned *pCircuitCount )
 {
+    if(!clientQlock) { /* not yet initialized, or disabled via dbServer */
+        if(pChanCount)
+            *pChanCount = 0;
+        if(pCircuitCount)
+            *pCircuitCount = 0;
+        return;
+    }
     LOCK_CLIENTQ;
     {
         int circuitCount = ellCount ( &clientQ );


### PR DESCRIPTION
See #596.  Testing these global statics is not reentrant, however prior to `rsrv_init()`, or if it will never be called, then there is no racer.