### PR TITLE
Record reference updates

### DIFF
--- a/documentation/new-notes/PR-651.md
+++ b/documentation/new-notes/PR-651.md
@@ -1,0 +1,12 @@
+### Documentation Updates
+
+The reference documentation for the [event](eventRecord.html) record type
+has been updated to cover the use of named events which were added in Base
+3.14.12.3 and 3.15.1.
+
+Documentation for CALC expression evaluation has been updated for format
+enhancements and to add some missing operators.
+The best documentation for these expressions can be found in the
+[postfix.h](postfix_h.html) header in libCom, but both the
+[calc](calcRecord.html) and [calcout](calcoutRecord.html) record reference
+pages also cover the infix expressions supported.

--- a/modules/database/src/std/ComponentReference.pod
+++ b/modules/database/src/std/ComponentReference.pod
@@ -14,9 +14,9 @@ documentation is now being published.
 
 =over
 
-=item * L<Introduction to EPICS|https://docs.epics-controls.org/en/latest/guides/EPICS_Intro.html>
+=item * L<Introduction to EPICS|https://docs.epics-controls.org/en/latest/getting-started/EPICS_Intro.html>
 
-=item * L<Process Database Concepts|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html>
+=item * L<Process Database Concepts|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html>
 
 =back
 

--- a/modules/database/src/std/rec/aaoRecord.dbd.pod
+++ b/modules/database/src/std/rec/aaoRecord.dbd.pod
@@ -45,7 +45,7 @@ its output. It can be a hardware address, a channel access or database link, or
 a constant. Only in records that use soft device support can the OUT field be a
 channel access link, a database link, or a constant. Otherwise, the OUT field
 must be a hardware address. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of hardware addresses and database links.
 
 =head4 Fields related to array writing

--- a/modules/database/src/std/rec/aiRecord.dbd.pod
+++ b/modules/database/src/std/rec/aiRecord.dbd.pod
@@ -46,7 +46,7 @@ input data should come from.
 The format for the INP field value depends on the device support layer that is
 selected by the DTYP field.
 See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for a description of the various hardware address formats supported.
 
 =head3 Units Conversion
@@ -212,7 +212,7 @@ positive number of seconds will delay the record going into or out of a minor
 alarm severity or from minor to major severity until the input signal has been
 in the alarm range for that number of seconds.
 
-See L<Alarm Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#alarm-specification>
+See L<Alarm Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#alarm-specification>
 for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.

--- a/modules/database/src/std/rec/aoRecord.dbd.pod
+++ b/modules/database/src/std/rec/aoRecord.dbd.pod
@@ -162,7 +162,7 @@ OUT field. For analog outputs that write their values to devices, the
 OUT field must specify the address of the I/O card. In addition, the
 DTYP field must contain the name of the device support module. Be aware
 that the address format differs according to the I/O bus used. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of hardware addresses.
 
 For soft records the output link can be a database link, a channel

--- a/modules/database/src/std/rec/biRecord.dbd.pod
+++ b/modules/database/src/std/rec/biRecord.dbd.pod
@@ -47,13 +47,13 @@ field contains the address from where device support retrieves the value.
 If the binary input record gets its value from hardware, the address of the
 card must be entered in the INP field, and the name of the device support
 module must be entered in the DTYP field. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of the hardware address.
 
 For records that specify C<Soft Channel> or C<Raw Soft Channel> device
 support routines, the INP field can be a channel or a database link, or a
 constant. If a constant, VAL can be changed directly by dbPuts. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of database and
 channel access addresses. Also, see L<Device Support for Soft Records> in
 this chapter for information on soft device support.
@@ -107,7 +107,7 @@ C<MAJOR>. The ZSV field holds the severity for the zero state; OSV, for
 the one state.  COSV causes an alarm whenever the state changes between
 0 and 1 and the severity is configured as MINOR or MAJOR.
 
-See L<Alarm Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#alarm-specification>
+See L<Alarm Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#alarm-specification>
 for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.

--- a/modules/database/src/std/rec/boRecord.dbd.pod
+++ b/modules/database/src/std/rec/boRecord.dbd.pod
@@ -45,7 +45,7 @@ continuous control, a database link to a control algorithm record should be
 entered in the DOL field.
 
 See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on hardware addresses and links.
 
 =fields DOL, OMSL
@@ -105,13 +105,13 @@ It must specify the address of an I/O card if the record sends its output
 to hardware, and the DTYP field must contain the corresponding device
 support module. Be aware that the address format differs according to the
 I/O bus used. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of hardware addresses.
 
 Otherwise, if the record is configured to use the soft device support modules,
 then it can be either a database link, a channel access link, or a constant. Be
 aware that nothing will be written when OUT is a constant. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of the database and channel access addresses.
 Also, see L<Device Support For Soft Records> in this chapter for more on output
 to other records.

--- a/modules/database/src/std/rec/calcRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcRecord.dbd.pod
@@ -49,31 +49,35 @@ for information on how to specify database links.
 
 =head3 Expression
 
-At the core of the Calc record lies the CALC and RPCL fields. The CALC field
-contains the infix expresion which the record routine will use when it
-processes the record. The resulting value is placed in the VAL field and
-can be accessed from there. The CALC expression is actually converted to
-opcode and stored as Reverse Polish Notation in the RPCL field. It is this
-expression which is actually used to calculate VAL. The Reverse Polish
-expression is evaluated more efficiently during run-time than an infix
-expression. CALC can be changed at run-time, and a special record routine
-calls a function to convert it to Reverse Polish Notation.
+At the core of the Calc record lies the CALC and RPCL fields.
+The CALC field holds an infix expression to be evaluated whenever the record is
+processed.
+The calculated value is placed in the VAL field and can be accessed from there.
+
+The CALC expression gets compiled into a stream of Reverse Polish Notation (RPN)
+opcodes for a stack-based machine, and stored in the RPCL field.
+The RPN opcodes are used to calculate VAL at run-time, and are more efficient
+than evaluating the infix expression.
+The CALC expression can be replaced at run-time, triggering a special record
+routine to compile the new expression into Reverse Polish Notation.
 
 The infix expressions that can be used are very similar to the C expression
