### PR TITLE
Forcing CA protocol version for clients connecting through the nameserver

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -188,7 +188,7 @@ LINKER_ORIGIN_ROOT = $(INSTALL_LOCATION)
 # name server being used and revert to an older CA protocol version when
 # connecting to IOCs. This is only needed if the site has any IOCs prior to
 # EPICS 3.14.12, or more specifically CA protocol version prior to 4.13.
-MIN_IOC_CA_VER_WHEN_REDIRECT = 11
+#MIN_IOC_CA_VER_WHEN_REDIRECT = 11
 
 # Overrides for the settings above may appear in a CONFIG_SITE.local file
 -include $(CONFIG)/CONFIG_SITE.local

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -178,5 +178,17 @@ LINKER_USE_RPATH = YES
 # All root directories are considered to be the same.
 LINKER_ORIGIN_ROOT = $(INSTALL_LOCATION)
 
+# When using the name server to find PVs on the network, what is the oldest
+# Channel Access server version. The CA protocol versions can be found in
+# include/caProto.h file.
+# Prior to EPICS 3.14.12, the IOC didn't advertise its version when subscribing
+# a channel. This leads to CA clients getting confused and using the CA version
+# of the name server, and in some cases fail to communicate properly with IOC.
+# When enabled, this compile-time option allows CA clients to detect the
+# name server being used and revert to an older CA protocol version when
+# connecting to IOCs. This is only needed if the site has any IOCs prior to
+# EPICS 3.14.12, or more specifically CA protocol version prior to 4.13.
+MIN_IOC_CA_VER_WHEN_REDIRECT = 11
+
 # Overrides for the settings above may appear in a CONFIG_SITE.local file
 -include $(CONFIG)/CONFIG_SITE.local

--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -120,6 +120,10 @@ PROD_HOST += ca_test
 ca_test_SRCS = ca_test_main.c ca_test.c
 ca_test_SYS_LIBS_WIN32 = ws2_32 advapi32 user32
 
+ifdef MIN_IOC_CA_VER_WHEN_REDIRECT
+udpiiu_CPPFLAGS += -DMIN_IOC_CA_VER_WHEN_REDIRECT=$(MIN_IOC_CA_VER_WHEN_REDIRECT)
+endif
+
 OBJS_vxWorks += ca_test
 
 # shared library ABI version.

--- a/modules/ca/src/client/SearchDest.h
+++ b/modules/ca/src/client/SearchDest.h
@@ -34,6 +34,7 @@ struct SearchDest :
     virtual void searchRequest ( epicsGuard < epicsMutex > &,
         const char * pbuf, size_t len ) = 0;
     virtual void show ( epicsGuard < epicsMutex > &, unsigned level ) const = 0;
+    virtual void getAddr( osiSockAddr & addr ) const = 0;
 };
 
 #endif // ifndef INC_SearchDest_H

--- a/modules/ca/src/client/tcpiiu.cpp
+++ b/modules/ca/src/client/tcpiiu.cpp
@@ -2186,6 +2186,11 @@ void SearchDestTCP :: show (
     :: printf ( "tcpiiu :: SearchDestTCP\n" );
 }
 
