### PR TITLE
Fix compile error on RTEMS-uC5282 w/RTEMS 6

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS-uC5282
+++ b/configure/os/CONFIG.Common.RTEMS-uC5282
@@ -13,6 +13,12 @@ ARCH_DEP_CFLAGS += -DMY_DO_BOOTP=NULL
 ARCH_DEP_CXXFLAGS_5 = -std=c++98
 ARCH_DEP_CXXFLAGS += $(ARCH_DEP_CXXFLAGS_$(RTEMS_VERSION))
 
+# Workaround for bug in newlib (seen with RTEMS 6 GCC toolchain). _LDBL_EQ_DBL is defined by newlib.h,
+# but is determined at newlib configure time. The default -mcpu setting for m68k-rtems6-gcc supports long double,
+# so the define is excluded from newlib.h. Coldfire ISAs do not support long double, so this needs to be defined.
+# See: https://sourceware.org/bugzilla/show_bug.cgi?id=33750
+ARCH_DEP_CPPFLAGS += -D_LDBL_EQ_DBL=1
+
 MUNCH_SUFFIX = .boot
 define MUNCH_CMD
 	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $@


### PR DESCRIPTION
This is a hacky workaround for an issue in newlib. _LDBL_EQ_DBL is normally defined by newlib.h, but its value is determined at configure time. The default -mcpu setting for m68k-rtems6-gcc supports long double (where sizeof long dobule == 12), while the Coldfire ISAs do not (sizeof long double == 8). Since newlib.h is shared for all m68k targets, this breaks some targets w/o long double support.

So, when building with -mcpu=5282, for example, _LDBL_EQ_DBL is not defined when it should be. ieefp.h has a sanity check that fails in this case, meanwhile libstdc++ completely explodes.

I'm kind of surprised this hasn't been an issue with other targets supported by GCC...