-syntax, but with some additions and subtle differences in operator meaning
-and precedence. The string may contain a series of expressions separated by
-a semi-colon character ";" any one of which may actually provide the
-calculation result; however, all of the other expressions included must
-assign their result to a variable. All alphabetic elements described below
-are case independent, so upper and lower case letters may be used and mixed
-in the variable and function names as desired. Spaces may be used anywhere
-within an expression except between characters that make up a single
-expression element.
+syntax, but with some additions and subtle differences in operator meaning and
+precedence.
+The string may contain a series of expressions separated by a semi-colon
+character C<;>, any one of which may provide the calculation result.
+All other expressions included in the string must assign their result to a
+variable.
+All alphabetic elements described below are case independent, so upper and lower
+case letters may be used and mixed in the variable and function names as
+desired.
+Spaces may be used anywhere within an expression except between characters that
+make up a single expression element.
 
-The range of expressions supported by the calculation record are separated
-into literals, constants, operands, algebraic operators, trigonometric operators,
-relational operators, logical operators, the assignment operator,
-parentheses and commas, and the question mark or '?:' operator.
+The range of expressions supported by the calculation record are separated into
+literals, constants, operands, algebraic operators, trigonometric operators,
+relational operators, logical operators, the assignment operator, parentheses
+and commas, and the question mark colon or C<?:> operator.
 
 =fields CALC, RPCL
 
@@ -127,111 +131,204 @@ The keyword VAL returns the current contents of the VAL field (which can be
 written to by a CA put, so it might I<not> be the result from the last time
 the expression was evaluated).
 
-=head3 Algebraic Operators
+=head3 Arithmetic Operators
+
+Except for unary minus these are infix binary operators.
 
 =over 1
 
 =item *
-C<ABS>: Absolute value (unary)
+C<+> : Addition
 
 =item *
-C<SQR>: Square root (unary)
+C<-> : Subtraction
 
 =item *
-C<MIN>: Minimum (any number of args)
+C<-> : Minus (unary)
 
 =item *
-C<MAX>: Maximum (any number of args)
+C<*> : Multiplication
 
 =item *
-C<FINITE>: returns non-zero if none of the arguments are NaN or Inf (any
-number of args)
+C</> : Division
 
 =item *
-C<ISNAN>: returns non-zero if any of the arguments is NaN or Inf (any number
-of args)
+C<%> : Modulo
 
 =item *
-C<CEIL>: Ceiling (unary)
+C<^> : Exponential
 
 =item *
-C<FLOOR>: Floor (unary)
-
-=item *
-C<FMOD>: Floating point modulo (binary)  Added in 7.0.8
-
-=item *
-C<LOG>: Log base 10 (unary)
-
-=item *
-C<LOGE>: Natural log (unary)
-
-=item *
-C<LN>: Natural log (unary)
-
-=item *
-C<EXP>: Exponential function (unary)
-
-=item *
-C<^> : Exponential (binary)
-
-=item *
-C<**> : Exponential (binary)
-
-=item *
-C<+> : Addition (binary)
-
-=item *
-C<-> : Subtraction (binary)
-
-=item *
-C<*> : Multiplication (binary)
-
-=item *
-C</> : Division (binary)
-
-=item *
-C<%> : Modulo (binary)
-
-=item *
-C<NOT>: Negate (unary)
+C<**> : Exponential
 
 =back
 
-=head3 Trigonometric Operators
+=head3 Algebraic Functions
+
+When functions take more than one argument, a comma separator must appear
+between them.
 
 =over 1
 
 =item *
-C<SIN>: Sine
+C<ABS (arg)> : Absolute value
 
 =item *
-C<SINH>: Hyperbolic sine
+C<EXP (arg)> : Exponential function
 
 =item *
-C<ASIN>: Arc sine
+C<FMOD (num, den)> : Floating point modulo. Added in 7.0.8
 
 =item *
-C<COS>: Cosine
+C<LN (arg)> : Natural log
 
 =item *
-C<COSH>: Hyperbolic cosine
+C<LOG (arg)> : Log base 10
 
 =item *
-C<ACOS>: Arc cosine
+C<LOGE (arg)> : Natural log
 
 =item *
-C<TAN>: Tangent
+C<MIN (any number of args)> : Minimum
 
 =item *
-C<TANH>: Hyperbolic tangent
+C<MAX (any number of args)> : Maximum
 
 =item *
