### PR TITLE
Add dfanout test

### DIFF
--- a/modules/database/test/std/rec/Makefile
+++ b/modules/database/test/std/rec/Makefile
@@ -107,6 +107,13 @@ testHarness_SRCS += boTest.c
 TESTFILES += ../boTest.db
 TESTS += boTest
 
+TESTPROD_HOST += dfanoutTest
+dfanoutTest_SRCS += dfanoutTest.c
+dfanoutTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
+testHarness_SRCS += dfanoutTest.c
+TESTFILES += ../dfanoutTest.db
+TESTS += dfanoutTest
+
 TESTPROD_HOST += biTest
 biTest_SRCS += biTest.c
 biTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -15,15 +15,15 @@
 #define SLEEP_TIME 0.001
 #define SLEEP epicsThreadSleep(SLEEP_TIME);
 
-char dfanout_OUT_pvs[8][25] = {{"test_dfanout_record.OUTA\0"}, {"test_dfanout_record.OUTB\0"},
-                           {"test_dfanout_record.OUTC\0"}, {"test_dfanout_record.OUTD\0"},
-                           {"test_dfanout_record.OUTE\0"}, {"test_dfanout_record.OUTF\0"},
-                           {"test_dfanout_record.OUTG\0"}, {"test_dfanout_record.OUTH\0"}};
+static const char *dfanout_OUT_pvs[] = {{"test_dfanout_record.OUTA"}, {"test_dfanout_record.OUTB"},
+    {"test_dfanout_record.OUTC"}, {"test_dfanout_record.OUTD"},
+    {"test_dfanout_record.OUTE"}, {"test_dfanout_record.OUTF"},
+    {"test_dfanout_record.OUTG"}, {"test_dfanout_record.OUTH"}};
 
