### PR TITLE
Minimize host compilation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,7 +82,7 @@ matrix:
 #---------------------------------#
 
 install:
-  - cmd: git submodule update --init --recursive
+  - cmd: git submodule update --init --recursive .ci
   - cmd: pip install git+https://github.com/mdavidsaver/ci-core-dumper#egg=ci-core-dumper
   - cmd: python .ci/cue.py prepare
 

--- a/.appveyor/epics-base-7.yml
+++ b/.appveyor/epics-base-7.yml
@@ -89,7 +89,7 @@ matrix:
 #---------------------------------#
 
 install:
-  - cmd: git submodule update --init --recursive
+  - cmd: git submodule update --init --recursive .ci
   - cmd: pip install git+https://github.com/mdavidsaver/ci-core-dumper#egg=ci-core-dumper
   - cmd: python .ci/cue.py prepare
 

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -83,7 +83,8 @@ jobs:
             cmp: gcc
             configuration: static
             cross: "windows-x64-mingw"
-            name: "Ub-22 gcc + MinGW, static"
+            extra: "HOST_ARCH_BUILDS=Host"
+            name: "Ub-22 X- MinGW, static"
 
           - os: ubuntu-22.04
             cmp: gcc
@@ -95,7 +96,7 @@ jobs:
             cmp: gcc
             configuration: static
             extra: "CMD_CFLAGS=-funsigned-char CMD_CXXFLAGS=-funsigned-char"
-            name: "Ub-22 gcc unsigned char"
+            name: "Ub-22 gcc uchar"
 
           - os: ubuntu-22.04
             cmp: clang
@@ -112,41 +113,47 @@ jobs:
             cmp: gcc
             configuration: default
             cross: "RTEMS-pc686-qemu@5"
-            name: "Ub-22 gcc + RT-5.1 pc686"
+            extra: "HOST_ARCH_BUILDS=Host"
+            name: "Ub-22 X- RT-5.1 pc686"
 
           - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             cross: "RTEMS-beatnik@5"
+            extra: "HOST_ARCH_BUILDS=Host"
             test: NO
-            name: "Ub-22 gcc + RT-5.1 beatnik"
+            name: "Ub-22 X- RT-5.1 beatnik"
 
           - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             cross: "RTEMS-xilinx_zynq_a9_qemu@5"
+            extra: "HOST_ARCH_BUILDS=Host"
             test: NO
-            name: "Ub-22 gcc + RT-5.1 xilinx_zynq_a9_qemu"
+            name: "Ub-22 X- RT-5.1 xilinx_zynq_a9_qemu"
 
           - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             cross: "RTEMS-uC5282@5"
+            extra: "HOST_ARCH_BUILDS=Host"
             test: NO
-            name: "Ub-22 gcc + RT-5.1 uC5282"
+            name: "Ub-22 X- RT-5.1 uC5282"
 
           - os: ubuntu-22.04
             cmp: gcc
             configuration: default
-            name: "Ub-22 gcc + RT-4.10"
             cross: "RTEMS-pc386-qemu@4.10"
+            extra: "HOST_ARCH_BUILDS=Host"
             test: NO
+            name: "Ub-22 X- RT-4.10 pc386"
 
           - os: ubuntu-22.04
             cmp: gcc
             configuration: default
-            name: "Ub-22 gcc + RT-4.9"
             cross: "RTEMS-pc386-qemu@4.9"
+            extra: "HOST_ARCH_BUILDS=Host"
+            name: "Ub-22 X- RT-4.9 pc386"
 
           - os: macos-latest
             cmp: clang
@@ -180,20 +187,23 @@ jobs:
           - os: ubuntu-latest
             cmp: gcc
             configuration: default
-            name: "Cross linux-aarch64"
             cross: linux-aarch64
+            extra: "HOST_ARCH_BUILDS=Host"
+            name: "Ub X- linux-aarch64"
 
           - os: ubuntu-latest
             cmp: gcc
             configuration: default
-            name: "Cross linux-arm gnueabi"
             cross: linux-arm@arm-linux-gnueabi
+            extra: "HOST_ARCH_BUILDS=Host"
+            name: "Ub X- linux-arm gnueabi"
 
           - os: ubuntu-latest
             cmp: gcc
             configuration: default
-            name: "Cross linux-arm gnueabihf"
             cross: linux-arm@arm-linux-gnueabihf
+            extra: "HOST_ARCH_BUILDS=Host Cmd"
+            name: "Ub Xc linux-arm gnueabihf"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -83,7 +83,7 @@ jobs:
             cmp: gcc
             configuration: static
             cross: "windows-x64-mingw"
-            extra: "HOST_ARCH_BUILDS=Host"
+            host-builds: Host
             name: "Ub-22 X- MinGW, static"
 
           - os: ubuntu-22.04
