### PR TITLE
Replace dbgrep by dbglob, leaving dbgrep as an alias

### DIFF
--- a/documentation/new-notes/PR-626.md
+++ b/documentation/new-notes/PR-626.md
@@ -1,0 +1,5 @@
+*** Add `dbglob` to replace `dbgrep`
+
+A new IOC shell command, `dbglob` has been added, with `dbgrep` becoming
+an alias of this new function, with the intent of deprecating it in a
+future release.

--- a/modules/database/src/ioc/db/dbIocRegister.c
+++ b/modules/database/src/ioc/db/dbIocRegister.c
@@ -233,18 +233,26 @@ static const iocshFuncDef dblaFuncDef = {"dbla",1,dblaArgs,
                                          "Example: dbla(\"alia*\")\n"};
 static void dblaCallFunc(const iocshArgBuf *args) { iocshSetError(dbla(args[0].sval));}
 
+/* dbglob */
+static const iocshArg dbglobArg0 = { "pattern",iocshArgStringRecord};
+static const iocshArg dbglobArg1 = { "fields",iocshArgString};
+static const iocshArg * const dbglobArgs[2] = {&dbglobArg0,&dbglobArg1};
+static const iocshFuncDef dbglobFuncDef = {"dbglob",2,dbglobArgs,
+                                           "List record names matching pattern and optionally print field values. \n"
+                                           "The pattern can contain any characters that are legal in record names as well as:\n"
+                                           " - \"?\", which matches 0 or one characters.\n"
+                                           " - \"*\", which matches 0 or more characters.\n\n"
+                                           "Example: dbglob(\"*gpibAi*\")\n"
+                                           "         dbglob(\"*gpibAi*\",\"VAL DESC\")\n"};
+static void dbglobCallFunc(const iocshArgBuf *args) { iocshSetError(dbglob(args[0].sval,args[1].sval));}
+
 /* dbgrep */
 static const iocshArg dbgrepArg0 = { "pattern",iocshArgStringRecord};
 static const iocshArg dbgrepArg1 = { "fields",iocshArgString};
 static const iocshArg * const dbgrepArgs[2] = {&dbgrepArg0,&dbgrepArg1};
 static const iocshFuncDef dbgrepFuncDef = {"dbgrep",2,dbgrepArgs,
-                                           "List record names matching pattern and optionally print field values. \n"
-                                           "The pattern can contain any characters that are legal in record names as well as:\n"
-                                           " - \"?\", which matches 0 or one characters.\n"
-                                           " - \"*\", which matches 0 or more characters.\n\n"
-                                           "Example: dbgrep(\"*gpibAi*\")\n"
-                                           "         dbgrep(\"*gpibAi*\",\"VAL DESC\")\n"};
-static void dbgrepCallFunc(const iocshArgBuf *args) { iocshSetError(dbgrep(args[0].sval,args[1].sval));}
+                                           "See dbglob.\n"};
+static void dbgrepCallFunc(const iocshArgBuf *args) { iocshSetError(dbglob(args[0].sval,args[1].sval));}
 
 /* dbgf */
 static const iocshArg dbgfArg0 = { "record name",iocshArgStringRecord};
@@ -600,6 +608,7 @@ void dbIocRegister(void)
     iocshRegister(&dbnrFuncDef,dbnrCallFunc);
     iocshRegister(&dblaFuncDef,dblaCallFunc);
     iocshRegister(&dbliFuncDef,dbliCallFunc);
+    iocshRegister(&dbglobFuncDef,dbglobCallFunc);
     iocshRegister(&dbgrepFuncDef,dbgrepCallFunc);
     iocshRegister(&dbgfFuncDef,dbgfCallFunc);
     iocshRegister(&dbpfFuncDef,dbpfCallFunc);

