### PR TITLE
Update GitHub Actions build configuration

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -239,6 +239,15 @@ jobs:
       matrix:
         # Job names also name artifacts, character limitations apply
         include:
+          - name: "CentOS-8"
+            image: centos:8
+            cmp: gcc
+            configuration: default
+
+          - name: "Rocky-9"
+            image: rockylinux:9
+            cmp: gcc
+            configuration: default
 
           - name: "Fedora-33"
             image: fedora:33
@@ -251,6 +260,13 @@ jobs:
             configuration: default
 
     steps:
+    - name: "Fix repo URLs on CentOS-8"
+      # centos:8 is frozen, repos are in the vault
+      if: matrix.image=='centos:8'
+      run: |
+        sed -i -e "s|mirrorlist=|#mirrorlist=|" \
+        -e "s|#baseurl=http://mirror|baseurl=http://vault|" \
+        /etc/yum.repos.d/CentOS-Linux-{BaseOS,AppStream,Extras,Plus}.repo
     - name: "Redhat setup"
       run: |
         dnf -y install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -50,9 +50,9 @@ jobs:
       matrix:
         # Job names also name artifacts, character limitations apply
         include:
-          - os: ubuntu-22.04
-            cmp: gcc-12
-            name: "Ub-22 gcc-12 c++20 Werror"
+          - os: ubuntu-24.04
+            cmp: gcc
+            name: "Ub-24 gcc-13 c++20 Werror"
             # Turn all warnings into errors,
             # except for those we could not fix (yet).
             # Remove respective -Wno-error=... flag once it is fixed.
@@ -73,79 +73,79 @@ jobs:
                                   -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3'
                     CMD_LDFLAGS=-Wl,-z,relro"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             cross: "windows-x64-mingw"
-            name: "Ub-20 gcc + MinGW"
+            name: "Ub-22 gcc + MinGW"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: static
             cross: "windows-x64-mingw"
-            name: "Ub-20 gcc + MinGW, static"
+            name: "Ub-22 gcc + MinGW, static"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: static
             extra: "CMD_CXXFLAGS=-std=c++11"
-            name: "Ub-20 gcc C++11, static"
+            name: "Ub-22 gcc C++11, static"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: static
             extra: "CMD_CFLAGS=-funsigned-char CMD_CXXFLAGS=-funsigned-char"
-            name: "Ub-20 gcc unsigned char"
+            name: "Ub-22 gcc unsigned char"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: clang
             configuration: default
-            name: "Ub-20 clang"
+            name: "Ub-22 clang"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: clang
             configuration: default
             extra: "CMD_CXXFLAGS=-std=c++11"
-            name: "Ub-20 clang C++11"
+            name: "Ub-22 clang C++11"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             cross: "RTEMS-pc686-qemu@5"
-            name: "Ub-20 gcc + RT-5.1 pc686"
+            name: "Ub-22 gcc + RT-5.1 pc686"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             cross: "RTEMS-beatnik@5"
             test: NO
-            name: "Ub-20 gcc + RT-5.1 beatnik"
+            name: "Ub-22 gcc + RT-5.1 beatnik"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             cross: "RTEMS-xilinx_zynq_a9_qemu@5"
             test: NO
-            name: "Ub-20 gcc + RT-5.1 xilinx_zynq_a9_qemu"
+            name: "Ub-22 gcc + RT-5.1 xilinx_zynq_a9_qemu"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             cross: "RTEMS-uC5282@5"
             test: NO
-            name: "Ub-20 gcc + RT-5.1 uC5282"
+            name: "Ub-22 gcc + RT-5.1 uC5282"
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: default
-            name: "Ub-20 gcc + RT-4.10"
+            name: "Ub-22 gcc + RT-4.10"
             cross: "RTEMS-pc386-qemu@4.10"
             test: NO
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             cmp: gcc
             configuration: default