@@ -113,14 +113,14 @@ jobs:
             cmp: gcc
             configuration: default
             cross: "RTEMS-pc686-qemu@5"
-            extra: "HOST_ARCH_BUILDS=Host"
+            host-builds: Host
             name: "Ub-22 X- RT-5.1 pc686"
 
           - os: ubuntu-22.04
             cmp: gcc
             configuration: default
             cross: "RTEMS-beatnik@5"
-            extra: "HOST_ARCH_BUILDS=Host"
+            host-builds: Host
             test: NO
             name: "Ub-22 X- RT-5.1 beatnik"
 
@@ -128,7 +128,7 @@ jobs:
             cmp: gcc
             configuration: default
             cross: "RTEMS-xilinx_zynq_a9_qemu@5"
-            extra: "HOST_ARCH_BUILDS=Host"
+            host-builds: Host
             test: NO
             name: "Ub-22 X- RT-5.1 xilinx_zynq_a9_qemu"
 
@@ -136,7 +136,7 @@ jobs:
             cmp: gcc
             configuration: default
             cross: "RTEMS-uC5282@5"
-            extra: "HOST_ARCH_BUILDS=Host"
+            host-builds: Host
             test: NO
             name: "Ub-22 X- RT-5.1 uC5282"
 
@@ -144,7 +144,7 @@ jobs:
             cmp: gcc
             configuration: default
             cross: "RTEMS-pc386-qemu@4.10"
-            extra: "HOST_ARCH_BUILDS=Host"
+            host-builds: Host
             test: NO
             name: "Ub-22 X- RT-4.10 pc386"
 
@@ -152,7 +152,7 @@ jobs:
             cmp: gcc
             configuration: default
             cross: "RTEMS-pc386-qemu@4.9"
-            extra: "HOST_ARCH_BUILDS=Host"
+            host-builds: Host
             name: "Ub-22 X- RT-4.9 pc386"
 
           - os: macos-latest
@@ -188,27 +188,30 @@ jobs:
             cmp: gcc
             configuration: default
             cross: linux-aarch64
-            extra: "HOST_ARCH_BUILDS=Host"
+            host-builds: Host
             name: "Ub X- linux-aarch64"
 
           - os: ubuntu-latest
             cmp: gcc
             configuration: default
             cross: linux-arm@arm-linux-gnueabi
-            extra: "HOST_ARCH_BUILDS=Host"
+            host-builds: Host
             name: "Ub X- linux-arm gnueabi"
 
           - os: ubuntu-latest
             cmp: gcc
             configuration: default
             cross: linux-arm@arm-linux-gnueabihf
-            extra: "HOST_ARCH_BUILDS=Host Cmd"
+            host-builds: "Host Cmd"
             name: "Ub Xc linux-arm gnueabihf"
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: true
+      # with:
+      #   submodules: true
+    - name: Init the .ci submodule
+      run: git submodule update --init --recursive .ci
+
     - name: Automatic core dumper analysis
       uses: mdavidsaver/ci-core-dumper@master
     - name: "apt-get install"
@@ -218,6 +221,9 @@ jobs:
       if: runner.os == 'Linux'
     - name: Prepare and compile dependencies
       run: python .ci/cue.py prepare
+    - name: Create CONFIG_SITE.local
+      run: echo "HOST_ARCH_BUILDS = ${{ matrix.host-builds }}" > configure/CONFIG_SITE.local
+      if: ${{ matrix.host-builds }}
     - name: Build main module
       run: python .ci/cue.py build
     - name: Run main module tests
@@ -234,7 +240,7 @@ jobs:
       run: python .ci/cue.py -T 5M test-results
 
   docker:
-    name: ${{ matrix.name }}
+    name: Docker ${{ matrix.name }}
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.image }}
@@ -283,8 +289,13 @@ jobs:
         git --version || dnf -y install git
         python3 --version
     - uses: actions/checkout@v4
-      with:
-        submodules: true
+      # with:
+      #   submodules: true
+    - name: Init the .ci submodule
+      run: |
+        git config --global --add safe.directory /__w/epics-base/epics-base
+        git submodule update --init --recursive .ci
+
     - name: Automatic core dumper analysis
       uses: mdavidsaver/ci-core-dumper@master
     - name: Prepare and compile dependencies
@@ -313,8 +324,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: true
+      # with:
+      #   submodules: true
+    - name: Init the .ci submodule
+      run: git submodule update --init --recursive .ci
     
     - name: Run...
       run: |

--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -102,6 +102,11 @@ ifdef T_A
 
 endif # ifdef T_A
 
+ifeq ($(EPICS_HOST_ARCH),$(T_A))
+  ifneq ($(filter Host,$(VALID_BUILDS)),Host)
+    $(error 'Host' missing from VALID_BUILDS: $(VALID_BUILDS))
+  endif
+endif
 
 # Include <top>/cfg/CONFIG* definitions from tops defined in RELEASE* files
 #