--- a/modules/database/src/ioc/db/dbIocRegister.c
+++ b/modules/database/src/ioc/db/dbIocRegister.c
@@ -246,11 +246,8 @@ static const iocshFuncDef dbglobFuncDef = {"dbglob",2,dbglobArgs,
                                            "         dbglob(\"*gpibAi*\",\"VAL DESC\")\n"};
 static void dbglobCallFunc(const iocshArgBuf *args) { iocshSetError(dbglob(args[0].sval,args[1].sval));}
 
-/* dbgrep */
-static const iocshArg dbgrepArg0 = { "pattern",iocshArgStringRecord};
-static const iocshArg dbgrepArg1 = { "fields",iocshArgString};
-static const iocshArg * const dbgrepArgs[2] = {&dbgrepArg0,&dbgrepArg1};
-static const iocshFuncDef dbgrepFuncDef = {"dbgrep",2,dbgrepArgs,
+/* dbgrep; alias for dbglob, so it should have the same arguments */
+static const iocshFuncDef dbgrepFuncDef = {"dbgrep",2,dbglobArgs,
                                            "See dbglob.\n"};
 static void dbgrepCallFunc(const iocshArgBuf *args) { iocshSetError(dbglob(args[0].sval,args[1].sval));}
 

--- a/modules/database/src/ioc/db/dbTest.c
+++ b/modules/database/src/ioc/db/dbTest.c
@@ -295,7 +295,7 @@ long dbli(const char *pattern)
     return 0;
 }
 
-long dbgrep(const char *pmask,const char *fields)
+long dbglob(const char *pmask,const char *fields)
 {
     DBENTRY dbentry;
     DBENTRY *pdbentry = &dbentry;
@@ -305,7 +305,7 @@ long dbgrep(const char *pmask,const char *fields)
     char **papfields = 0;
 
     if (!pmask || !*pmask) {
-        printf("Usage: dbgrep \"pattern\" \"fields\"\n");
+        printf("Usage: dbglob \"pattern\" \"fields\"\n");
         return 1;
     }
 
@@ -340,7 +340,11 @@ long dbgrep(const char *pmask,const char *fields)
     dbFinishEntry(pdbentry);
     return 0;
 }
-
+
+long dbgrep(const char *pname, const char *fields) {
+    return dbglob(pname, fields);
+}
+
 long dbgf(const char *pname)
 {
     /* declare buffer long just to ensure correct alignment */

--- a/modules/database/src/ioc/db/dbTest.h
+++ b/modules/database/src/ioc/db/dbTest.h
@@ -28,10 +28,10 @@ DBCORE_API long dbnr(int verbose);
 DBCORE_API long dbla(const char *pmask);
 /* list infos */
 DBCORE_API long dbli(const char *patern);
-/*list records with mask*/
-DBCORE_API long dbglob(const char *pmask,const char *fields);
-/*list records with mask; alias for dbglob*/
-DBCORE_API long dbgrep(const char *pmask,const char *fields);
+/*list records filtered by glob pattern*/
+DBCORE_API long dbglob(const char *ppattern,const char *fields);
+/*list records filtered by glob pattern; alias for dbglob*/
+DBCORE_API long dbgrep(const char *ppatern,const char *fields);
 /*get field value*/
 DBCORE_API long dbgf(const char *pname);
 /*put field value*/

--- a/modules/database/src/ioc/db/dbTest.h
+++ b/modules/database/src/ioc/db/dbTest.h
@@ -29,6 +29,8 @@ DBCORE_API long dbla(const char *pmask);
 /* list infos */
 DBCORE_API long dbli(const char *patern);
 /*list records with mask*/
+DBCORE_API long dbglob(const char *pmask,const char *fields);
+/*list records with mask; alias for dbglob*/
 DBCORE_API long dbgrep(const char *pmask,const char *fields);
 /*get field value*/
 DBCORE_API long dbgf(const char *pname);


### PR DESCRIPTION
Possible future plan to make dbgrep actually use regular expressions.