-C<ATAN>: Arc tangent
+C<SQR (arg)> : Square root
+
+=item *
+C<SQRT (arg)> : Square root
+
+=back
+
+=head3 Trigonometric Functions
+
+=over 1
+
+=item *
+C<SIN (arg)> : Sine
+
+=item *
+C<ASIN (arg)> : Arc sine
+
+=item *
+C<COS (arg)> : Cosine
+
+=item *
+C<ACOS (arg)> : Arc cosine
+
+=item *
+C<TAN (arg)> : Tangent
+
+=item *
+C<ATAN (arg)> : Arc tangent
+
+=item *
+C<ATAN2 (den, num)> : 2-parameter Arc tangent. Arg's are reversed to ANSI C
+
+=back
+
+=head3 Hyperbolic Trigonometry Functions
+
+=over 1
+
+=item *
+C<SINH (arg)> : Hyperbolic sine
+
+=item *
+C<COSH (arg)> : Hyperbolic cosine
+
+=item *
+C<TANH (arg)> : Hyperbolic tangent
+
+=back
+
+=head3 Numeric Functions
+
+=over 1
+
+=item *
+C<CEIL (arg)> : Ceiling
+
+=item *
+C<FLOOR (arg)> : Floor
+
+=item *
+C<NINT (arg)> : Round to nearest integer
+
+=item *
+C<ISINF (arg)> : returns non-zero if any argument is Inf
+
+=item *
+C<ISNAN (any number of args)> : returns non-zero (true) if any argument is NaN
+or Inf
+
+=item *
+C<FINITE (any number of args)> : returns non-zero (true) if none of the
+arguments are NaN or Inf
+
+=back
+
+=head3 Boolean/Logical Operators
+
+These operators use their arguments as a true (non-zero) or false (zero) value.
+
+=over 1
+
+=item *
+C<&&> : And, infix binary
+
+=item *
+C<||> : Or, infix binary
+
+=item *
+C<!> : Not, unary prefix
+
+=back
+
+=head3 Bitwise Operators
+
+Mostly infix binary, the arguments are converted to a 32-bit integer, the
+operator is applied, and the result converted back into a double.
+
+=over 1
+
+=item *
+C<&> : Bitwise and
+
+=item *
+C<|> : Bitwise or
+
+=item *
+C<~> : Bitwise not or one's complement, unary prefix
+
+=item *
+C<<< << >>> : Arithmetic shift left
+
+=item *
+C<<< >> >>> : Arithmetic shift right
+
+=item *
+C<<<< >>> >>>> : Logical shift right
+
+=item *
+C<AND> : Bitwise and
+
+=item *
+C<OR> : Bitwise or
+
+=item *
+C<XOR> : Bitwise exclusive or
+
+=item *
+C<NOT> : Bitwise not or one's complement, unary prefix
 
 =back
 
 =head3 Relational Operators
+
+These are all infix binary operators.
 
 =over 1
 
@@ -248,58 +345,16 @@ C<<< <= >>> : Less than or equal to
 C<<< < >>> : Less than
 
 =item *
+C<<< != >>> : Not equal to
+
+=item *
 C<<< # >>> : Not equal to
 
 =item *
-C<<< = >>> : Equal to
-
-=back
-
-=head3 Logical Operators
-
-=over 1
+C<<< == >>> : Equal to
 
 =item *
-C<&&> : And
-
-=item *
-C<||> : Or
-
-=item *
-C<!> : Not
-
-=back
-
-=head3 Bitwise Operators
-
-=over 1
-
-=item *
-C<|> : Bitwise Or
-
-=item *
-C<&> : Bitwise And
-
-=item *
-C<OR> : Bitwise Or
-
-=item *
-C<AND> : Bitwise And
-
-=item *
-C<XOR> : Bitwise Exclusive Or
-
-=item *
-C<~> : One's Complement
-
-=item *
-C<<< << >>> : Arithmetic Left Shift
-
-=item *
-C<<< >> >>> : Arithmetic Right Shift
-
-=item *
-C<<<< >>> >>>> : Logical Right Shift
+C<<< = >>> : Equal to (not assignment)
 
 =back
 
@@ -314,22 +369,24 @@ C<:=> : assigns a value (right hand side) to a variable (i.e. field)
 
 =head3 Parantheses, Comma, and Semicolon
 
-The open and close parentheses are supported. Nested parentheses are
-supported.
+The open C<(> and close parentheses C<)> are supported to override precedence
+rules in a sub-expression.
+Nested parentheses are supported to significant depth.
 
-The comma is supported when used to separate the arguments of a binary
-function.
+The comma C<,> is required to separate the arguments of a function.
 
-The semicolon is used to separate expressions. Although only one
-traditional calculation expression is allowed, multiple assignment
-expressions are allowed.
+The semicolon C<;> is used to value separate expressions.
+Exactly one value expression must be present, but multiple assignment
+expressions may be included before and/or after the value expression.
 
-=head3 Conditional Expression
+=head3 Conditional Operator
 
-The C language's question mark operator is supported. The format is:
-C<condition ? True result : False result>
+The C language's question mark colon C<?:> ternary operator is supported.
+The format is:
 
-=head3 Expression Examples
+I<condition> C<?> I<true-expression> C<:> I<false-expression>
+
+=head2 Expression Examples
 
 =head3 Algebraic
 
@@ -370,8 +427,8 @@ Result is C<F + L + 10> if C<<< (A + B) >= (C + D) >>>
 
 =back
 
-Prior to Base 3.14.9 it was legal to omit the : and the second (else) part
-of the conditional, like this:
+Prior to Base 3.14.9 it was legal to omit the colon C<:> and the second (else)
+part of the conditional, like this:
 
 C<<< (A + B)<(C + D) ? E >>>
 

--- a/modules/database/src/std/rec/calcRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcRecord.dbd.pod
@@ -367,7 +367,7 @@ C<:=> : assigns a value (right hand side) to a variable (i.e. field)
 
 =back
 
-=head3 Parantheses, Comma, and Semicolon
+=head3 Parentheses, Comma, and Semicolon
 
 The open C<(> and close parentheses C<)> are supported to override precedence
 rules in a sub-expression.