--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -93,6 +93,12 @@
 #       win32-x86-mingw         (linux-x86 or -x86_64 host)
 #
 
+# What program types should be built for the host architecture?
+#  This list must include Host; Command and Ioc are optional.
+#  Definitions in configure/os/CONFIG_SITE.Common.<host>
+#  may override this setting.
+HOST_ARCH_BUILDS=Host Ioc Command
+
 # Which target architectures to cross-compile for.
 #  Definitions in configure/os/CONFIG_SITE.<host>.Common
 #  may override this setting.

--- a/configure/os/CONFIG.Common.UnixCommon
+++ b/configure/os/CONFIG.Common.UnixCommon
@@ -8,7 +8,7 @@
 #-------------------------------------------------------
 
 # Unix valid build types
-VALID_BUILDS = Host Ioc Command
+VALID_BUILDS = $(HOST_ARCH_BUILDS)
 
 #-------------------------------------------------------
 # Unix prefix and suffix definitions

--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -6,7 +6,7 @@
 
 # Win32 valid build types and include directory suffixes
 
-VALID_BUILDS = Host Ioc Command
+VALID_BUILDS = $(HOST_ARCH_BUILDS)
 
 CMPLR_CLASS = msvc
 

--- a/modules/database/src/ioc/as/Makefile
+++ b/modules/database/src/ioc/as/Makefile
@@ -21,6 +21,9 @@ dbCore_SRCS += asDbLib.c
 dbCore_SRCS += asCa.c
 dbCore_SRCS += asIocRegister.c
 
-PROD_HOST += ascheck
-ascheck_SRCS = ascheck.c
-ascheck_LIBS = dbCore ca
+ifeq ($(filter Ioc,$(VALID_BUILDS)),Ioc)
+  # Only when both Ioc and Command are built
+  PROD_CMD += ascheck
+  ascheck_SRCS = ascheck.c
+  ascheck_LIBS = dbCore ca
+endif

--- a/modules/database/test/ioc/db/Makefile
+++ b/modules/database/test/ioc/db/Makefile
@@ -15,7 +15,7 @@ include $(TOP)/configure/CONFIG
 USR_CPPFLAGS += -I $(CURDIR)/../../../src/ioc/db
 USR_CPPFLAGS += -DUSE_TYPED_RSET -DUSE_TYPED_DSET
 
-TESTLIBRARY = dbTestIoc
+TESTLIBRARY_IOC = dbTestIoc
 
 dbTestIoc_SRCS += arrRecord.c
 dbTestIoc_SRCS += xRecord.c
@@ -43,33 +43,33 @@ testHarness_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 
 PROD_LIBS = dbTestIoc dbCore ca Com
 
-TESTPROD_HOST += dbScanTest
+TESTPROD_IOC += dbScanTest
 dbScanTest_SRCS += dbScanTest.c
 dbScanTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbScanTest.c
 TESTS += dbScanTest
 
-TESTPROD_HOST += dbShutdownTest
+TESTPROD_IOC += dbShutdownTest
 dbShutdownTest_SRCS += dbShutdownTest.c
 dbShutdownTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbShutdownTest.c
 TESTS += dbShutdownTest
 
-TESTPROD_HOST += dbPutLinkTest
+TESTPROD_IOC += dbPutLinkTest
 dbPutLinkTest_SRCS += dbPutLinkTest.c
 dbPutLinkTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbPutLinkTest.c
 TESTS += dbPutLinkTest
 TESTFILES += ../dbPutLinkTest.db ../dbPutLinkTestJ.db ../dbBadLink.db
 
-TESTPROD_HOST += dbLockTest
+TESTPROD_IOC += dbLockTest
 dbLockTest_SRCS += dbLockTest.c
 dbLockTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbLockTest.c
 TESTS += dbLockTest
 TESTFILES += ../dbLockTest.db
 
-TESTPROD_HOST += dbStressTest
+TESTPROD_IOC += dbStressTest
 dbStressTest_SRCS += dbStressLock.c
 dbStressTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 dbStressTest_SYS_LIBS_solaris += rt
@@ -77,39 +77,39 @@ dbStressTest_SYS_LIBS_Linux += rt
 TESTS += dbStressTest
 TESTFILES += ../dbStressLock.db
 
-TESTPROD_HOST += testdbConvert
+TESTPROD_IOC += testdbConvert
 testdbConvert_SRCS += testdbConvert.c
 testHarness_SRCS += testdbConvert.c
 TESTS += testdbConvert
 
-TESTPROD_HOST += callbackTest
+TESTPROD_IOC += callbackTest
 callbackTest_SRCS += callbackTest.c
 testHarness_SRCS += callbackTest.c
 TESTS += callbackTest
 
