### PR TITLE
osiClockTime for RTOS only

### DIFF
--- a/modules/database/test/std/rec/dbHeaderTest.c
+++ b/modules/database/test/std/rec/dbHeaderTest.c
@@ -178,7 +178,6 @@
 #include <menuSimm.h>
 #include <menuYesNo.h>
 #include <miscIocRegister.h>
-#include <osiClockTime.h>
 #include <osiPoolStatus.h>
 #include <osiProcess.h>
 #include <osiSock.h>

--- a/modules/libcom/src/osi/Makefile
+++ b/modules/libcom/src/osi/Makefile
@@ -38,7 +38,6 @@ INC += epicsTime.h
 INC += epicsGeneralTime.h
 INC += osdTime.h
 INC += generalTimeSup.h
-INC += osiClockTime.h
 INC += epicsSignal.h
 INC += osiProcess.h
 INC += osiUnistd.h
@@ -80,9 +79,8 @@ Com_SRCS += epicsAtomicOSD.cpp
 Com_SRCS += epicsGeneralTime.c
 
 # Time providers
-Com_SRCS += osiClockTime.c
-Com_SRCS_vxWorks += osiNTPTime.c tz2timezone.c
-Com_SRCS_RTEMS += osiNTPTime.c
+Com_SRCS_vxWorks += osiClockTime.c osiNTPTime.c tz2timezone.c
+Com_SRCS_RTEMS += osiClockTime.c osiNTPTime.c
 
 ifeq ($(OS_CLASS),vxWorks)
 osdTime.o: USR_CXXFLAGS += -DBUILD_TIME=$(shell perl -e 'print time')

--- a/modules/libcom/src/osi/os/posix/osdTime.cpp
+++ b/modules/libcom/src/osi/os/posix/osdTime.cpp
@@ -13,6 +13,8 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+#include <unistd.h>
+#include <sys/stat.h>
 
 #define EPICS_EXPOSE_LIBCOM_MONOTONIC_PRIVATE
 #include "osiSock.h"
@@ -20,8 +22,55 @@
 #include "cantProceed.h"
 #include "epicsTime.h"
 #include "generalTimeSup.h"
+#include "errlog.h"
 
-#ifdef CLOCK_REALTIME
+#if defined(__linux__)
+
+#define TIME_INIT generalTimeCurrentTpRegister("GetTimeOfDay", \
+    LAST_RESORT_PRIORITY, osdTimeGetCurrent)
+
+extern "C"
+int osdTimeGetCurrent(epicsTimeStamp *pDest)
+{
+    struct timespec clockNow;
+    if(clock_gettime(CLOCK_REALTIME, &clockNow)) {
+        static unsigned char shown;
+        if(!shown) {
+            // likely an unrecoverable situation, but at least don't just flood the log
+            fprintf(stderr, ERL_ERROR ": CLOCK_REALTIME not available.  %d\n", errno);
+            shown = 1;
+        }
+    }
+    if(clockNow.tv_sec < POSIX_TIME_AT_EPICS_EPOCH) {
+        clockNow.tv_sec = POSIX_TIME_AT_EPICS_EPOCH + 86400;
+        clockNow.tv_nsec = 0;
+    }
+    epicsTimeFromTimespec(pDest, &clockNow);
+    return 0;
+}
+
+extern "C"
+void ClockTime_GetProgramStart(epicsTimeStamp *pDest)
+{
+    static epicsTimeStamp startTime;
+
+    if(startTime.secPastEpoch==0) {
+        pid_t self = getpid();
+        char procdir[sizeof("/proc/18446744073709551615")]; // 1<<64 - 1
+
+        sprintf(procdir, "/proc/%llu", (unsigned long long)self);
+
+        struct stat out;
+        if(::stat(procdir, &out)==0 && out.st_ctim.tv_sec > POSIX_TIME_AT_EPICS_EPOCH) {
+            startTime.nsec = out.st_ctim.tv_nsec;
+            startTime.secPastEpoch = out.st_ctim.tv_sec - POSIX_TIME_AT_EPICS_EPOCH;
+        }
+    }
+
+    *pDest = startTime;
+}
+
+#elif defined(CLOCK_REALTIME)
     #include "osiClockTime.h"
 
     #define TIME_INIT ClockTime_Init(CLOCKTIME_NOSYNC)

--- a/modules/libcom/src/osi/osiClockTime.c
+++ b/modules/libcom/src/osi/osiClockTime.c
@@ -22,6 +22,11 @@
 #include "osiClockTime.h"
 #include "taskwd.h"
 
+#if defined(vxWorks) || defined(__rtems__)
+#else
+#  error Unsupported OS
+#endif
+
 #define NSEC_PER_SEC 1000000000
 #define ClockTimeSyncInterval_initial 1.0
 #define ClockTimeSyncInterval_normal 60.0
