### PR TITLE
Fix use-after-free issue on array filters

### DIFF
--- a/modules/database/src/std/filters/arr.c
+++ b/modules/database/src/std/filters/arr.c
@@ -28,6 +28,8 @@ typedef struct myStruct {
     epicsInt32 end;
     void *arrayFreeList;
     long no_elements;
+    long refCount;
+    unsigned int markToDestroy;
 } myStruct;
 
 static void *myStructFreeList;
@@ -48,6 +50,8 @@ static void * allocPvt(void)
     my->start = 0;
     my->incr = 1;
     my->end = -1;
+    my->refCount = 1;
+    my->markToDestroy = 0;
     return (void *) my;
 }
 
@@ -55,8 +59,15 @@ static void freePvt(void *pvt)
 {
     myStruct *my = (myStruct*) pvt;
 
-    if (my->arrayFreeList) freeListCleanup(my->arrayFreeList);
-    freeListFree(myStructFreeList, pvt);
+    my->refCount--;
+    if (my->refCount > 0) {
+        my->markToDestroy++;
+        return;
+    }
+    if (my->refCount <= 0 ) {
+        if (my->arrayFreeList) freeListCleanup(my->arrayFreeList);
+        freeListFree(myStructFreeList, pvt);
+    }
 }
 
 static int parse_ok(void *pvt)
@@ -69,8 +80,14 @@ static int parse_ok(void *pvt)
 
 static void freeArray(db_field_log *pfl)
 {
+    myStruct *my = (myStruct *)pfl->u.r.pvt;
+
     if (pfl->type == dbfl_type_ref) {
-        freeListFree(pfl->u.r.pvt, pfl->u.r.field);
+        freeListFree(my->arrayFreeList, pfl->u.r.field);
+        my->refCount--;
+    }
+    if (my->refCount <= 0 && my->markToDestroy){
+        freePvt(my);
     }
 }
 
@@ -126,7 +143,8 @@ static db_field_log* filter(void* pvt, dbChannel *chan, db_field_log *pfl)
             if (pfl->dtor) pfl->dtor(pfl);
             pfl->u.r.field = pTarget;
             pfl->dtor = freeArray;
-            pfl->u.r.pvt = my->arrayFreeList;
+            pfl->u.r.pvt = my;
+            my->refCount++;
         }
         /* adjust no_elements (even if zero elements remain) */
         pfl->no_elements = nTarget;


### PR DESCRIPTION
This is a long issue we have are having with some complex IOCs at ESS. We have a code to reproduce it, from @simon-ess, https://gitlab.esss.lu.se/icshwi/pva-datarace-test. This reproduce with QSRV as PVA backend but we could not reproduce wtih QSRV2. Still IMO the bogus code is on the array filter as freePvt can be called even if there are still array references on the event queue.

---
This patch fix a use-after-free bug in the array filter that happens when the filter's private struct (`pvt`) is freed while there are still pending events referencing it. Specifically, this leads to the destruction of the `arrayFreeList` and its mutex, which is later accessed during field log cleanup.

When the queue thread eventually processes one of these `db_field_log` entries and attempts to free the array via `freeListFree()`, it tries to lock a now-destroyed mutex. This results in `epicsMutexMustLock`
failing with `EINVAL`, triggering an assertion and suspending the queue thread. The error looks like the following:

A call to 'assert(status == epicsMutexLockOK)'
    by thread 'PDB-event' failed in ../freeList/freeListLib.c line 169.
errlog: lost 1 messages
[    0x7f82695e7fb3]errlog: lost 3 messages
[    0x7f82695e10ce]errlog: lost 3 messages
[    0x7f82695cfb9a]errlog: lost 3 messages
[    0x7f826965c6e9]errlog: lost 3 messages
[    0x7f826965cce3]errlog: lost 3 messages
[    0x7f82695e2315]errlog: lost 3 messages
[    0x7f82691f7a92]errlog: lost 3 messages
[    0x7f82692797d0]errlog: lost 3 messages
EPICS Release EPICS R7.0.8.1-E3-7.0.8.1-patch.
Local time is 2025-03-20 08:53:04.260698231 CET
errlog: lost 2 messages
Thread PDB-event (0x558fad15ca90) suspended
callbackRequest: ERROR cbLow ring buffer full

To reproduce this data race for PVA was used a simple python script to rapidly open and close monitor on array PVs with a random filter. The same script cannot reproduce this on PVXS.

The fix is using a simple reference counter to ensure the pvt struct is never destroyed if there are still references for arrays on the arrayFreeList.