-TESTPROD_HOST += callbackParallelTest
+TESTPROD_IOC += callbackParallelTest
 callbackParallelTest_SRCS += callbackParallelTest.c
 testHarness_SRCS += callbackParallelTest.c
 TESTS += callbackParallelTest
 
-TESTPROD_HOST += dbStateTest
+TESTPROD_IOC += dbStateTest
 dbStateTest_SRCS += dbStateTest.c
 testHarness_SRCS += dbStateTest.c
 TESTS += dbStateTest
 
-TESTPROD_HOST += dbServerTest
+TESTPROD_IOC += dbServerTest
 dbServerTest_SRCS += dbServerTest.c
 testHarness_SRCS += dbServerTest.c
 TESTS += dbServerTest
 
-TESTPROD_HOST += dbCaStatsTest
+TESTPROD_IOC += dbCaStatsTest
 dbCaStatsTest_SRCS += dbCaStatsTest.c
 dbCaStatsTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbCaStatsTest.c
 TESTS += dbCaStatsTest
 TESTFILES += ../dbCaStats.db
 
-TESTPROD_HOST += dbCaLinkTest
+TESTPROD_IOC += dbCaLinkTest
 dbCaLinkTest_SRCS += dbCaLinkTest.c
 dbCaLinkTest_SRCS += dbCACTest.cpp
 dbCaLinkTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
@@ -118,21 +118,21 @@ testHarness_SRCS += dbCACTest.cpp
 TESTS += dbCaLinkTest
 TESTFILES += ../dbCaLinkTest1.db ../dbCaLinkTest2.db ../dbCaLinkTest3.db
 
-TESTPROD_HOST += dbDbLinkTest
+TESTPROD_IOC += dbDbLinkTest
 dbDbLinkTest_SRCS += dbDbLinkTest.c
 dbDbLinkTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbDbLinkTest.c
 TESTS += dbDbLinkTest
 TESTFILES += ../dbDbLinkTest.db
 
-TESTPROD_HOST += scanIoTest
+TESTPROD_IOC += scanIoTest
 scanIoTest_SRCS += scanIoTest.c
 scanIoTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += scanIoTest.c
 TESTFILES += ../scanIoTest.db
 TESTS += scanIoTest
 
-TESTPROD_HOST += dbChannelTest
+TESTPROD_IOC += dbChannelTest
 dbChannelTest_SRCS += dbChannelTest.c
 dbChannelTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbChannelTest.c
@@ -141,7 +141,7 @@ TESTS += dbChannelTest
 TARGETS += $(COMMON_DIR)/dbChArrTest.dbd
 DBDDEPENDS_FILES += dbChArrTest.dbd$(DEP)
 dbChArrTest_DBD += arrRecord.dbd
-TESTPROD_HOST += dbChArrTest
+TESTPROD_IOC += dbChArrTest
 dbChArrTest_SRCS += dbChArrTest.cpp
 dbChArrTest_SRCS += dbChArrTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbChArrTest.cpp
@@ -149,35 +149,35 @@ testHarness_SRCS += dbChArrTest_registerRecordDeviceDriver.cpp
 TESTFILES += $(COMMON_DIR)/dbChArrTest.dbd ../dbChArrTest.db
 TESTS += dbChArrTest
 
-TESTPROD_HOST += chfPluginTest
+TESTPROD_IOC += chfPluginTest
 chfPluginTest_SRCS += chfPluginTest.c
 chfPluginTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += chfPluginTest.c
 TESTS += chfPluginTest
 
-TESTPROD_HOST += arrShorthandTest
+TESTPROD_IOC += arrShorthandTest
 arrShorthandTest_SRCS += arrShorthandTest.c
 arrShorthandTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += arrShorthandTest.c
 TESTS += arrShorthandTest
 
-TESTPROD_HOST += benchdbConvert
+TESTPROD_IOC += benchdbConvert
 benchdbConvert_SRCS += benchdbConvert.c
 
-TESTPROD_HOST += recGblCheckDeadbandTest
+TESTPROD_IOC += recGblCheckDeadbandTest
 recGblCheckDeadbandTest_SRCS += recGblCheckDeadbandTest.c
 recGblCheckDeadbandTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += recGblCheckDeadbandTest.c
 TESTS += recGblCheckDeadbandTest
 
-TESTPROD_HOST += testPutGetTest
+TESTPROD_IOC += testPutGetTest
 testPutGetTest_SRCS += dbPutGetTest.c
 testPutGetTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbPutGetTest.c
 TESTFILES += ../dbPutGetTest.db
 TESTS += testPutGetTest
 
-TESTPROD_HOST += dbStaticTest
+TESTPROD_IOC += dbStaticTest
 dbStaticTest_SRCS += dbStaticTest.c
 dbStaticTest_SRCS += dbTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbStaticTest.c