-char dfanout_receivers[8][18] = {{"test_dfanout_outa\0"}, {"test_dfanout_outb\0"},
-                                 {"test_dfanout_outc\0"}, {"test_dfanout_outd\0"},
-                                 {"test_dfanout_oute\0"}, {"test_dfanout_outf\0"},
-                                 {"test_dfanout_outg\0"}, {"test_dfanout_outh\0"}};
+static const char *dfanout_receivers[] = {{"test_dfanout_outa"}, {"test_dfanout_outb"},
+    {"test_dfanout_outc"}, {"test_dfanout_outd"},
+    {"test_dfanout_oute"}, {"test_dfanout_outf"},
+    {"test_dfanout_outg"}, {"test_dfanout_outh"}};
 
 void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
 

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -93,7 +93,7 @@ static void test_selm_mask() {
     test_all(0, -1);
 
     /* Resets values. Tests if fields in bitmask have been set */
-    for (int mask = 0; mask <= 0b11111111; ++mask) {
+    for (int mask = 0; mask <= 255; ++mask) {
 
         testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "All"); //Setting all values to 1 so we know what to compare with.
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 1);

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -14,7 +14,7 @@
 
 #include "dfanoutRecord.h"
 
-#define SLEEP_TIME 0.1
+#define SLEEP_TIME 0.01
 #define SLEEP epicsThreadSleep(SLEEP_TIME);
 
 char dfanout_OUT_pvs[8][25] = {{"test_dfanout_record.OUTA\0"}, {"test_dfanout_record.OUTB\0"},

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -89,9 +89,42 @@ static void test_selm_specified() {
 
 }
 
+static void test_selm_mask() {
+
+    /* Resetting values */
+    testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "All");
+    testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 0);
+    test_all(0, -1);
+
+    /* Resets values. Tests if fields in bitmask have been set */
+    for (int mask = 0; mask <= 0b11111111; ++mask) {
+
+        testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "All"); //Resetting all values to 0
+        testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 0);
+        SLEEP
+
+        testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "Mask");
+        testdbPutFieldOk("test_dfanout_record.SELN", DBF_LONG, mask);
+        testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 9);
+        SLEEP
+
+        for (int item = 0; item < 8; ++item) {
+
+            if ( mask & (1 << item) ) { // If i represents a set bit in the bitmask
+                testdbGetFieldEqual(dfanout_receivers[item], DBF_LONG, 9);
+            } else {
+                testdbGetFieldEqual(dfanout_receivers[item], DBF_LONG, 0);
+            }
+
+        }
+
+    }
+
+}
+
 MAIN(dfanoutTest) {
 
-    testPlan(117);
+    testPlan(3455);
 
     testdbPrepare();   
     testdbReadDatabase("recTestIoc.dbd", NULL, NULL);
@@ -105,6 +138,7 @@ MAIN(dfanoutTest) {
 
     test_all_output();
     test_selm_specified();
+    test_selm_mask();
 
     testIocShutdownOk();
     testdbCleanup();

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -30,7 +30,7 @@ static void test_all(int val, int exception){
 
     testMonitorWait(monitor);
     // if i < 0 or > 8 then it tests all.
-    for (uint i = 0; i < NELEMENTS(dfanout_receivers); ++i) {
+    for (int i = 0; i < NELEMENTS(dfanout_receivers); ++i) {
         if ( i == exception) continue;
         testdbGetFieldEqual(dfanout_receivers[i], DBF_LONG, val);
     }
@@ -40,7 +40,7 @@ static void test_all(int val, int exception){
 static void test_all_output(void){
     
     /* set output fields */
-    for (uint i = 0; i < NELEMENTS(dfanout_OUT_pvs); ++i) {
+    for (int i = 0; i < NELEMENTS(dfanout_OUT_pvs); ++i) {
         testdbPutFieldOk(dfanout_OUT_pvs[i], DBF_STRING, dfanout_receivers[i]);
     }
 

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -12,7 +12,7 @@
 #include "epicsThread.h"
 #include "dfanoutRecord.h"
 
-#define SLEEP_TIME 0.01
+#define SLEEP_TIME 0.001
 #define SLEEP epicsThreadSleep(SLEEP_TIME);
 
 char dfanout_OUT_pvs[8][25] = {{"test_dfanout_record.OUTA\0"}, {"test_dfanout_record.OUTB\0"},

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -1,5 +1,5 @@
 /*************************************************************************\
-* Copyright (c) 2023 Karl Vestin
+* Copyright (c) 2023 Marco Montevechi Filho
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -10,8 +10,6 @@
 #include "dbAccess.h"
 #include "menuIvoa.h"
 #include "epicsThread.h"
-#include <stdlib.h>
-
 #include "dfanoutRecord.h"
 
 #define SLEEP_TIME 0.01

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -12,9 +12,6 @@
 #include "epicsThread.h"
 #include "dfanoutRecord.h"
 
-#define SLEEP_TIME 0.001
-#define SLEEP epicsThreadSleep(SLEEP_TIME);
-
 static const char *dfanout_OUT_pvs[] = {"test_dfanout_record.OUTA", "test_dfanout_record.OUTB",
     "test_dfanout_record.OUTC", "test_dfanout_record.OUTD",
     "test_dfanout_record.OUTE", "test_dfanout_record.OUTF",
@@ -25,12 +22,13 @@ static const char *dfanout_receivers[] = {"test_dfanout_outa", "test_dfanout_out
     "test_dfanout_oute", "test_dfanout_outf",
     "test_dfanout_outg", "test_dfanout_outh"};
 
+static testMonitor *monitor;
+
 void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 static void test_all(int val, int exception){
 
-    SLEEP // Needed, unfortunately :(
-
+    testMonitorWait(monitor);
     // if i < 0 or > 8 then it tests all.
     for (uint i = 0; i < NELEMENTS(dfanout_receivers); ++i) {
         if ( i == exception) continue;
@@ -68,7 +66,7 @@ static void test_selm_specified() {
     for (int val = 0; val < NELEMENTS(dfanout_receivers); ++val) {
         testdbPutFieldOk("test_dfanout_record.SELN", DBF_LONG, val + 1);
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, val + 1);
-        SLEEP
+        testMonitorWait(monitor);
 
         testdbGetFieldEqual(dfanout_receivers[val], DBF_LONG, val + 1);
         
@@ -97,21 +95,21 @@ static void test_selm_mask() {
     /* Resets values. Tests if fields in bitmask have been set */
     for (int mask = 0; mask <= 0b11111111; ++mask) {
 
-        testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "All"); //Resetting all values to 0
-        testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 0);
-        SLEEP
+        testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "All"); //Setting all values to 1 so we know what to compare with.
+        testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 1);
+        testMonitorWait(monitor);
 
         testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "Mask");
         testdbPutFieldOk("test_dfanout_record.SELN", DBF_LONG, mask);
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 9);
-        SLEEP
+        testMonitorWait(monitor);
 
         for (int item = 0; item < NELEMENTS(dfanout_receivers); ++item) {
 
             if ( mask & (1 << item) ) { // If i represents a set bit in the bitmask
                 testdbGetFieldEqual(dfanout_receivers[item], DBF_LONG, 9);
             } else {
-                testdbGetFieldEqual(dfanout_receivers[item], DBF_LONG, 0);
+                testdbGetFieldEqual(dfanout_receivers[item], DBF_LONG, 1);
             }
 
         }
@@ -134,9 +132,11 @@ MAIN(dfanoutTest) {
     testIocInitOk();
     eltc(1);
 
+    monitor = testMonitorCreate("test_dfanout_record", DBE_VALUE, 0);
     test_all_output();
     test_selm_specified();
     test_selm_mask();
+    testMonitorDestroy(monitor);
 
     testIocShutdownOk();
     testdbCleanup();

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -15,15 +15,15 @@
 #define SLEEP_TIME 0.001
 #define SLEEP epicsThreadSleep(SLEEP_TIME);
 
-static const char *dfanout_OUT_pvs[] = {{"test_dfanout_record.OUTA"}, {"test_dfanout_record.OUTB"},
-    {"test_dfanout_record.OUTC"}, {"test_dfanout_record.OUTD"},
-    {"test_dfanout_record.OUTE"}, {"test_dfanout_record.OUTF"},
-    {"test_dfanout_record.OUTG"}, {"test_dfanout_record.OUTH"}};
+static const char *dfanout_OUT_pvs[] = {"test_dfanout_record.OUTA", "test_dfanout_record.OUTB",
+    "test_dfanout_record.OUTC", "test_dfanout_record.OUTD",
+    "test_dfanout_record.OUTE", "test_dfanout_record.OUTF",
+    "test_dfanout_record.OUTG", "test_dfanout_record.OUTH"};
 
-static const char *dfanout_receivers[] = {{"test_dfanout_outa"}, {"test_dfanout_outb"},
-    {"test_dfanout_outc"}, {"test_dfanout_outd"},
-    {"test_dfanout_oute"}, {"test_dfanout_outf"},
-    {"test_dfanout_outg"}, {"test_dfanout_outh"}};
+static const char *dfanout_receivers[] = {"test_dfanout_outa", "test_dfanout_outb",
+    "test_dfanout_outc", "test_dfanout_outd",
+    "test_dfanout_oute", "test_dfanout_outf",
+    "test_dfanout_outg", "test_dfanout_outh"};
 
 void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
 

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -1,0 +1,112 @@
+/*************************************************************************\
+* Copyright (c) 2023 Karl Vestin
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include "dbUnitTest.h"
+#include "testMain.h"
+#include "errlog.h"
+#include "dbAccess.h"
+#include "menuIvoa.h"
+#include "epicsThread.h"
+#include <stdlib.h>
+
+#include "dfanoutRecord.h"
+
+#define SLEEP_TIME 0.1
+#define SLEEP epicsThreadSleep(SLEEP_TIME);
+
+char dfanout_OUT_pvs[8][25] = {{"test_dfanout_record.OUTA\0"}, {"test_dfanout_record.OUTB\0"},
+                           {"test_dfanout_record.OUTC\0"}, {"test_dfanout_record.OUTD\0"},
+                           {"test_dfanout_record.OUTE\0"}, {"test_dfanout_record.OUTF\0"},
+                           {"test_dfanout_record.OUTG\0"}, {"test_dfanout_record.OUTH\0"}};
+
+char dfanout_receivers[8][18] = {{"test_dfanout_outa\0"}, {"test_dfanout_outb\0"},
+                                 {"test_dfanout_outc\0"}, {"test_dfanout_outd\0"},
+                                 {"test_dfanout_oute\0"}, {"test_dfanout_outf\0"},
+                                 {"test_dfanout_outg\0"}, {"test_dfanout_outh\0"}};
+
+void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
+
+static void test_all(int val, int exception){
+
+    SLEEP
+
+    // if i < 0 or > 8 then it tests all.
+    for (uint i = 0; i < 8; ++i) {
+        if ( i == exception) continue;
+        testdbGetFieldEqual(dfanout_receivers[i], DBF_LONG, val);
+    }
+
+}
+
+static void test_all_output(void){
+    
+    /* set output fields */
+    for (uint i = 0; i < 8; ++i) {
+        testdbPutFieldOk(dfanout_OUT_pvs[i], DBF_STRING, dfanout_receivers[i]);
+    }
+
+    /* set VAL from src to any random number */
+    testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 5);
+
+    /* verify that OUT records are updated */
+    test_all(5, -1);
+
+}
+
+static void test_selm_specified() {
+
+    testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 0);
+    test_all(0, -1);
+
+    testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "Specified");
+    testdbPutFieldOk("test_dfanout_record.SELN", DBF_LONG, 0);
+    testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 10);
+    test_all(0, -1);
+
+    for (int val = 0; val < 8; ++val) {
+        testdbPutFieldOk("test_dfanout_record.SELN", DBF_LONG, val + 1);
+        testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, val + 1);
+        SLEEP
+
+        testdbGetFieldEqual(dfanout_receivers[val], DBF_LONG, val + 1);
+        
+        int not_seln_val;
+        for (int not_seln = 0; not_seln < 8; ++not_seln) {
+            if (not_seln == val) continue;
+            if (not_seln < val) {
+                not_seln_val = not_seln + 1;
+            }  else {
+                not_seln_val = 0;
+            }
+            testdbGetFieldEqual(dfanout_receivers[not_seln], DBF_LONG, not_seln_val);
+        }
+
+    }
+
+}
+
+MAIN(dfanoutTest) {
+
+    testPlan(117);
+
+    testdbPrepare();   
+    testdbReadDatabase("recTestIoc.dbd", NULL, NULL);
+    recTestIoc_registerRecordDeviceDriver(pdbbase);
+
+    testdbReadDatabase("dfanoutTest.db", NULL, NULL);
+    
+    eltc(0);
+    testIocInitOk();
+    eltc(1);
+
+    test_all_output();
+    test_selm_specified();
+
+    testIocShutdownOk();
+    testdbCleanup();
+
+    return testDone();
+}

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -32,7 +32,7 @@ static void test_all(int val, int exception){
     SLEEP // Needed, unfortunately :(
 
     // if i < 0 or > 8 then it tests all.
-    for (uint i = 0; i < 8; ++i) {
+    for (uint i = 0; i < NELEMENTS(dfanout_receivers); ++i) {
         if ( i == exception) continue;
         testdbGetFieldEqual(dfanout_receivers[i], DBF_LONG, val);
     }
@@ -42,7 +42,7 @@ static void test_all(int val, int exception){
 static void test_all_output(void){
     
     /* set output fields */
-    for (uint i = 0; i < 8; ++i) {
+    for (uint i = 0; i < NELEMENTS(dfanout_OUT_pvs); ++i) {
         testdbPutFieldOk(dfanout_OUT_pvs[i], DBF_STRING, dfanout_receivers[i]);
     }
 
@@ -65,7 +65,7 @@ static void test_selm_specified() {
     testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 10);
     test_all(0, -1);
 
-    for (int val = 0; val < 8; ++val) {
+    for (int val = 0; val < NELEMENTS(dfanout_receivers); ++val) {
         testdbPutFieldOk("test_dfanout_record.SELN", DBF_LONG, val + 1);
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, val + 1);
         SLEEP
@@ -73,7 +73,7 @@ static void test_selm_specified() {
         testdbGetFieldEqual(dfanout_receivers[val], DBF_LONG, val + 1);
         
         int not_seln_val;
-        for (int not_seln = 0; not_seln < 8; ++not_seln) {
+        for (int not_seln = 0; not_seln < NELEMENTS(dfanout_receivers); ++not_seln) {
             if (not_seln == val) continue;
             if (not_seln < val) { // If record has already been tested, expected value is index + 1
                 not_seln_val = not_seln + 1;
@@ -106,7 +106,7 @@ static void test_selm_mask() {
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 9);
         SLEEP
 
-        for (int item = 0; item < 8; ++item) {
+        for (int item = 0; item < NELEMENTS(dfanout_receivers); ++item) {
 
             if ( mask & (1 << item) ) { // If i represents a set bit in the bitmask
                 testdbGetFieldEqual(dfanout_receivers[item], DBF_LONG, 9);

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -31,7 +31,7 @@ void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 static void test_all(int val, int exception){
 
-    SLEEP
+    SLEEP // Needed, unfortunately :(
 
     // if i < 0 or > 8 then it tests all.
     for (uint i = 0; i < 8; ++i) {
@@ -58,6 +58,7 @@ static void test_all_output(void){
 
 static void test_selm_specified() {
 
+    /* Resetting values */
     testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 0);
     test_all(0, -1);
 
@@ -76,9 +77,9 @@ static void test_selm_specified() {
         int not_seln_val;
         for (int not_seln = 0; not_seln < 8; ++not_seln) {
             if (not_seln == val) continue;
-            if (not_seln < val) {
+            if (not_seln < val) { // If record has already been tested, expected value is index + 1
                 not_seln_val = not_seln + 1;
-            }  else {
+            }  else { // If record hasn't been tested yet, expected value is 0
                 not_seln_val = 0;
             }
             testdbGetFieldEqual(dfanout_receivers[not_seln], DBF_LONG, not_seln_val);

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -29,8 +29,9 @@ void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
 static void test_all(int val, int exception){
 
     testMonitorWait(monitor);
-    // if i < 0 or > 8 then it tests all.
-    for (int i = 0; i < NELEMENTS(dfanout_receivers); ++i) {
+    // if exception < 0 or > 8 then it tests all.
+    int i;
+    for (i = 0; i < NELEMENTS(dfanout_receivers); ++i) {
         if ( i == exception) continue;
         testdbGetFieldEqual(dfanout_receivers[i], DBF_LONG, val);
     }
@@ -40,7 +41,8 @@ static void test_all(int val, int exception){
 static void test_all_output(void){
     
     /* set output fields */
-    for (int i = 0; i < NELEMENTS(dfanout_OUT_pvs); ++i) {
+    int i;
+    for (i = 0; i < NELEMENTS(dfanout_OUT_pvs); ++i) {
         testdbPutFieldOk(dfanout_OUT_pvs[i], DBF_STRING, dfanout_receivers[i]);
     }
 
@@ -63,15 +65,16 @@ static void test_selm_specified() {
     testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 10);
     test_all(0, -1);
 
-    for (int val = 0; val < NELEMENTS(dfanout_receivers); ++val) {
+    int val;
+    for (val = 0; val < NELEMENTS(dfanout_receivers); ++val) {
         testdbPutFieldOk("test_dfanout_record.SELN", DBF_LONG, val + 1);
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, val + 1);
         testMonitorWait(monitor);
 
         testdbGetFieldEqual(dfanout_receivers[val], DBF_LONG, val + 1);
         
-        int not_seln_val;
-        for (int not_seln = 0; not_seln < NELEMENTS(dfanout_receivers); ++not_seln) {
+        int not_seln, not_seln_val;
+        for (not_seln = 0; not_seln < NELEMENTS(dfanout_receivers); ++not_seln) {
             if (not_seln == val) continue;
             if (not_seln < val) { // If record has already been tested, expected value is index + 1
                 not_seln_val = not_seln + 1;
@@ -93,7 +96,8 @@ static void test_selm_mask() {
     test_all(0, -1);
 
     /* Resets values. Tests if fields in bitmask have been set */
-    for (int mask = 0; mask <= 255; ++mask) {
+    int mask;
+    for (mask = 0; mask <= 255; ++mask) {
 
         testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "All"); //Setting all values to 1 so we know what to compare with.
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 1);
@@ -104,7 +108,8 @@ static void test_selm_mask() {
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 9);
         testMonitorWait(monitor);
 
-        for (int item = 0; item < NELEMENTS(dfanout_receivers); ++item) {
+        int item;
+        for (item = 0; item < NELEMENTS(dfanout_receivers); ++item) {
 
             if ( mask & (1 << item) ) { // If i represents a set bit in the bitmask
                 testdbGetFieldEqual(dfanout_receivers[item], DBF_LONG, 9);

--- a/modules/database/test/std/rec/dfanoutTest.db
+++ b/modules/database/test/std/rec/dfanoutTest.db
@@ -1,0 +1,32 @@
+record(ao, "test_dfanout_src") {
+
+}
+
+record(dfanout, "test_dfanout_record") {
+    field(OMSL, "closed_loop")
+    field(DOL, "test_dfanout_src CP")
+}
+
+record(ai, "test_dfanout_outa") {
+}
+
+record(ai, "test_dfanout_outb") {
+}
+
+record(ai, "test_dfanout_outc") {
+}
+
+record(ai, "test_dfanout_outd") {
+}
+
+record(ai, "test_dfanout_oute") {
+}
+
+record(ai, "test_dfanout_outf") {
+}
+
+record(ai, "test_dfanout_outg") {
+}
+
+record(ai, "test_dfanout_outh") {
+}

--- a/modules/database/test/std/rec/dfanoutTest.db
+++ b/modules/database/test/std/rec/dfanoutTest.db
@@ -30,3 +30,4 @@ record(ai, "test_dfanout_outg") {
 
 record(ai, "test_dfanout_outh") {
 }
+


### PR DESCRIPTION
This adds a few unit tests to the dfanout record.
Unfortunately SLEEP is needed for it to work. I don't know if there is a better way to wait for the records to process.
@simon-ess 