### PR TITLE
Always search Homebrew and MacPorts directories

### DIFF
--- a/configure/os/CONFIG_SITE.darwinCommon.darwinCommon
+++ b/configure/os/CONFIG_SITE.darwinCommon.darwinCommon
@@ -6,24 +6,17 @@
 # These settings are designed for users of Homebrew.
 # Users of other third-party package managers are welcome to
 # provide patches appropriate for their manager.
-ifneq (,$(wildcard /opt/homebrew))
-  # Default location on aarch64
-  HOMEBREW_DIR = /opt/homebrew
-else ifneq (,$(wildcard /usr/local/Homebrew))
-  # Default location on x86_64
-  HOMEBREW_DIR = /usr/local
-else ifneq (,$(wildcard /opt/local/include/readline))
-  # MacPorts
-  READLINE_DIR = /opt/local
-endif
+HOMEBREW_DIR := $(shell brew --prefix 2>/dev/null)
+INCLUDES += $(HOMEBREW_DIR:%=-I%/include)
+LDFLAGS += $(HOMEBREW_DIR:%=-L%/lib)
 
 # Look for Homebrew's readline
 ifneq (,$(wildcard $(HOMEBREW_DIR)/opt/readline))
-  READLINE_DIR = $(HOMEBREW_DIR)/opt/readline
+  INCLUDES_READLINE += -I$(HOMEBREW_DIR)/opt/readline/include
+  LDFLAGS_READLINE += -L$(HOMEBREW_DIR)/opt/readline/lib
 endif
 
-# Use GNU readline if it's avaiilable
-ifneq (,$(wildcard $(READLINE_DIR)/include/readline/readline.h))
-  INCLUDES_READLINE = -I$(READLINE_DIR)/include
-  LDFLAGS_READLINE = -L$(READLINE_DIR)/lib
-endif
+# Look for MacPorts
+MACPORT_DIR := $(patsubst %/bin/port,%,$(shell which port))
+INCLUDES += $(MACPORT_DIR:%=-I%/include)
+LDFLAGS += $(MACPORT_DIR:%=-L%/lib)


### PR DESCRIPTION
This allows other modules like pvxs to find files there, too. Still, readline is recogized correctly.