@@ -206,10 +206,8 @@ PROD_RTEMS = dbTestHarness
 TESTSPEC_vxWorks = dbTestHarness.munch; epicsRunDbTests
 TESTSPEC_RTEMS = dbTestHarness.boot; epicsRunDbTests
 
-TESTSCRIPTS_HOST += $(TESTS:%=%.t)
-ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
-TESTPROD += $(TESTPROD_HOST)
-TESTSCRIPTS += $(TESTS:%=%.t)
+ifneq ($(filter $(T_A),$(EPICS_HOST_ARCH) $(CROSS_COMPILER_RUNTEST_ARCHS)),)
+TESTSCRIPTS_IOC += $(TESTS:%=%.t)
 endif
 
 include $(TOP)/configure/RULES

--- a/modules/database/test/std/filters/Makefile
+++ b/modules/database/test/std/filters/Makefile
@@ -13,7 +13,7 @@ include $(TOP)/configure/CONFIG
 
 USR_CPPFLAGS += -DUSE_TYPED_RSET
 
-TESTLIBRARY = Recs
+TESTLIBRARY_IOC = Recs
 
 Recs_SRCS += xRecord.c
 Recs_SRCS += arrRecord.c
@@ -33,33 +33,33 @@ TESTFILES += $(COMMON_DIR)/filterTest.dbd
 
 testHarness_SRCS += filterTest_registerRecordDeviceDriver.cpp
 
-TESTPROD_HOST += tsTest
+TESTPROD_IOC += tsTest
 tsTest_SRCS += tsTest.c
 tsTest_SRCS += filterTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += tsTest.c
 TESTFILES += ../xRecord.db
 TESTS += tsTest
 
-TESTPROD_HOST += dbndTest
+TESTPROD_IOC += dbndTest
 dbndTest_SRCS += dbndTest.c
 dbndTest_SRCS += filterTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += dbndTest.c
 TESTS += dbndTest
 
-TESTPROD_HOST += arrTest
+TESTPROD_IOC += arrTest
 arrTest_SRCS += arrTest.cpp
 arrTest_SRCS += filterTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += arrTest.cpp
 TESTFILES += ../arrTest.db
 TESTS += arrTest
 
-TESTPROD_HOST += syncTest
+TESTPROD_IOC += syncTest
 syncTest_SRCS += syncTest.c
 syncTest_SRCS += filterTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += syncTest.c
 TESTS += syncTest
 
-TESTPROD_HOST += decTest
+TESTPROD_IOC += decTest
 decTest_SRCS += decTest.c
 decTest_SRCS += filterTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += decTest.c
@@ -79,10 +79,8 @@ PROD_RTEMS = filterTestHarness
 TESTSPEC_vxWorks = filterTestHarness.munch; epicsRunFilterTests
 TESTSPEC_RTEMS = filterTestHarness.boot; epicsRunFilterTests
 
-TESTSCRIPTS_HOST += $(TESTS:%=%.t)
-ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
-TESTPROD += $(TESTPROD_HOST)
-TESTSCRIPTS += $(TESTS:%=%.t)
+ifneq ($(filter $(T_A),$(EPICS_HOST_ARCH) $(CROSS_COMPILER_RUNTEST_ARCHS)),)
+TESTSCRIPTS_IOC += $(TESTS:%=%.t)
 endif
 
 include $(TOP)/configure/RULES

--- a/modules/database/test/std/link/Makefile
+++ b/modules/database/test/std/link/Makefile
@@ -10,7 +10,7 @@ include $(TOP)/configure/CONFIG
 
 USR_CPPFLAGS += -DUSE_TYPED_RSET
 
-TESTLIBRARY = Recs
+TESTLIBRARY_IOC = Recs
 
 Recs_SRCS += ioRecord.c
 Recs_LIBS += dbCore ca Com
@@ -29,13 +29,13 @@ TESTFILES += ../ioRecord.db
 
 testHarness_SRCS += linkTest_registerRecordDeviceDriver.cpp
 
-TESTPROD_HOST += lnkStateTest
+TESTPROD_IOC += lnkStateTest
 lnkStateTest_SRCS += lnkStateTest.c
 lnkStateTest_SRCS += linkTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += lnkStateTest.c
 TESTS += lnkStateTest
 
-TESTPROD_HOST += lnkCalcTest
+TESTPROD_IOC += lnkCalcTest
 lnkCalcTest_SRCS += lnkCalcTest.c
 lnkCalcTest_SRCS += linkTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += lnkCalcTest.c
@@ -55,10 +55,8 @@ PROD_RTEMS = linkTestHarness
 TESTSPEC_vxWorks = linkTestHarness.munch; epicsRunLinkTests
 TESTSPEC_RTEMS = linkTestHarness.boot; epicsRunLinkTests
 