--- a/modules/database/src/std/rec/calcRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcRecord.dbd.pod
@@ -42,7 +42,7 @@ the value they are configured with and can be changed via C<dbPuts>. They
 cannot be hardware addresses.
 
 See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on how to specify database links.
 
 =fields INPA - INPL
@@ -522,7 +522,7 @@ reporting of limit alarms until the signal has been within the alarm range for
 that number of seconds (the default AFTC value of zero retains the previous
 behavior).
 
-See L<Alarm Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#alarm-specification>
+See L<Alarm Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#alarm-specification>
 for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.

--- a/modules/database/src/std/rec/calcoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcoutRecord.dbd.pod
@@ -70,38 +70,45 @@ fields.
 
 =fields INPA - INPL
 
-=head3 Expression
+=head3 Expressions
 
-Like the Calc record, the Calcout record has a CALC field in which the
-developer can enter an infix expression which the record routine will
-evaluate when it processes the record. The resulting value is placed in the
-VAL field. This value can then be used by the OOPT field (see
-L<Output Parameters>) to determine whether or not to write to the output
-link or post an output event. It can also be the value that is written to
-the output link. The CALC expression is actually converted to opcode and
-stored in Reverse Polish Notation in the RPCL field. It is this expression
-which is actually used to calculate VAL. The Reverse Polish expression is
-evaluated more efficiently during run-time than an infix expression. CALC
-can be changes at run-time, and a special record routine will call a
-function to convert it to Reverse Polish Notation.
+Like the Calc record, the Calcout record's CALC field holds an infix expression
+to be evaluated whenever the record is processed.
+The resulting value is placed in the VAL field.
+
+The OOPT field condition is applied to VAL (see L<Output Parameters>) and
+controls whether to write to the output link (or post a named event), and the
+DOPT field selects whether VAL should be written, or another expression from
+the OCAL field should be evaluated and used instead.
+
+The CALC and OCAL expressions get compiled into streams of Reverse Polish
+Notation (RPN) opcodes for a stack-based machine, and stored in the RPCL and
+ORPC fields respectively.
+
+The RPN opcodes are used to calculate VAL at run-time, and are more efficient
+than evaluating the infix expression.
+The CALC and OCAL expressions can be replaced at run-time, triggering a special
+record routine to compile the new expression into Reverse Polish Notation.
 
 The infix expressions that can be used are very similar to the C expression
-syntax, but with some additions and subtle differences in operator meaning
-and precedence. The string may contain a series of expressions separated by
-a semi-colon character ';' any one of which may actually provide the
-calculation result; however all of the other expressions included must
-assign their result to a variable. All alphabetic elements described below
-are case independent, so upper and lower case letters may be used and mixed
-in the variable and function names as desired. Spaces may be used anywhere
-within an expression except between the characters that make up a single
-expression element.
+syntax, but with some additions and subtle differences in operator meaning and
+precedence.
+The string may contain a series of expressions separated by a semi-colon
+character C<;>, any one of which may provide the calculation result.
+All other expressions included in the string must assign their result to a
+variable.
+All alphabetic elements described below are case independent, so upper and lower
+case letters may be used and mixed in the variable and function names as
+desired.
+Spaces may be used anywhere within an expression except between characters that
+make up a single expression element.
 
 The range of expressions supported by the calculation record are separated into
 literals, constants, operands, algebraic operators, trigonometric operators,
-relational operators, logical operator, the assignment operator,
-parentheses and commas, and the question mark or '?:' operator.
+relational operators, logical operators, the assignment operator, parentheses
+and commas, and the question mark colon or C<?:> operator.
 
-=fields CALC, VAL, RPCL
+=fields CALC, VAL, OVAL, RPCL, ORPC
 
 =head3 Literals
 
@@ -153,111 +160,204 @@ field, i.e. the VAL field for the CALC expression and the OVAL field for
 the OCAL expression. (These fields can be written to by CA put, so it might
 I<not> be the result from the last time the expression was evaluated).
 
-=head3 Algebraic Operations
+=head3 Arithmetic Operators
+
+Except for unary minus these are infix binary operators.
 
 =over 1
 
 =item *
-C<ABS>: Absolute value (unary)
+C<+> : Addition
 
 =item *
-C<SQR>: Square root (unary)
+C<-> : Subtraction
 
 =item *
-C<MIN>: Minimum (any number of args)
+C<-> : Minus (unary)
 
 =item *
-C<MAX>: Maximum (any number of args)
+C<*> : Multiplication
 
 =item *
-C<FINITE>: returns non-zero if none of the arguments are NaN or Inf (any
-number of args)
+C</> : Division
 
 =item *
-C<ISNAN>: returns non-zero if any of the arguments is NaN or Inf (any number
-of args)
+C<%> : Modulo
 
 =item *
-C<CEIL>: Ceiling (unary)
+C<^> : Exponential
 
 =item *
-C<FLOOR>: Floor (unary)
-
-=item *
-C<FMOD>: Floating point modulo (binary)  **Added in 7.0.8**
-
-=item *
-C<LOG>: Log base 10 (unary)
-
-=item *
-C<LOGE>: Natural log (unary)
-
-=item *
-C<LN>: Natural log (unary)
-
-=item *
-C<EXP>: Exponential function (unary)
-
-=item *
-C<^> : Exponential (binary)
-
-=item *
-C<**> : Exponential (binary)
-
-=item *
-C<+> : Addition (binary)
-
-=item *
-C<-> : Subtraction (binary)
-
-=item *
-C<*> : Multiplication (binary)
-
-=item *
-C</> : Division (binary)
-
-=item *
-C<%> : Modulo (binary)
-
-=item *
-C<NOT>: Negate (unary)
+C<**> : Exponential
 
 =back
 