-            name: "Ub-20 gcc + RT-4.9"
+            name: "Ub-22 gcc + RT-4.9"
             cross: "RTEMS-pc386-qemu@4.9"
 
           - os: macos-latest

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -239,10 +239,6 @@ jobs:
       matrix:
         # Job names also name artifacts, character limitations apply
         include:
-          #- name: "CentOS-7"
-          #  image: centos:7
-          #  cmp: gcc
-          #  configuration: default
 
           - name: "Fedora-33"
             image: fedora:33
@@ -255,47 +251,22 @@ jobs:
             configuration: default
 
     steps:
-    - name: "Build newer Git"
-      # actions/checkout@v2 wants git >=2.18
-      # centos:7 has 1.8
-      if: matrix.image=='centos:7'
-      run: |
-        yum -y install curl make gcc curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker
-        curl https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.29.0.tar.gz | tar -xz
-        cd git-*
-        make -j2 prefix=/usr/local all
-        make prefix=/usr/local install
-        cd ..
-        rm -rf git-*
-        type -a git
-        git --version
     - name: "Redhat setup"
       run: |
-        dnfyum() {
-            dnf -y "$@" || yum -y "$@"
-            return $?
-        }
-        dnfyum install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple
-        git --version || dnfyum install git
-        # rather than just bite the bullet and link python3 -> python,
-        # people would rather just break all existing scripts...
-        [ -e /usr/bin/python ] || ln -sf python3 /usr/bin/python
-        python --version
+        dnf -y install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple
+        git --version || dnf -y install git
+        python3 --version
     - uses: actions/checkout@v4
       with:
         submodules: true
     - name: Automatic core dumper analysis
       uses: mdavidsaver/ci-core-dumper@master
-      if: matrix.image!='centos:7'
-    - name: Automatic core dumper analysis
-      uses: mdavidsaver/ci-core-dumper@node16
-      if: matrix.image=='centos:7'
     - name: Prepare and compile dependencies
-      run: python .ci/cue.py prepare
+      run: python3 .ci/cue.py prepare
     - name: Build main module
-      run: python .ci/cue.py build
+      run: python3 .ci/cue.py build
     - name: Run main module tests
-      run: python .ci/cue.py -T 20M test
+      run: python3 .ci/cue.py -T 20M test
     - name: Upload tapfiles Artifact
       if: ${{ always() }}
       uses: actions/upload-artifact@v4
@@ -305,4 +276,55 @@ jobs:
         if-no-files-found: ignore
     - name: Collect and show test results
       if: ${{ always() }}
-      run: python .ci/cue.py -T 5M test-results
+      run: python3 .ci/cue.py -T 5M test-results
+
+  build-docker:
+    name: Docker CentOS-7
+    runs-on: ubuntu-latest
+    env:
+      CMP: gcc
+      BCFG: default
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    
+    - name: Run...
+      run: |
+        env > env.list
+        cat <<EOF > runit.sh
+        #!/bin/sh
+        set -e -x
+        cd /io
+        id
+
+        sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+        sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+        sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+        yum -y install epel-release
+        yum -y install \
+          curl make gcc curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker \
+          python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple \
+          libevent-devel sudo re2c
+        [ -e /usr/bin/python ] || ln -sf /usr/bin/python3 /usr/bin/python
+
+        # fake out cue.py
+        ln -s /bin/true /usr/bin/apt-get
+
+        # quiet warnings spam from perl
+        export LANG=C
+
+        python --version
+        python .ci/cue.py prepare
+        python .ci/cue.py build
+        python .ci/cue.py -T 15M test
+        python .ci/cue.py test-results
+        EOF
+        chmod +x runit.sh
+        docker run --rm --quiet \
+          --pull=always \
+          --env-file env.list \
+          -v `pwd`:/io \
+          centos:7 \
+          /io/runit.sh


### PR DESCRIPTION
Update of the GitHub Actions build configuration:
- Bump Ubuntu jobs (22.04 -> 24.04; 20.04 -> 22.04)
- Re-add CentOS-7 job as a self-managed Docker build
- Add CentOS-8 and Rocky-9 jobs as GHA-managed Docker builds