### PR TITLE
support CROSS_COMPILER_RUNTESTS_ARCHS other than RTEMS

### DIFF
--- a/modules/database/test/ioc/db/Makefile
+++ b/modules/database/test/ioc/db/Makefile
@@ -208,8 +208,8 @@ TESTSPEC_RTEMS = dbTestHarness.boot; epicsRunDbTests
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
-TESTPROD_RTEMS = $(TESTPROD_HOST)
-TESTSCRIPTS_RTEMS += $(TESTS:%=%.t)
+TESTPROD += $(TESTPROD_HOST)
+TESTSCRIPTS += $(TESTS:%=%.t)
 endif
 
 include $(TOP)/configure/RULES

--- a/modules/database/test/std/filters/Makefile
+++ b/modules/database/test/std/filters/Makefile
@@ -81,8 +81,8 @@ TESTSPEC_RTEMS = filterTestHarness.boot; epicsRunFilterTests
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
-TESTPROD_RTEMS = $(TESTPROD_HOST)
-TESTSCRIPTS_RTEMS += $(TESTS:%=%.t)
+TESTPROD += $(TESTPROD_HOST)
+TESTSCRIPTS += $(TESTS:%=%.t)
 endif
 
 include $(TOP)/configure/RULES

--- a/modules/database/test/std/link/Makefile
+++ b/modules/database/test/std/link/Makefile
@@ -57,8 +57,8 @@ TESTSPEC_RTEMS = linkTestHarness.boot; epicsRunLinkTests
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
-  TESTPROD = $(TESTPROD_HOST)
-  TESTSCRIPTS_RTEMS += $(TESTS:%=%.t)
+  TESTPROD += $(TESTPROD_HOST)
+  TESTSCRIPTS += $(TESTS:%=%.t)
 endif
 
 include $(TOP)/configure/RULES

--- a/modules/database/test/std/rec/Makefile
+++ b/modules/database/test/std/rec/Makefile
@@ -251,8 +251,8 @@ TESTSPEC_RTEMS = recordTestHarness.boot; epicsRunRecordTests
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
-TESTPROD_RTEMS = $(TESTPROD_HOST)
-TESTSCRIPTS_RTEMS += $(TESTS:%=%.t)
+TESTPROD += $(TESTPROD_HOST)
+TESTSCRIPTS += $(TESTS:%=%.t)
 endif
 
 include $(TOP)/configure/RULES

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -295,7 +295,7 @@ TESTSPEC_RTEMS = libComTestHarness.boot; epicsRunLibComTests
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
-TESTPROD = $(TESTPROD_HOST)
+TESTPROD += $(TESTPROD_HOST)
 TESTSCRIPTS += $(filter-out epicsUnitTestTest.t, $(TESTS:%=%.t))
 endif
 


### PR DESCRIPTION
Several Makefiles (not all) have added tests only for RTEMS if `CROSS_COMPILER_RUNTEST_ARCHS` matched the current `T_A`. The tests must be added independent of the OS for other than RTEMS RUNTEST_ARCHS to work.