-=head3 Trigonometric Operators
+=head3 Algebraic Functions
+
+When functions take more than one argument, a comma separator must appear
+between them.
 
 =over 1
 
 =item *
-C<SIN>: Sine
+C<ABS (arg)> : Absolute value
 
 =item *
-C<SINH>: Hyperbolic sine
+C<EXP (arg)> : Exponential function
 
 =item *
-C<ASIN>: Arc sine
+C<FMOD (num, den)> : Floating point modulo. Added in 7.0.8
 
 =item *
-C<COS>: Cosine
+C<LN (arg)> : Natural log
 
 =item *
-C<COSH>: Hyperbolic cosine
+C<LOG (arg)> : Log base 10
 
 =item *
-C<ACOS>: Arc cosine
+C<LOGE (arg)> : Natural log
 
 =item *
-C<TAN>: Tangent
+C<MIN (any number of args)> : Minimum
 
 =item *
-C<TANH>: Hyperbolic tangent
+C<MAX (any number of args)> : Maximum
 
 =item *
-C<ATAN>: Arc tangent
+C<SQR (arg)> : Square root
+
+=item *
+C<SQRT (arg)> : Square root
+
+=back
+
+=head3 Trigonometric Functions
+
+=over 1
+
+=item *
+C<SIN (arg)> : Sine
+
+=item *
+C<ASIN (arg)> : Arc sine
+
+=item *
+C<COS (arg)> : Cosine
+
+=item *
+C<ACOS (arg)> : Arc cosine
+
+=item *
+C<TAN (arg)> : Tangent
+
+=item *
+C<ATAN (arg)> : Arc tangent
+
+=item *
+C<ATAN2 (den, num)> : 2-parameter Arc tangent. Arg's are reversed to ANSI C
+
+=back
+
+=head3 Hyperbolic Trigonometry Functions
+
+=over 1
+
+=item *
+C<SINH (arg)> : Hyperbolic sine
+
+=item *
+C<COSH (arg)> : Hyperbolic cosine
+
+=item *
+C<TANH (arg)> : Hyperbolic tangent
+
+=back
+
+=head3 Numeric Functions
+
+=over 1
+
+=item *
+C<CEIL (arg)> : Ceiling
+
+=item *
+C<FLOOR (arg)> : Floor
+
+=item *
+C<NINT (arg)> : Round to nearest integer
+
+=item *
+C<ISINF (arg)> : returns non-zero if any argument is Inf
+
+=item *
+C<ISNAN (any number of args)> : returns non-zero (true) if any argument is NaN
+or Inf
+
+=item *
+C<FINITE (any number of args)> : returns non-zero (true) if none of the
+arguments are NaN or Inf
+
+=back
+
+=head3 Boolean/Logical Operators
+
+These operators use their arguments as a true (non-zero) or false (zero) value.
+
+=over 1
+
+=item *
+C<&&> : And, infix binary
+
+=item *
+C<||> : Or, infix binary
+
+=item *
+C<!> : Not, unary prefix
+
+=back
+
+=head3 Bitwise Operators
+
+Mostly infix binary, the arguments are converted to a 32-bit integer, the
+operator is applied, and the result converted back into a double.
+
+=over 1
+
+=item *
+C<&> : Bitwise and
+
+=item *
+C<|> : Bitwise or
+
+=item *
+C<~> : Bitwise not or one's complement, unary prefix
+
+=item *
+C<<< << >>> : Arithmetic shift left
+
+=item *
+C<<< >> >>> : Arithmetic shift right
+
+=item *
+C<<<< >>> >>>> : Logical shift right
+
+=item *
+C<AND> : Bitwise and
+
+=item *
+C<OR> : Bitwise or
+
+=item *
+C<XOR> : Bitwise exclusive or
+
+=item *
+C<NOT> : Bitwise not or one's complement, unary prefix
 
 =back
 
 =head3 Relational Operators
+
+These are all infix binary operators.
 
 =over 1
 
@@ -274,58 +374,16 @@ C<<< <= >>> : Less than or equal to
 C<<< < >>> : Less than
 
 =item *
+C<<< != >>> : Not equal to
+
+=item *
 C<<< # >>> : Not equal to
 
 =item *
-C<<< = >>> : Equal to
-
-=back
-
-=head3 Logical Operators
-
-=over 1
+C<<< == >>> : Equal to
 
 =item *
-C< && >: And
-
-=item *
-C<||> : Or
-
-=item *
-C<!> : Not
-
-=back
-
-=head3 Bitwise Operators
-
-=over 1
-
-=item *
-C<|> : Bitwise Or
-
-=item *
-C<&> : Bitwise And
-
-=item *
-C<OR> : Bitwise Or
-
-=item *
-C<AND> : Bitwise And
-
-=item *
-C<XOR> : Bitwise Exclusive Or
-
-=item *
-C<~> : One's Complement
-
-=item *
-C<<< << >>> : Arithmetic Left Shift
-
-=item *
-C<<< >> >>> : Arithmetic Right Shift
-
-=item *
-C<<<< >>> >>>> : Logical Right Shift
+C<<< = >>> : Equal to (not assignment)
 
 =back
 
@@ -338,24 +396,26 @@ C<:=> : assigns a value (right hand side) to a variable (i.e. field)
 
 =back
 
-=head3 Parentheses, Comma, and Semicolon
+=head3 Parantheses, Comma, and Semicolon
 
-The open and close parentheses are supported. Nested parentheses are
-supported.
+The open C<(> and close parentheses C<)> are supported to override precedence
+rules in a sub-expression.
+Nested parentheses are supported to significant depth.
 
