### PR TITLE
More colour, better error/warning messages

### DIFF
--- a/configure/CONFIG_SITE_ENV
+++ b/configure/CONFIG_SITE_ENV
@@ -71,7 +71,7 @@ EPICS_TS_NTP_INET=
 #	Number of lines of command history to keep.
 # IOCSH_HISTEDIT_DISABLE
 # 	Prevents use of readline or equivalent if defined.
-IOCSH_PS1="epics> "
+IOCSH_PS1=ANSI_GREEN("epics> ")
 IOCSH_HISTSIZE=50
 IOCSH_HISTEDIT_DISABLE=
 

--- a/documentation/new-notes/PR-644.md
+++ b/documentation/new-notes/PR-644.md
@@ -1,0 +1,29 @@
+### Expand the use of colour in the IOCs output
+
+This release includes various changes to iocsh.cpp and elsewhere to add and
+expand the use of color:
+
+- When loading a startup script, the IOC Shell now displays comment lines in
+blue, and uses bold to make command lines stand out from other text.
+
+- The `softIoc -v` output also uses the above color scheme for the commands it
+prints.
+
+- The default IOC Shell prompt is now displayed in green; this color can be
+modified in the `configure/CONFIG_SITE_ENV` file for all targets, or set for
+a specific target by adding a `configure/os/CONFIG_SITE_ENV.<arch>` file.
+The value of the `IOCSH_PS1` environment paremeter in those files can use the
+`ANSI_ENV_*` and `ANSI_*()` color macros found in errlog.h to configure the
+appearance of the prompt. The C string literal concatenation syntax can be
+used to construct the prompt string:
+
+    IOCSH_PS1 = ANSI_ESC_RED "e" ANSI_ESC_YELLOW "p" ANSI_ESC_GREEN "i" ANSI_ESC_CYAN "c" ANSI_BLUE("s") "> "
+
+- More error messages printed by IOC Shell commands now appear in red, or use
+the red `ERROR` prefix that was introduced in previous releases.
+
+- The word "Illegal" has been replaced with "Invalid" in several Shell error
+messages.
+
+- The iocsh `var` command now shows the data type of the registered variables
+as well as their values.

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -565,7 +565,7 @@ static void dbRecordtypeFieldHead(char *name,char *type)
             strcmp(pdbFldDes->name, "OUT")==0;
     i = dbFindFieldType(type);
     if (i < 0)
-        yyerrorAbort("Illegal Field Type");
+        yyerrorAbort("Invalid Field Type");
     pdbFldDes->field_type = i;
 }
 
@@ -597,7 +597,7 @@ static void dbRecordtypeFieldItem(char *name,char *value)
         } else if(strcmp(value,"ASL1")==0) {
             pdbFldDes->as_level = ASL1;
         } else {
-            yyerror("Illegal Access Security value: Must be ASL0 or ASL1");
+            yyerror("Invalid 'asl' value, must be ASL0 or ASL1");
         }
         return;
     }
@@ -624,7 +624,7 @@ static void dbRecordtypeFieldItem(char *name,char *value)
         if(sscanf(value,"%hd",&pdbFldDes->special)==1) {
             return;
         }