@@ -41,7 +46,7 @@ static struct {
 static epicsThreadOnceId onceId = EPICS_THREAD_ONCE_INIT;
 
 
-#if defined(CLOCK_REALTIME) && !defined(_WIN32) && !defined(__APPLE__)
+#if defined(CLOCK_REALTIME)
 /* This code is not used on systems without Posix CLOCK_REALTIME,
  * but the only way to detect that is from the OS headers, so the
  * Makefile can't exclude compiling this file on those systems.
@@ -51,7 +56,6 @@ static epicsThreadOnceId onceId = EPICS_THREAD_ONCE_INIT;
 
 int osdTimeGetCurrent(epicsTimeStamp *pDest);
 
-#if defined(vxWorks) || defined(__rtems__)
 static void ClockTimeSync(void *dummy);
 
 /* ClockTime_Init iocsh command */
@@ -74,7 +78,6 @@ static void ShutdownCallFunc(const iocshArgBuf *args)
 {
     ClockTime_Shutdown(NULL);
 }
-#endif
 
 /* ClockTime_Report iocsh command */
 static const iocshArg ReportArg0 = { "interest_level", iocshArgArgv};
@@ -106,10 +109,8 @@ static void ClockTime_InitOnce(void *pfirst)
     epicsAtExit(ClockTime_Shutdown, NULL);
 
     /* Register the iocsh commands */
-#if defined(vxWorks) || defined(__rtems__)
     iocshRegister(&InitFuncDef, InitCallFunc);
     iocshRegister(&ShutdownFuncDef, ShutdownCallFunc);
-#endif
     iocshRegister(&ReportFuncDef, ReportCallFunc);
 
     /* Register as a time provider */
@@ -126,7 +127,6 @@ void ClockTime_Init(int synchronize)
     if (synchronize) {
         if (ClockTimePvt.synchronize == CLOCKTIME_NOSYNC) {
 
-#if defined(vxWorks) || defined(__rtems__)
             /* Start synchronizing */
             ClockTimePvt.synchronize = CLOCKTIME_SYNC;
             ClockTimePvt.ClockTimeSyncInterval = ClockTimeSyncInterval_initial;
@@ -135,9 +135,6 @@ void ClockTime_Init(int synchronize)
             epicsThreadCreate("ClockTimeSync", epicsThreadPriorityHigh,
                 epicsThreadGetStackSize(epicsThreadStackSmall),
                 ClockTimeSync, NULL);
-#else
-            errlogPrintf("Clock synchronization must be performed by the OS\n");
-#endif
 
         }
         else {
@@ -174,7 +171,6 @@ void ClockTime_GetProgramStart(epicsTimeStamp *pDest)
 
 /* Synchronization thread */
 
-#if defined(vxWorks) || defined(__rtems__)
 CLOCKTIME_SYNCHOOK ClockTime_syncHook = NULL;
 
 static void ClockTimeSync(void *dummy)
@@ -220,7 +216,6 @@ static void ClockTimeSync(void *dummy)
         ClockTime_syncHook(0);
     taskwdRemove(0);
 }
-#endif
 
 
 /* Time Provider Routine */
@@ -236,14 +231,9 @@ int osdTimeGetCurrent(epicsTimeStamp *pDest)
         clockNow.tv_sec = POSIX_TIME_AT_EPICS_EPOCH + 86400;
         clockNow.tv_nsec = 0;
 
-#if defined(vxWorks) || defined(__rtems__)
         clock_settime(CLOCK_REALTIME, &clockNow);
         errlogPrintf("WARNING: OS Clock time was read before being set.\n"
             "Using 1990-01-02 00:00:00.000000 UTC\n");
-#else
-        errlogPrintf("WARNING: OS Clock pre-dates the EPICS epoch!\n"
-            "Using 1990-01-02 00:00:00.000000 UTC\n");
-#endif
     }
 
     epicsTimeFromTimespec(pDest, &clockNow);

--- a/modules/libcom/src/osi/osiClockTime.c
+++ b/modules/libcom/src/osi/osiClockTime.c
@@ -229,11 +229,6 @@ int osdTimeGetCurrent(epicsTimeStamp *pDest)
 {
     struct timespec clockNow;
 
-    /* If a Hi-Res clock is available and works, use it */
-    #ifdef CLOCK_REALTIME_HR
-        clock_gettime(CLOCK_REALTIME_HR, &clockNow) &&
-        /* Note: Uses the lo-res clock below if the above call fails */
-    #endif
     clock_gettime(CLOCK_REALTIME, &clockNow);
 
     if (!ClockTimePvt.synchronized &&

--- a/modules/libcom/src/osi/osiClockTime.h
+++ b/modules/libcom/src/osi/osiClockTime.h
@@ -24,6 +24,8 @@ int  ClockTime_Report(int level);
 typedef void (* CLOCKTIME_SYNCHOOK)(int synchronized);
 
 extern CLOCKTIME_SYNCHOOK ClockTime_syncHook;
+#else
+#  error Unsupported OS
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
A possible step towards `fork()` safety (see #211 and #286).  Avoid pulling osiClockTime in for Linux.  Avoids `ClockTime_Init()` from a global ctor, which extensively uses epicsThread.  This still leaves that ctor calling `osdMonotonicInit()`, which does not use `epicsThread`.  So an improvement.

With this PR and #587, the remaining global ctors in libCom would not call `epicsThreadInit()`, which would resolve #286.

```
$ nm lib/linux-x86_64/libCom.a|grep -E '__static_initialization_and_destruction|_GLOBAL__sub'
0000000000000000 t _GLOBAL__sub_I_fdManager.cpp
0000000000000000 t _GLOBAL__sub_I_osdTime.cpp
```

This PR is a Draft as I am not sure I have handled OSX and FreeBSD correctly.  (the `#ifdef` logic in `osiClockTime.c` and `posix/osdTime.cpp` is confusing me)