-TESTSCRIPTS_HOST += $(TESTS:%=%.t)
-ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
-  TESTPROD += $(TESTPROD_HOST)
-  TESTSCRIPTS += $(TESTS:%=%.t)
+ifneq ($(filter $(T_A),$(EPICS_HOST_ARCH) $(CROSS_COMPILER_RUNTEST_ARCHS)),)
+  TESTSCRIPTS_IOC += $(TESTS:%=%.t)
 endif
 
 include $(TOP)/configure/RULES

--- a/modules/database/test/std/rec/Makefile
+++ b/modules/database/test/std/rec/Makefile
@@ -13,7 +13,7 @@ include $(TOP)/configure/CONFIG
 USR_CPPFLAGS += -DUSE_TYPED_RSET
 USR_CPPFLAGS += -DUSE_TYPED_DSET
 
-TESTLIBRARY = dbRecStdTest
+TESTLIBRARY_IOC = dbRecStdTest
 
 dbRecStdTest_SRCS += asTestLib.c
 dbRecStdTest_LIBS += dbRecStd dbCore ca Com
@@ -35,14 +35,14 @@ TESTFILES += $(COMMON_DIR)/recTestIoc.dbd
 testHarness_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += asTestIoc_registerRecordDeviceDriver.cpp
 
-TESTPROD_HOST += arrayOpTest
+TESTPROD_IOC += arrayOpTest
 arrayOpTest_SRCS += arrayOpTest.c
 arrayOpTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += arrayOpTest.c
 TESTFILES += ../arrayOpTest.db
 TESTS += arrayOpTest
 
-TESTPROD_HOST += recMiscTest
+TESTPROD_IOC += recMiscTest
 recMiscTest_SRCS += recMiscTest.c
 recMiscTest_CFLAGS_NO = -DLINK_DYNAMIC
 recMiscTest_CFLAGS += $(recMiscTest_CFLAGS_$(STATIC_BUILD))
@@ -51,77 +51,77 @@ testHarness_SRCS += recMiscTest.c
 TESTFILES += ../recMiscTest.db
 TESTS += recMiscTest
 
-TESTPROD_HOST += linkRetargetLinkTest
+TESTPROD_IOC += linkRetargetLinkTest
 linkRetargetLinkTest_SRCS += linkRetargetLinkTest.c
 linkRetargetLinkTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += linkRetargetLinkTest.c
 TESTFILES += ../linkRetargetLink.db
 TESTS += linkRetargetLinkTest
 
-TESTPROD_HOST += linkInitTest
+TESTPROD_IOC += linkInitTest
 linkInitTest_SRCS += linkInitTest.c
 linkInitTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += linkInitTest.c
 TESTFILES += ../linkInitTest.db
 TESTS += linkInitTest
 
-TESTPROD_HOST += compressTest
+TESTPROD_IOC += compressTest
 compressTest_SRCS += compressTest.c
 compressTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += compressTest.c
 TESTFILES += ../compressTest.db
 TESTS += compressTest
 
-TESTPROD_HOST += asyncSoftTest
+TESTPROD_IOC += asyncSoftTest
 asyncSoftTest_SRCS += asyncSoftTest.c
 asyncSoftTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += asyncSoftTest.c
 TESTFILES += ../asyncSoftTest.db
 TESTS += asyncSoftTest
 
-TESTPROD_HOST += softTest
+TESTPROD_IOC += softTest
 softTest_SRCS += softTest.c
 softTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += softTest.c
 TESTFILES += ../softTest.db
 TESTS += softTest
 
-TESTPROD_HOST += seqTest
+TESTPROD_IOC += seqTest
 seqTest_SRCS += seqTest.c
 seqTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += seqTest.c
 TESTFILES += ../seqTest.db
 TESTS += seqTest
 
-TESTPROD_HOST += longoutTest
+TESTPROD_IOC += longoutTest
 longoutTest_SRCS += longoutTest.c
 longoutTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += longoutTest.c
 TESTFILES += ../longoutTest.db
 TESTS += longoutTest
 
-TESTPROD_HOST += boTest
+TESTPROD_IOC += boTest
 boTest_SRCS += boTest.c
 boTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += boTest.c
 TESTFILES += ../boTest.db
 TESTS += boTest
 
-TESTPROD_HOST += biTest
+TESTPROD_IOC += biTest
 biTest_SRCS += biTest.c
 biTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += biTest.c
 TESTFILES += ../biTest.db
 TESTS += biTest
 
-TESTPROD_HOST += printfTest
+TESTPROD_IOC += printfTest
 printfTest_SRCS += printfTest.c
 printfTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += printfTest.c
 TESTFILES += ../printfTest.db
 TESTS += printfTest
 
