### PR TITLE
caget: convert INT to SHORT in dbr type.

### DIFF
--- a/modules/ca/src/tools/caget.c
+++ b/modules/ca/src/tools/caget.c
@@ -417,12 +417,24 @@ int main (int argc, char *argv[])
                                 /* Argument (type) may be text or number */
             if (sscanf(optarg, "%d", &type) != 1)
             {
-                dbr_text_to_type(optarg, type);
+                const char *typeStr = optarg;
+                size_t len = strlen(typeStr);
+                char intToShortStr[30];
+                if (len >= 3 && len < (sizeof intToShortStr) - 2)                /* There's room to replace INT with SHORT (2 extra chars) */
+                {
+                    if (strcmp(typeStr + len - 3, "INT") == 0)                /* Replace INT with SHORT */
+                    {
+                        strcpy(intToShortStr, typeStr);
+                        strcpy(intToShortStr + len - 3, "SHORT");
+                        typeStr = intToShortStr;
+                    }
+                }
+                dbr_text_to_type(typeStr, type);
                 if (type == -1)                   /* Invalid? Try prefix DBR_ */
                 {
-                    char str[30] = "DBR_";
-                    strncat(str, optarg, 25);
-                    dbr_text_to_type(str, type);
+                    char dbrStr[30] = "DBR_";
+                    strncat(dbrStr, typeStr, 25);
+                    dbr_text_to_type(dbrStr, type);
                 }
             }
             if (type < DBR_STRING       || type > DBR_CLASS_NAME


### PR DESCRIPTION
This makes the interface consistent with the caget help message, which documents DBR*_INT types as separate items, though they are equivalent to SHORT types.

The INT to SHORT replacement happens before any calls to dbr_text_to_type, because it's impossible for a type ending in "INT" to be parsed successfully by dbr_text_to_type. And the longest DBR type name is shorter than 20 chars, so 30 chars is definitely a safe bet for temporary buffers (and matches the size used elsewhere in the function).

We rename the 'str' buffer to 'dbrStr' to help with disambiguation.

---

I considered updating the help message, but that was much more manual work to align properly >:)