### PR TITLE
RTEMS: Exclude BSD and legacy networking components from GeSys objects

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS
+++ b/configure/os/CONFIG.Common.RTEMS
@@ -165,7 +165,8 @@ MOD_SYS_LDFLAGS += $(CPU_CFLAGS) -Wl,-r -nostdlib
 GESYS_LIBS += -lgcc
 GESYS_LIBS += -lc -lm -lrtemscpu -lrtemsbsp -lrtems++
 GESYS_LIBS += -lcexp -ltecla_r -lspencer_regexp -lpmelf -lpmbfd
-GESYS_LIBS += -lnfs -ltelnetd -lrtems-gdb-stub
+GESYS_LIBS += -lnfs -ltelnetd -lrtems-gdb-stub -lbsd -ltftpfs -lz
+GESYS_LIBS += -lnetworking
 
 # While not part of the Generic Image it provides symbols which
 # would conflict.


### PR DESCRIPTION
Exclude some additional RTEMS components from GeSys objects.

While GeSys and Cexpsh do not (currently) support RTEMS 5+, GeSys-style objects are still useful with the RTEMS runtime linker.