### PR TITLE
fix: stdint.h is not available before vw6.9

### DIFF
--- a/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
+++ b/modules/database/src/ioc/misc/registerAllRecordDeviceDrivers.cpp
@@ -9,7 +9,14 @@
 #include <set>
 #include <map>
 
+#if defined(vxWorks) && \
+      (_WRS_VXWORKS_MAJOR+0 <= 6) && (_WRS_VXWORKS_MINOR+0 < 9)
+typedef int intptr_t;
+typedef unsigned int uintptr_t;
+#else
 #include <stdint.h>
+#endif
+
 #include <string.h>
 
 #define EPICS_PRIVATE_API


### PR DESCRIPTION
commit 3dae29b7e8f9bb48c0359edf9996014754e223cb causes error on VxWorks 6.8
```
/cont/VxWorks/vw68/gnu/4.1.2-vxworks-6.8/x86-linux2/bin/ccppc           -DUSE_TYPED_RSET -DUSE_TYPED_DSET  -DCPU=PPC32  -DvxWorks=vxWorks -include /cont/VxWorks/vw68/vxworks-6.8/target/h/vxWorks.h  -DBUILDING_dbCore_API   -O2   -Wall      -mstrict-align -mlongcall    -fno-builtin   -I. -I../O.Common -I. -I. -I.. -I../as -I../bpt -I../db -I../dbStatic -I../dbtemplate -I../misc -I../registry -I../rsrv -I../../../../../include/compiler/gcc -I../../../../../include/os/vxWorks -I../../../../../include        -I/cont/VxWorks/vw68/vxworks-6.8/target/h -I/cont/VxWorks/vw68/vxworks-6.8/target/h/wrn/coreip -c ../misc/registerAllRecordDeviceDrivers.cpp
../misc/registerAllRecordDeviceDrivers.cpp:12:20: error: stdint.h: No such file or directory
../misc/registerAllRecordDeviceDrivers.cpp: In member function 'bool<unnamed>::compareLoc::operator()(const recordTypeLocation&, const recordTypeLocation&) const':
../misc/registerAllRecordDeviceDrivers.cpp:40: error: expected type-specifier before 'uintptr_t'
../misc/registerAllRecordDeviceDrivers.cpp:40: error: expected `>' before 'uintptr_t'
../misc/registerAllRecordDeviceDrivers.cpp:40: error: expected `(' before 'uintptr_t'
../misc/registerAllRecordDeviceDrivers.cpp:40: error: 'uintptr_t' was not declared in this scope
../misc/registerAllRecordDeviceDrivers.cpp:41: error: expected type-specifier before 'uintptr_t'
../misc/registerAllRecordDeviceDrivers.cpp:41: error: expected `>' before 'uintptr_t'
../misc/registerAllRecordDeviceDrivers.cpp:41: error: expected `(' before 'uintptr_t'
../misc/registerAllRecordDeviceDrivers.cpp:41: error: expected `)' before ';' token
../misc/registerAllRecordDeviceDrivers.cpp:41: error: expected `)' before ';' token
make[5]: *** [registerAllRecordDeviceDrivers.o] Error 1
```

`stdint.h` is not available before vw6.9
```
$ ls /cont/VxWorks/vw68/vxworks-6.8/target/h/std*
/cont/VxWorks/vw68/vxworks-6.8/target/h/stdio.h     /cont/VxWorks/vw68/vxworks-6.8/target/h/stdlib.h
/cont/VxWorks/vw68/vxworks-6.8/target/h/stdioLib.h

$ ls /cont/VxWorks/vw69/vxworks-6.9/target/h/std*
/cont/VxWorks/vw69/vxworks-6.9/target/h/stdint.h  /cont/VxWorks/vw69/vxworks-6.9/target/h/stdioLib.h
/cont/VxWorks/vw69/vxworks-6.9/target/h/stdio.h   /cont/VxWorks/vw69/vxworks-6.9/target/h/stdlib.h
```