### PR TITLE
fix epicsStrtod for 32 bit architectures

### DIFF
--- a/modules/libcom/src/misc/epicsStdlib.c
+++ b/modules/libcom/src/misc/epicsStdlib.c
@@ -362,9 +362,9 @@ epicsStrtod(const char *str, char **endp)
 
     if (epicsStrnCaseCmp("0x", cp, 2) == 0) {
         if (negative)
-            return strtol(str, endp, 16);
+            return strtoll(str, endp, 16);
         else
-            return strtoul(str, endp, 16);
+            return strtoull(str, endp, 16);
     }
     if (!isalpha((int)*cp)) {
         res = strtod(str, endp);


### PR DESCRIPTION
On 64 bit architectures, double values could be parsed as  64 bit hex integers (with possible precision loss) but on 32 bit architectures only 32 bit hex values worked. Allow 64 bit hex values on 32 bit architectures too.