-TESTPROD_HOST += aiTest
+TESTPROD_IOC += aiTest
 aiTest_SRCS += aiTest.c
 aiTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += aiTest.c
@@ -132,7 +132,7 @@ TARGETS += $(COMMON_DIR)/asTestIoc.dbd
 DBDDEPENDS_FILES += asTestIoc.dbd$(DEP)
 asTestIoc_DBD += base.dbd
 asTestIoc_DBD += asTest.dbd
-TESTPROD_HOST += asTest
+TESTPROD_IOC += asTest
 asTest_SRCS += asTest.c
 asTest_SRCS += asTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += asTest.c
@@ -142,7 +142,7 @@ TESTS += asTest
 TARGETS += $(COMMON_DIR)/analogMonitorTest.dbd
 DBDDEPENDS_FILES += analogMonitorTest.dbd$(DEP)
 analogMonitorTest_DBD += base.dbd
-TESTPROD_HOST += analogMonitorTest
+TESTPROD_IOC += analogMonitorTest
 analogMonitorTest_SRCS += analogMonitorTest.c
 analogMonitorTest_SRCS += analogMonitorTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += analogMonitorTest.c
@@ -153,7 +153,7 @@ TESTS += analogMonitorTest
 TARGETS += $(COMMON_DIR)/scanEventTest.dbd
 DBDDEPENDS_FILES += scanEventTest.dbd$(DEP)
 scanEventTest_DBD += base.dbd
-TESTPROD_HOST += scanEventTest
+TESTPROD_IOC += scanEventTest
 scanEventTest_SRCS += scanEventTest.c
 scanEventTest_SRCS += scanEventTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += scanEventTest.c
@@ -164,7 +164,7 @@ TESTS += scanEventTest
 TARGETS += $(COMMON_DIR)/regressTest.dbd
 DBDDEPENDS_FILES += regressTest.dbd$(DEP)
 regressTest_DBD += base.dbd
-TESTPROD_HOST += regressTest
+TESTPROD_IOC += regressTest
 regressTest_SRCS += regressTest.c
 regressTest_SRCS += regressTest_registerRecordDeviceDriver.cpp
 TESTFILES += $(COMMON_DIR)/regressTest.dbd ../regressArray1.db ../regressHex.db ../regressLinkMS.db
@@ -180,7 +180,7 @@ ifneq (inc,$(strip $(MAKECMDGOALS)))
 DBDDEPENDS_FILES += simmTest.db$(DEP)
 endif
 simmTest_DBD += base.dbd
-TESTPROD_HOST += simmTest
+TESTPROD_IOC += simmTest
 simmTest_SRCS += simmTest.c
 simmTest_SRCS += simmTest_registerRecordDeviceDriver.cpp
 testHarness_SRCS += simmTest.c
@@ -188,7 +188,7 @@ testHarness_SRCS += simmTest_registerRecordDeviceDriver.cpp
 TESTFILES += $(COMMON_DIR)/simmTest.dbd $(COMMON_DIR)/simmTest.db
 TESTS += simmTest
 
-TESTPROD_HOST += mbbioDirectTest
+TESTPROD_IOC += mbbioDirectTest
 mbbioDirectTest_SRCS += mbbioDirectTest.c
 mbbioDirectTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += mbbioDirectTest.c
@@ -198,7 +198,7 @@ TESTS += mbbioDirectTest
 TARGETS += $(COMMON_DIR)/asyncproctest.dbd
 DBDDEPENDS_FILES += asyncproctest.dbd$(DEP)
 asyncproctest_DBD += base.dbd
-TESTPROD_HOST += asyncproctest
+TESTPROD_IOC += asyncproctest
 asyncproctest_SRCS += asyncproctest.c
 asyncproctest_SRCS += asyncproctest_registerRecordDeviceDriver.cpp
 TESTFILES += $(COMMON_DIR)/asyncproctest.dbd ../asyncproctest.db
@@ -207,14 +207,14 @@ TESTS += asyncproctest
 TARGETS += $(COMMON_DIR)/subproctest.dbd
 DBDDEPENDS_FILES += subproctest.dbd$(DEP)
 subproctest_DBD += base.dbd
-TESTPROD_HOST += subproctest
+TESTPROD_IOC += subproctest
 subproctest_SRCS += subproctest.c
 subproctest_SRCS += subproctest_registerRecordDeviceDriver.cpp
 TESTFILES += $(COMMON_DIR)/subproctest.dbd ../subproctest.db
 TESTS += subproctest
 
 
-TESTPROD_HOST += linkFilterTest
+TESTPROD_IOC += linkFilterTest
 linkFilterTest_SRCS += linkFilterTest.c
 linkFilterTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
 testHarness_SRCS += linkFilterTest.c