-The comma is supported when used to separate the arguments of a binary
-function.
+The comma C<,> is required to separate the arguments of a function.
 
-The semicolon is used to separate expressions. Although only one
-traditional calculation expression is allowed, multiple assignment
-expressions are allowed.
+The semicolon C<;> is used to value separate expressions.
+Exactly one value expression must be present, but multiple assignment
+expressions may be included before and/or after the value expression.
 
-=head3 Conditional Expression
+=head3 Conditional Operator
 
-The C language's question mark operator is supported. The format is:
-C<condition ? True result : False result>
+The C language's question mark colon C<?:> ternary operator is supported.
+The format is:
 
-=head3 Expression Examples
+I<condition> C<?> I<true-expression> C<:> I<false-expression>
+
+=head2 Expression Examples
 
 =head3 Algebraic
 
@@ -396,8 +456,8 @@ Result is C<F + L + 10> if C<<< (A + B) >= (C + D) >>>
 
 =back
 
-Prior to Base 3.14.9 it was legal to omit the : and the second (else) part
-of the conditional, like this:
+Prior to Base 3.14.9 it was legal to omit the colon C<:> and the second (else)
+part of the conditional, like this:
 
 C<<< (A + B)<(C + D) ? E >>>
 
@@ -511,13 +571,14 @@ necessary, the record can use the result of the CALC expression to
 determine if data should be written and can use the result of the OCAL
 expression as the data to write.
 
-If the OEVT field specifies a non-zero integer and the condition in the
-OOPT field is met, the record will post a corresponding event. If the ODLY
-field is non-zero, the record pauses for the specified number of seconds
-before executing the OUT link or posting the output event. During this
-waiting period the record is "active" and will not be processed again until
-the wait is over. The field DLYA is equal to 1 during the delay period. The
-resolution of the delay entry system dependent.
+If the OEVT field isn't empty and the condition in the OOPT field is met, the
+record will post the corresponding named event.
+If the ODLY field is non-zero, the record pauses for the specified number of
+seconds before executing the OUT link or posting the output event.
+During this waiting period the record is "active" and will not be processed
+again until the wait is over.
+The field DLYA is equal to 1 during the delay period. The resolution of the
+delay entry system dependent.
 
 The IVOA field specifies what action to take with the OUT link if the
 Calcout record enters an INVALID alarm status. The options are
@@ -1277,8 +1338,8 @@ field IVOA.
 =item 3.
 
 The Alarm Severity is not INVALID or IVOA specifies "Continue Normally",
-put the value of OVAL to the OUT link and post the event in OEVT (if
-non-zero).
+put the value of OVAL to the OUT link and post the event named in OEVT (if
+not empty).
 
 =item 4.
 

--- a/modules/database/src/std/rec/calcoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcoutRecord.dbd.pod
@@ -396,7 +396,7 @@ C<:=> : assigns a value (right hand side) to a variable (i.e. field)
 
 =back
 
-=head3 Parantheses, Comma, and Semicolon
+=head3 Parentheses, Comma, and Semicolon
 
 The open C<(> and close parentheses C<)> are supported to override precedence
 rules in a sub-expression.

--- a/modules/database/src/std/rec/calcoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcoutRecord.dbd.pod
@@ -656,7 +656,7 @@ conditions.
 
 The HYST field defines an alarm deadband for each limit.
 
-See L<Alarm Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#alarm-specification>
+See L<Alarm Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#alarm-specification>
 for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.

--- a/modules/database/src/std/rec/compressRecord.dbd.pod
+++ b/modules/database/src/std/rec/compressRecord.dbd.pod
@@ -88,7 +88,7 @@ As stated above, the ALG field specifies which algorithm to be performed on the 
 The INP should be a database or channel access link. Though INP can be a
 constant, the data compression algorithms are supported only when INP is a
 database link. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on specifying links.
 
 

--- a/modules/database/src/std/rec/dfanoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/dfanoutRecord.dbd.pod
@@ -60,7 +60,7 @@ undergoes no conversions before it is sent out to the output links.
 
 The OUTA-OUTH fields specify where VAL is to be sent. Each field that is to
 forward data must specify an address to another record. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on specifying links.
 
 The SELL, SELM, and SELN fields specify which output links are to be
@@ -135,7 +135,7 @@ in the corresponding field (HHSV, LLSV, HSV, LSV) and can be either
 NO_ALARM, MINOR, or MAJOR. In the hysteresis field (HYST) can be entered a
 number which serves as the deadband on the limit alarms.
 
-See L<Alarm Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#alarm-specification>
+See L<Alarm Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#alarm-specification>
 for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.

--- a/modules/database/src/std/rec/eventRecord.dbd.pod
+++ b/modules/database/src/std/rec/eventRecord.dbd.pod
@@ -9,9 +9,12 @@
 
 =title Event Record (event)
 
-The normal use for this record type is to post an event and/or process a
-forward link. Device support for this record can provide a hardware interrupt
-handler routine for I/O Event-scanned records.
+The normal use for this record type is to post a soft-event and/or process a
+forward link.
+C<Soft Channel> device support is provided to allow the soft-event name to be
+read from an input link.
+Hardware device support for this record can provide an interrupt handler routine
+to trigger processing of the record when an I/O Intr event occurs.
 
 =head2 Parameter Fields
 
