### PR TITLE
Don't use __attribute__((noreturn)) on VxWorks

### DIFF
--- a/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
@@ -60,6 +60,9 @@
 /*
  * No return marker
  */
+#ifndef vxWorks
+// VxWorks does not mark abort() or exit() noreturn!
 #define EPICS_NORETURN __attribute__((noreturn))
+#endif
 
 #endif  /* ifndef compilerSpecific_h */


### PR DESCRIPTION
VxWorks does not mark `abort()` or `exit()` as noreturn. Thus, functions declared noreturn which end in a call to those functions cause a compiler warning on vxWorks.