### PR TITLE
fix EPICS_PRINTF_STYLE for mingw to recognize %ll and %z

### DIFF
--- a/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
@@ -45,7 +45,11 @@
 /*
  * Enable format-string checking if possible
  */
+#if __USE_MINGW_ANSI_STDIO
+#define EPICS_PRINTF_STYLE(f,a) __attribute__((format(__gnu_printf__,f,a)))
+#else
 #define EPICS_PRINTF_STYLE(f,a) __attribute__((format(__printf__,f,a)))
+#endif
 
 /*
  * Deprecation marker

--- a/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
@@ -45,7 +45,7 @@
 /*
  * Enable format-string checking if possible
  */
-#if __USE_MINGW_ANSI_STDIO
+#if __GNUC__ * 100 + __GNUC_MINOR__  >= 404
 #define EPICS_PRINTF_STYLE(f,a) __attribute__((format(__gnu_printf__,f,a)))
 #else
 #define EPICS_PRINTF_STYLE(f,a) __attribute__((format(__printf__,f,a)))


### PR DESCRIPTION
The macro `__USE_MINGW_ANSI_STDIO` defined in https://github.com/epics-base/epics-base/blob/f911f8ca3eb94e0a7be3e3ed26166cc63ad8dac4/configure/os/CONFIG.Common.win32-x86-mingw#L33  makes recent MinGW accept `%ll` (`long long`) and `%z` (`size_t`) formats for `printf()` by choosing the format style `gnu_printf`.

This patch extends the same behavior to `EPICS_PRINTF_STYLE`, so that those formats used with `printf`-like EPICS functions no longer show warnings when compiling for MinGW targets. For simplicity, generally apply `__gnu_printf__` style to all compilers that support it, that is gcc version >= 4.4.0.

`%ll` and `%z` are used for example in tests:
https://github.com/epics-base/epics-base/blob/f911f8ca3eb94e0a7be3e3ed26166cc63ad8dac4/modules/database/src/ioc/db/dbUnitTest.c#L241-L242
https://github.com/epics-base/epics-base/blob/f911f8ca3eb94e0a7be3e3ed26166cc63ad8dac4/modules/libcom/test/epicsErrlogTest.c#L456