### PR TITLE
Add `coverage` target and run analysis and upload report in CI

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -45,6 +45,7 @@ jobs:
       CI_CROSS_TARGETS: ${{ matrix.cross }}
       EXTRA: ${{ matrix.extra }}
       TEST: ${{ matrix.test }}
+      COVERAGE: ${{ matrix.coverage }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +73,15 @@ jobs:
                                   -Wno-error=stringop-overread
                                   -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3'
                     CMD_LDFLAGS=-Wl,-z,relro"
+
+          - os: ubuntu-22.04
+            cmp: gcc
+            configuration: default
+            coverage: true
+            extra: "CMD_CXXFLAGS=--coverage
+                    CMD_CFLAGS=--coverage
+                    CMD_LDFLAGS=--coverage"
+            name: "Ub-22 gcc coverage"
 
           - os: ubuntu-22.04
             cmp: gcc
@@ -204,7 +214,7 @@ jobs:
     - name: "apt-get install"
       run: |
         sudo apt-get update
-        sudo apt-get -y install qemu-system-x86 g++-mingw-w64-x86-64 gdb
+        sudo apt-get -y install qemu-system-x86 g++-mingw-w64-x86-64 gdb lcov
       if: runner.os == 'Linux'
     - name: Prepare and compile dependencies
       run: python .ci/cue.py prepare
@@ -212,6 +222,19 @@ jobs:
       run: python .ci/cue.py build
     - name: Run main module tests
       run: python .ci/cue.py -T 60M test
+    - name: Generate coverage report
+      if: env.COVERAGE == 'true'
+      run: make coverage
+    - name: Print coverage summary
+      if: env.COVERAGE == 'true'
+      run: lcov --list coverage/coverage.cleaned.info | tee coverage/summary.txt
+    - name: Upload coverage artifacts
+      if: env.COVERAGE == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage ${{ matrix.name }}
+        path: coverage
+        if-no-files-found: error
     - name: Upload tapfiles Artifact
       if: ${{ always() }}
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ O.*/
 .*.swp
 .DS_Store
 .iocsh_history
+coverage/

--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -594,7 +594,7 @@ include $(CONFIG)/RULES_EXPAND
 .PRECIOUS: $(COMMON_INC)
 
 .PHONY: all host inc build install clean rebuild buildInstall build_clean
-.PHONY: runtests run-tap-tests tapfiles junitfiles test-results tap-results
+.PHONY: runtests run-tap-tests tapfiles junitfiles test-results tap-results coverage
 .PHONY: clean-tests checkRelease warnRelease noCheckRelease FORCE
 
 include $(CONFIG)/RULES_COMMON

--- a/configure/RULES_TOP
+++ b/configure/RULES_TOP
@@ -61,6 +61,21 @@ ifndef DISABLE_TOP_RULES
   runtests test-results:
 	@$(SHOWTESTFAILURES)
 
+  coverage:
+	@mkdir -p coverage
+	@if ! find . -name '*.gcda' | grep -q .; then \
+	  echo "No .gcda files found! Did you build with coverage flags?"; \
+	  exit 2; \
+	fi
+
+	@lcov --capture --directory . --output-file coverage/coverage.info --ignore-errors gcov,source
+	@genhtml coverage/coverage.info \
+		--output-directory coverage/html \
+		--ignore-errors source \
+		--prefix $(realpath .)
+
+	@echo "Coverage HTML report in coverage/html/index.html"
+
 else
   #
   # Using a disabled rule aborts
@@ -95,6 +110,9 @@ help:
 	@echo "     tapfiles       - Run self-tests, save to O.<arch>/*.tap files"
 	@echo "     test-results   - Summarize all O.<arch>/*.tap files"
 	@echo "     clean-tests    - Removes all O.<arch>/*.tap files"
+	@echo "     coverage       - Produce coverage report"
+	@echo "                    - Requires that the build was done with coverage flags"
+	@echo "                    - and that the tests were run"
 	@echo "\"Partial\" build targets supported by Makefiles:"
 	@echo "     host           - Builds and installs $(EPICS_HOST_ARCH) only."
 	@echo "     inc$(DIVIDER)<arch>     - Installs <arch> only header files."

--- a/configure/RULES_TOP
+++ b/configure/RULES_TOP
@@ -69,7 +69,10 @@ ifndef DISABLE_TOP_RULES
 	fi
 
 	@lcov --capture --directory . --output-file coverage/coverage.info --ignore-errors gcov,source
-	@genhtml coverage/coverage.info \
+	@lcov --remove coverage/coverage.info \
+		'/usr/*' '*/O.*' '*/include/*' \
+		--output-file coverage/coverage.cleaned.info
+	@genhtml coverage/coverage.cleaned.info \
 		--output-directory coverage/html \
 		--ignore-errors source \
 		--prefix $(realpath .)


### PR DESCRIPTION
This PR adds a `coverage` target, that uses `lcov` and `genhtml` to produce a coverage report, and adds a CI job to produce, print, and upload a filtered coverage report.

The coverage target requires the user to, separately, have done compilation and linking with `--coverage` flags, and to have run tests. The target will perform a check to find gcov data files (`*.gcda`).

It should later be possible to, for example, upload coverage reports to codecov, or to integrate coverage analysis in PRs (e.g. using https://github.com/marketplace/actions/report-lcov).