### PR TITLE
Silence some error log messages during test runs

### DIFF
--- a/modules/database/test/std/rec/analogMonitorTest.c
+++ b/modules/database/test/std/rec/analogMonitorTest.c
@@ -24,6 +24,7 @@
 #include "chfPlugin.h"
 #include "iocInit.h"
 #include "testMain.h"
+#include "errlog.h"
 #include "epicsExport.h"
 
 /* Test parameters */
@@ -168,7 +169,9 @@ MAIN(analogMonitorTest)
         testAbort("Error reading test database 'analogMonitorTest.db'");
 
     /* Start the core IOC (no CA) */
+    eltc(0);
     iocBuildIsolated();
+    eltc(1);
 
     evtctx = db_init_events();
     chfPluginRegister(test, &pif, NULL);

--- a/modules/database/test/std/rec/asyncproctest.c
+++ b/modules/database/test/std/rec/asyncproctest.c
@@ -54,7 +54,9 @@ MAIN(asyncproctest)
 
     dbAccessDebugPUTF = 1;
 
+    eltc(0);
     testIocInitOk();
+    eltc(1);
     testDiag("===== Chain 1 ======");
 
     waitFor = 2;

--- a/modules/database/test/std/rec/epicsExportTestMain.c
+++ b/modules/database/test/std/rec/epicsExportTestMain.c
@@ -12,6 +12,7 @@
 #include <epicsUnitTest.h>
 #include <dbUnitTest.h>
 #include <testMain.h>
+#include <errlog.h>
 #include <dbAccess.h>
 #include <iocsh.h>
 #include <epicsExport.h>
@@ -51,7 +52,9 @@ MAIN(epicsExportTest)
 
     testDiag("Testing if dsets and functions are found");
     testdbReadDatabase("epicsExportTest.db", 0, 0);
+    eltc(0);
     testIocInitOk();
+    eltc(1);
 
     testDiag("Testing if dsets work correctly");
     testdbGetFieldEqual("li1", DBF_LONG, -1);

--- a/modules/database/test/std/rec/scanEventTest.c
+++ b/modules/database/test/std/rec/scanEventTest.c
@@ -14,6 +14,7 @@
 #include "dbAccessDefs.h"
 #include "dbUnitTest.h"
 #include "testMain.h"
+#include "errlog.h"
 #include "osiFileName.h"
 #include "epicsThread.h"
 #include "dbScan.h"
@@ -79,7 +80,9 @@ MAIN(scanEventTest)
         sprintf(substitutions, "N=%d,EVENT=%s", i, events[i].name);
         testdbReadDatabase("scanEventTest.db", NULL, substitutions);
     }
+    eltc(0);
     testIocInitOk();
+    eltc(1);
     testDiag("Test if eventNameToHandle() strips spaces and handles numeric events");
     for (i = 0; i < NELEMENTS(events); i++) {
         EVENTPVT pev = eventNameToHandle(events[i].name);

--- a/modules/database/test/std/rec/subproctest.c
+++ b/modules/database/test/std/rec/subproctest.c
@@ -10,6 +10,7 @@
  */
 
 #include <testMain.h>
+#include "errlog.h"
 #include <dbUnitTest.h>
 #include <dbAccess.h>
 #include <iocsh.h>
@@ -36,7 +37,9 @@ MAIN(subproctest)
     registryFunctionAdd("subproc", (REGISTRYFUNCTION) subproc);
     testdbReadDatabase("subproctest.db", NULL, "TPRO=0");
 
+    eltc(0);
     testIocInitOk();
+    eltc(1);
     testDiag("===== Test that invalid link in INPA field fails a put request ======");
 
     testdbPutFieldFail(-1, "InvalidINPARec.PROC", DBF_LONG, 1);


### PR DESCRIPTION
Several of the record tests do not silence output correctly, yielding e.g.
```
epicsExportTest.t ....... 1/31 Starting iocInit
iocRun: All initialization complete
```
instead of (e.g.)
```
simmTest.t .............. ok         
mbbioDirectTest.t ....... ok       
asyncproctest.t ......... ok     
subproctest.t ........... ok   
linkFilterTest.t ........ ok
```