@@ -227,22 +227,22 @@ epicsExportTestIoc_DBD += base.dbd
 epicsExportTestIoc_DBD += epicsExportTest.dbd
 TESTFILES += $(COMMON_DIR)/epicsExportTestIoc.dbd ../epicsExportTest.db
 
-TESTLIBRARY += epicsExportTestLib
+TESTLIBRARY_IOC += epicsExportTestLib
 epicsExportTestLib_SRCS += epicsExportTest.c
 epicsExportTestLib_LIBS += dbCore Com
 
-TESTPROD_HOST += epicsExportTest
+TESTPROD_IOC += epicsExportTest
 TESTS += epicsExportTest
 TARGETS += epicsExportTest$(OBJ)
 epicsExportTest_SRCS += epicsExportTestMain.c
 epicsExportTest_SRCS += epicsExportTestIoc_registerRecordDeviceDriver.cpp
 epicsExportTest_LIBS = epicsExportTestLib
 
-TESTLIBRARY += epicsExportTestxxLib
+TESTLIBRARY_IOC += epicsExportTestxxLib
 epicsExportTestxxLib_SRCS += epicsExportTestxx.cpp
 epicsExportTestxxLib_LIBS += dbCore Com
 
-TESTPROD_HOST += epicsExportTestxx
+TESTPROD_IOC += epicsExportTestxx
 TESTS += epicsExportTestxx
 TARGETS += epicsExportTestxx$(OBJ)
 epicsExportTestxx_SRCS += epicsExportTestMain.c
@@ -277,10 +277,8 @@ PROD_RTEMS = recordTestHarness
 TESTSPEC_vxWorks = recordTestHarness.munch; epicsRunRecordTests
 TESTSPEC_RTEMS = recordTestHarness.boot; epicsRunRecordTests
 
-TESTSCRIPTS_HOST += $(TESTS:%=%.t)
-ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
-TESTPROD += $(TESTPROD_HOST)
-TESTSCRIPTS += $(TESTS:%=%.t)
+ifneq ($(filter $(T_A),$(EPICS_HOST_ARCH) $(CROSS_COMPILER_RUNTEST_ARCHS)),)
+TESTSCRIPTS_IOC += $(TESTS:%=%.t)
 endif
 
 include $(TOP)/configure/RULES

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -21,8 +21,7 @@ ifeq ($(EPICS_HOST_ARCH),$(T_A))
 
 TESTPROD_HOST += epicsUnitTestTest
 epicsUnitTestTest_SRCS += epicsUnitTestTest.c
-# Not much point running this on vxWorks or RTEMS...
-TESTS += epicsUnitTestTest
+TESTS_HOSTONLY += epicsUnitTestTest
 
 endif
 
@@ -266,13 +265,11 @@ testexecname_SRCS += testexecname.c
 # no point in including in testHarness.  Not implemented for RTEMS/vxWorks.
 TESTS += testexecname
 
-ifeq ($(BUILD_CLASS),HOST)
 ifneq ($(OS_CLASS),WIN32)
 # This test can only be run on a build host, and is broken on Windows
 TESTPROD_HOST += yajl_test
 yajl_test_SRCS += yajl_test.c
-TESTS += yajlTest
-endif
+TESTS_HOSTONLY += yajlTest
 endif
 
 TESTPROD_HOST += iocshTest
@@ -303,10 +300,10 @@ PROD_RTEMS += libComTestHarness
 TESTSPEC_vxWorks = libComTestHarness.munch; epicsRunLibComTests
 TESTSPEC_RTEMS = libComTestHarness.boot; epicsRunLibComTests
 
-TESTSCRIPTS_HOST += $(TESTS:%=%.t)
+TESTSCRIPTS_HOST += $(TESTS_HOSTONLY:%=%.t) $(TESTS:%=%.t)
 ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
 TESTPROD += $(TESTPROD_HOST)
-TESTSCRIPTS += $(filter-out epicsUnitTestTest.t, $(TESTS:%=%.t))
+TESTSCRIPTS += $(TESTS:%=%.t)
 endif
 
 


### PR DESCRIPTION
A new `HOST_ARCH_BUILDS` variable controls what program types (`Host`, `Ioc` and/or `Command`) should be built for the host architecture. The default set in `configure/CONFIG_SITE` builds everything as we have always done, but it can now be set to just `Host` in say `configure/os/CONFIG_SITE.linux-x86_64.Common` alongside `CROSS_COMPILER_TARGET_ARCHS` if that host won't be running any IOCs.

To build command-line tools like `caget` and `ascheck` for the host as well, set it to `Host Command`.

To prevent say the `linux-arm` architecture from being self-built (requiring cross-builds only), set `HOST_ARCH_BUILDS` to the empty string in the `configure/os/CONFIG_SITE.linux-arm.Common` and any attempt to run `make` on that CPU will error out.

If nothing else using this could speed up our CI build jobs; we have lots of duplicate compilation at the moment.