@@ -37,18 +40,31 @@ recordtype(event) {
 =head3 Scan Parameters
 
 The event record has the standard fields for specifying under what circumstances
-it will be processed.
+it should be processed.
 These fields are described in L<Scan Fields|dbCommonRecord/Scan Fields>.
 
 =fields SCAN, PHAS, EVNT, PRIO, PINI
 
-=head3 Event Number Parameters
+=head3 Event Name Parameters
 
-The VAL field contains the event number read by the device support routines. It
-is this number which is posted. For records that use C<Soft Channel> device
-support, it can be configured before run-time or set via dbPuts.
+The VAL field is a string (prior to the Base-3.15.1 release it was a short
+integer) providing the name of an IOC soft-event.
+This named soft-event gets posted whenever the record is processed.
 
-=fields VAL
+When the soft-event name is known at design time, the VAL field should be set to
+the name in a loaded database file.
+Soft-event names do not have to be registered before use, a handle for the name
+is automatically created and stored when a name is first seen and the same
+handle returned later if the same name is re-used.
+
+The EPVT field holds the handle for the soft-event named in the VAL field.
+Looking up the handle for a soft-event name is fast and uses a hash table.
+
+For records that use the default C<Soft Channel> device support, the soft-event
+name can be fetched through the INP field link, written to the VAL field and the
+handle looked up during record processing.
+
+=fields VAL, EPVT
 
 =cut
 
@@ -69,16 +85,18 @@ support, it can be configured before run-time or set via dbPuts.
 
 =head3 Input Specification
 
-The device support routines use the address in this record to obtain input. For
-records that provide an interrupt handler, the INP field should specify the
+The device support routines use the address in this record to obtain input.
+For records that provide an interrupt handler, the INP field should specify the
 address of the I/O card, and the DTYP field should specify a valid device
-support module. Be aware that the address format differs according to the card
-type  used. See L<Address
+support module.
+
+The address format differs according to the card type  used. See
+L<Address
 Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of hardware addresses and specifying links.
 
 For soft records, the INP field can be a constant, a database link, or a channel
-access link. For soft records, the DTYP field should specify C<Soft Channel>.
+access link, and the DTYP field should be empty or set to C<Soft Channel>.
 
 =fields INP, DTYP
 
@@ -93,24 +111,27 @@ access link. For soft records, the DTYP field should specify C<Soft Channel>.
 =head3 Operator Display Parameters
 
 See L<Fields Common to All Record Types|dbCommonRecord/Operator Display
-Parameters> for more on the record name (NAME) and description (DESC) fields.
-
+Parameters>
+for more on the record name (NAME) and description (DESC) fields.
 
 =fields NAME, DESC
 
 =head3 Alarm Parameters
 
-The Event record has the alarm parameters common to all record types. L<Alarm
-Fields> lists other fields related to alarms that are common to all record
-types.
+The Event record has the alarm parameters common to all record types.
+L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related to alarms
+that are common to all record types.
+
+=fields STAT, SEVR, AMSG, NSTA, NSEV, NAMSG, ACKS, ACKT, UDF
 
 =head3 Simulation Mode Parameters
 
 The following fields are used to operate the event record in the simulation
-mode.  See L<Fields Common to Many Record Types> for more information on these
-fields.
+mode.
+See L<Fields Common to Input Record Types|dbCommonInput/Input Simulation Fields>
+for more information on these fields.
 
-=fields SIOL, SVAL, SIML, SIMM, SIMS
+=fields SIOL, SVAL, SIML, SIMM, SIMS, SSCN, SDLY
 
 =cut
 
@@ -179,38 +200,50 @@ initialized if SIOL is CONSTANT or PV_LINK.
 
 If device support includes C<init_record()>, it is called.
 
+The string in VAL is converted to a soft-event handle in EPVT.
+
 =head4 process
 
 See next section.
 
+=head4 special
+
+When the VAL field is set, the new string is converted to a soft-event handle in
+EPVT.
+
 =head3 Record Processing
 
-Routine process implements the following algorithm:
+Routine C<process()> implements the following algorithm:
 
 =over
 
 =item 1.
 
-readValue is called. See L<Input Records> for more information.
+C<readValue()> is called.
+See L<Input Records|dbCommonInput/Input Records> for more information.
 
 =item 2.
 
-If PACT has been changed to TRUE, the device support read routine has started
-but has not completed reading a new input value. In this case, the processing
-routine merely returns, leaving PACT TRUE.
+If PACT has changed to TRUE, the device support read routine has started
+but has not completed reading a new soft-event name.
+In this case, the processing routine returns immediately, leaving PACT TRUE.
 
 =item 3.
 
-If VAL E<gt> 0, post event number VAL.
+Set PACT to TRUE.
 
 =item 4.
 
-Check to see if monitors should be invoked. Alarm monitors are invoked if the
-alarm status or severity has chanet to 0.
+Post the soft-event whose handle is in EPVT.
 
 =item 5.
 
-Scan forward link if necessary, set PACT FALSE, and return.
+Check to see if monitors should be invoked.
+Alarm monitors are invoked if the new alarm status or severity are non-zero.
+
+=item 6.
+
+Scan forward link if set, set PACT to FALSE, and return.
 
 =back
 
@@ -221,13 +254,15 @@ Scan forward link if necessary, set PACT FALSE, and return.
 Each record must have an associated set of device support routines. The device
 support routines are primarily interested in the following fields:
 
-=fields PACT, DPVT, UDF, NSEV, NSTA, INP, PRIO
+=fields PACT, DPVT, UDF, NSEV, NSTA, INP, PRIO, VAL, EPVT
 
 =head3 Device Support Routines
 
 Device support consists of the following routines:
 
-=head4 long report(int level)
+=head4 report
+
+  long report(int level)
 
 This optional routine is called by the IOC command C<dbior> and is passed the
 report level that was requested by the user.
@@ -235,9 +270,11 @@ It should print a report on the state of the device support to stdout.
 The C<level> parameter may be used to output increasingly more detailed
 information at higher levels, or to select different types of information with
 different levels.
-Level zero should print no more than a small summary.
+Level zero should print only a 1-line summary.
 
-=head4 long init(int after)
+=head4 init
+
+  long init(int after)
 
 This optional routine is called twice at IOC initialization time.
 The first call happens before any of the C<init_record()> calls are made, with
@@ -247,23 +284,25 @@ with C<after> set to 1.
 
 =head4 init_record
 
-  init_record(precord)
+  long init_record(precord)
 
 This routine is optional. If provided, it is called by the record support
 C<init_record()> routine.
 
 =head4 get_ioint_info
 
-  get_ioint_info(int cmd, struct dbCommon *precord, IOSCANPVT *ppvt)
+  long get_ioint_info(int cmd, struct dbCommon *precord, IOSCANPVT *ppvt)
 
-This routine is called by the ioEventScan system each time the record is added
-or deleted from an I/O event scan list. C<cmd> has the value (0,1) if the record is
-being (added to, deleted from) an I/O event list. It must be provided for any
-device type that can use the ioEvent scanner.
+This routine is called by the dbScan system each time the record is added
+or deleted from an I/O event scan list.
+C<cmd> has the value (0, 1) if the record is being (added to, deleted from) an
+I/O event list.
+The C<get_ioint_info> routine is optional, but must be provided by any device
+support that implements C<I/O Intr> scanning for the event record type.
 
 =head4 read_event
 
-  read_event(precord)
+  long read_event(precord)
 
 This routine returns the following values:
 
@@ -281,15 +320,13 @@ Other: Error.
 
 =head3 Device Support For Soft Records
 
-The C<Soft Channel> device support module is available. The INP link type must
-be either CONSTANT, DB_LINK, or CA_LINK.
+A C<Soft Channel> device support module is available.
+The INP link field is used to fetch the soft-event name.
 
-If the INP link type is CONSTANT, then the constant value is stored into VAL by
-C<init_record()>, and UDF is set to FALSE. If the INP link type is PV_LINK, then
-dbCaAddInlink is called by C<init_record()>.
+The C<read_event()> routine reads a string through INP and stores it in VAL,
+then looks up the named soft-event handle and sets EPVT.
 
-C<read_event> calls recGblGetLinkValue to read the current value of VAL. See
-L<Input Records> for details on soft input.
+See L<Input Records|dbCommonInput/Input Records> for details on soft input.
 
 =cut
 

--- a/modules/database/src/std/rec/eventRecord.dbd.pod
+++ b/modules/database/src/std/rec/eventRecord.dbd.pod
@@ -92,7 +92,7 @@ support module.
 
 The address format differs according to the card type  used. See
 L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of hardware addresses and specifying links.
 
 For soft records, the INP field can be a constant, a database link, or a channel

--- a/modules/database/src/std/rec/longoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/longoutRecord.dbd.pod
@@ -78,7 +78,7 @@ channel access link. If the link is a constant, the result is no output. The
 DTYP field must then specify the C<<< Soft Channel >>> device support routine.
 
 See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of hardware addresses and database links.
 
 =fields OUT, DTYP, OOPT, OOCH
@@ -233,7 +233,7 @@ The HYST field sets an alarm deadband around each limit alarm.
 For an explanation of the IVOA and IVOV fields, see
 L<Invalid Output Action Fields|dbCommonOutput/Invalid Output Action Fields>.
 
-See L<Alarm Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#alarm-specification>
+See L<Alarm Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#alarm-specification>
 for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.

--- a/modules/database/src/std/rec/mbbiRecord.dbd.pod
+++ b/modules/database/src/std/rec/mbbiRecord.dbd.pod
@@ -436,7 +436,7 @@ state occurs, if set to MAJOR or MINOR.
 The other fields, when set to MAJOR or MINOR, trigger an alarm when VAL equals
 the corresponding state.
 
-See L<Alarm Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#alarm-specification>
+See L<Alarm Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#alarm-specification>
 for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.

--- a/modules/database/src/std/rec/mbboDirectRecord.dbd.pod
+++ b/modules/database/src/std/rec/mbboDirectRecord.dbd.pod
@@ -89,7 +89,7 @@ For records that are to write values to hardware devices, the OUT output link
 must contain the address of the I/O card, and the DTYP field must specify
 the proper device support module. Be aware that the address format differs
 according to the I/O bus used. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on the format of hardware addresses.
 
 During record processing VAL is converted into RVAL, which is the actual 32-bit
@@ -298,7 +298,7 @@ the IVOV field to the output.
 See L<Invalid Output Action Fields|dbCommonOutput/Invalid Output Action Fields>
 for more information about IVOA and IVOV.
 
-See L<Alarm Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#alarm-specification>
+See L<Alarm Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#alarm-specification>
 for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.

--- a/modules/database/src/std/rec/printfRecord.dbd.pod
+++ b/modules/database/src/std/rec/printfRecord.dbd.pod
@@ -148,7 +148,7 @@ which type of the data is requested through the appropriate input link. As with
 C<printf()> a C<*> character may be used in the format to specify width and/or
 precision instead of numeric literals, in which case additional input links are
 used to provide the necessary integer parameter or parameters. See L<Address
-Specification|https://docs.epics-controls.org/en/latest/guides/EPICS_Process_Database_Concepts.html#address-specification>
+Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on specifying links.
 
 The formatted string is written to the VAL field.  The maximum number of


### PR DESCRIPTION
Both calc and calout record type docs were missing operators, and the event record has never
been modified to cover named events.

Also improved the formatting in postfix.h.