+void SearchDestTCP :: getAddr ( osiSockAddr & addr ) const
+{
+    memcpy(&addr, &_addr, sizeof(osiSockAddr));
+}
+
 void tcpiiu :: versionRespNotify ( const caHdrLargeArray & msg )
 {
     this->minorProtocolVersion = msg.m_count;

--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -725,6 +725,33 @@ bool udpiiu :: searchRespAction (
         serverAddr.ia.sin_addr = addr.ia.sin_addr;
     }
 
+#ifdef MIN_IOC_CA_VER_WHEN_REDIRECT
+    // Try to detect the nameserver redirecting us to a different IP
+    if (memcmp(&addr.ia.sin_addr, &serverAddr.ia.sin_addr, sizeof(struct in_addr)) != 0) {
+
+        // Additional check: nameserver should be explicitly defined in the search list
+        tsDLIter < SearchDest > iter ( _searchDestList.firstIter () );
+        while ( iter.valid () )
+        {
+            osiSockAddr tmpAddr;
+            iter->getAddr(tmpAddr);
+            if (memcmp(&addr.ia.sin_addr, &tmpAddr.ia.sin_addr, sizeof(struct in_addr)) != 0 &&
+                addr.ia.sin_port == tmpAddr.ia.sin_port) {
+
+                char from[64];
+                char to[64];
+                ipAddrToDottedIP(&addr.ia, from, sizeof(from));
+                ipAddrToDottedIP(&serverAddr.ia, to, sizeof(to));
+                printf("Redirected to %s, nameserver %s version %u, min IOC version %u\n", to, from, minorVersion, MIN_IOC_CA_VER_WHEN_REDIRECT);
+
+                minorVersion = MIN_IOC_CA_VER_WHEN_REDIRECT;
+                break;
+            }
+            iter++;
+        }
+    }
+#endif
+
     if ( CA_V42 ( minorVersion ) ) {
        cacRef.transferChanToVirtCircuit
             ( msg.m_available, msg.m_cid, 0xffff,
@@ -1032,6 +1059,11 @@ void udpiiu :: SearchDestUDP :: show (
     char buf[64];
     sockAddrToDottedIP ( &_destAddr.sa, buf, sizeof ( buf ) );
     :: printf ( "UDP Search destination \"%s\"\n", buf );
+}
+
+void udpiiu :: SearchDestUDP :: getAddr ( osiSockAddr & addr ) const
+{
+    memcpy(&addr, &_destAddr, sizeof(osiSockAddr));
 }
 
 udpiiu :: SearchRespCallback :: SearchRespCallback ( udpiiu & udpiiuIn ) :

--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -726,23 +726,19 @@ bool udpiiu :: searchRespAction (
     }
 
 #ifdef MIN_IOC_CA_VER_WHEN_REDIRECT
-    // Try to detect the nameserver redirecting us to a different IP
-    if (memcmp(&addr.ia.sin_addr, &serverAddr.ia.sin_addr, sizeof(struct in_addr)) != 0) {
+    // Try to detect the nameserver redirecting us to a different IP.
+    // This is not a guaranteed nameserver determination, ie. on multi-IP
+    // system the UDP response may come from a second IP.
+    if ( memcmp(&addr.ia.sin_addr, &serverAddr.ia.sin_addr, sizeof(struct in_addr)) != 0 ) {
 
         // Additional check: nameserver should be explicitly defined in the search list
         tsDLIter < SearchDest > iter ( _searchDestList.firstIter () );
-        while ( iter.valid () )
-        {
+        while ( iter.valid () ) {
+
             osiSockAddr tmpAddr;
             iter->getAddr(tmpAddr);
-            if (memcmp(&addr.ia.sin_addr, &tmpAddr.ia.sin_addr, sizeof(struct in_addr)) != 0 &&
-                addr.ia.sin_port == tmpAddr.ia.sin_port) {
-
-                char from[64];
-                char to[64];
-                ipAddrToDottedIP(&addr.ia, from, sizeof(from));
-                ipAddrToDottedIP(&serverAddr.ia, to, sizeof(to));
-                printf("Redirected to %s, nameserver %s version %u, min IOC version %u\n", to, from, minorVersion, MIN_IOC_CA_VER_WHEN_REDIRECT);
+            if ( memcmp(&addr.ia.sin_addr, &tmpAddr.ia.sin_addr, sizeof(struct in_addr)) == 0 &&
+                 addr.ia.sin_port == tmpAddr.ia.sin_port ) {
 
                 minorVersion = MIN_IOC_CA_VER_WHEN_REDIRECT;
                 break;

--- a/modules/ca/src/client/udpiiu.h
+++ b/modules/ca/src/client/udpiiu.h
@@ -125,6 +125,7 @@ private:
             epicsGuard < epicsMutex > &, const char * pBuf, size_t bufLen );
         void show (
             epicsGuard < epicsMutex > &, unsigned level ) const;
+        void getAddr ( osiSockAddr & ) const;
     private:
         int _lastError;
         osiSockAddr _destAddr;

--- a/modules/ca/src/client/virtualCircuit.h
+++ b/modules/ca/src/client/virtualCircuit.h
@@ -102,6 +102,7 @@ public:
     void setCircuit ( tcpiiu * );
     void disable ();
     void enable ();
+    void getAddr ( osiSockAddr & ) const;
 private:
     tcpiiu * _ptcpiiu;
     cac & _cac;


### PR DESCRIPTION
This is a proposed patch to address issue #426 solely on the CA client side, no other changes to the name server are required. It works by letting user specify the oldest IOC/CA version used on the network. When not enabled (default), it has no impact on the existing code. When enabled at compile time, it tries to detect if UDP response is coming from the nameserver, in which case it ignores the CA version from the UDP response message and instead uses the compile-time value. When connecting to CA server 13+, the server properly advertises its version when TCP channel is established and overrides previous version from UDP. In all other cases it uses the compile-time value - frankly, this may introduce other version-compatibility problems if IOC is of different version. Luckily there has been few CA protocol changes, ie the oldest IOC at SNS is 3.14.8 which is CA version 11.