### PR TITLE
Fix failing windows conda builds

### DIFF
--- a/configure/RULES_MODULES
+++ b/configure/RULES_MODULES
@@ -41,7 +41,7 @@ RELEASE.host: $(RELEASE_LOCAL)
 
 $(RELEASE_LOCAL): Makefile $(CONFIG)/CONFIG_SITE \
     $(wildcard $(CONFIG)/CONFIG_SITE.local)
-	$(ECHO) Creating $@ with
+	$(ECHO) "Creating $@ with"
 	$(ECHO) "    $(PARENT_MODULE) = $(INSTALL_ABSOLUTE)"
 	@echo $(PARENT_MODULE) = $(INSTALL_ABSOLUTE)> $@
 


### PR DESCRIPTION
Certain windows build environments (see
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1234387&view=results for an example) fail unless the echo command is properly quoted. This seems to be due to how Make handles various commands on non-posix systems; without the quotes it directly tries to run
```
echo foo bar
```
inside cmd.exe, which fails as echo is not a valid command in that context.