-        yyerror("Illegal 'special' value.");
+        yyerror("Invalid 'special' value.");
         return;
     }
     if(strcmp(name,"pp")==0) {
@@ -633,13 +633,13 @@ static void dbRecordtypeFieldItem(char *name,char *value)
         } else if((strcmp(value,"NO")==0) || (strcmp(value,"FALSE")==0)) {
             pdbFldDes->process_passive = FALSE;
         } else {
-            yyerror("Illegal 'pp' value, must be YES/NO/TRUE/FALSE");
+            yyerror("Invalid 'pp' value, must be YES/NO/TRUE/FALSE");
         }
         return;
     }
     if(strcmp(name,"interest")==0) {
         if(sscanf(value,"%hd",&pdbFldDes->interest)!=1)
-            yyerror("Illegal 'interest' value, must be integer");
+            yyerror("Invalid 'interest' value, must be integer");
         return;
     }
     if(strcmp(name,"base")==0) {
@@ -648,13 +648,13 @@ static void dbRecordtypeFieldItem(char *name,char *value)
         } else if(strcmp(value,"HEX")==0) {
             pdbFldDes->base = CT_HEX;
         } else {
-            yyerror("Illegal 'base' value, must be DECIMAL/HEX");
+            yyerror("Invalid 'base' value, must be DECIMAL/HEX");
         }
         return;
     }
     if(strcmp(name,"size")==0) {
         if(sscanf(value,"%hd",&pdbFldDes->size)!=1)
-            yyerror("Illegal 'size' value, must be integer");
+            yyerror("Invalid 'size' value, must be integer");
         return;
     }
     if(strcmp(name,"extra")==0) {

--- a/modules/database/src/std/softIoc/softMain.cpp
+++ b/modules/database/src/std/softIoc/softMain.cpp
@@ -172,7 +172,6 @@ int main(int argc, char *argv[])
                 epicsExit(2);
                 return 2;
             case 'a':
-                lazy_dbd(dbd_file);
                 if (!macros.empty()) {
                     verbose_out(CMD, std::string("asSetSubstitutions(\"")
                         + macros + "\")");

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -1166,7 +1166,7 @@ iocshBody (const char *pathname, const char *commandLine, const char *macros)
         if (c == '#') {
             if ((prompt == NULL) && (commandLine == NULL))
                 if (raw[icin + 1] != '-') {
-                    printf(ANSI_CYAN("%s") "\n", raw);
+                    printf(ANSI_BLUE("%s") "\n", raw);
                 }
             continue;
         }

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -931,8 +931,8 @@ static void helpCallFunc(const iocshArgBuf *args)
         iocshTableUnlock ();
 
         fprintf(epicsGetStdout(), "\n"
-            "Type 'help <command>' to see the arguments of <command>, "
-            "eg. 'help db*'\n");
+            "Type 'help <glob>' for information about commands matching\n"
+            "the name or pattern <glob>, e.g. 'help db*'\n");
     }
     else {
         bool firstFunction = true;

--- a/modules/libcom/test/iocshTestHelpFunction1
+++ b/modules/libcom/test/iocshTestHelpFunction1
@@ -1,4 +1,4 @@
-[1m
-testHelpFunction1[0m
+
+[1mtestHelpFunction1[0m
 
 Usage message of testHelpFunction1

--- a/modules/libcom/test/iocshTestHelpFunctions
+++ b/modules/libcom/test/iocshTestHelpFunctions
@@ -1,14 +1,14 @@
-[1m
-testHelpFunction1[0m
+
+[1mtestHelpFunction1[0m
 
 Usage message of testHelpFunction1
-[4m                                                            
-[0m[1m
-testHelpFunction2[0m
+[4m                                                            [0m
+
+[1mtestHelpFunction2[0m
 
 Usage message of testHelpFunction2
-[4m                                                            
-[0m[1m
-testHelpFunction3[0m
+[4m                                                            [0m
+
+[1mtestHelpFunction3[0m
 
 Usage message of testHelpFunction3


### PR DESCRIPTION
Various changes to iocsh.cpp and others to add and improve the use of color.

- The IOC Shell output when running a startup script now displays comment lines in Cyan,
and Bold for command lines.
- The `softIoc -v` output also uses the same color scheme for the commands it shows.
- The default IOC Shell prompt is now green, but the choice of color can be edited in the
`configure/CONFIG_SITE_ENV` file – the default `ENV_PARAM` values can use the `ANSI_*()`
macros to select the text color.
- More error messages printed by the shell appear in Red, or use the red `ERROR` prefix.
- The word "Illegal" has been replaced with "Invalid" in several iocsh error messages.
- The iocsh `var` command now shows the data type of the registered variable.

![image](https://github.com/user-attachments/assets/d6a0b3a2-aa33-4ddd-8e1c-67a1794b4d75)
