### PR TITLE
feat: support building linux target from darwin host

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -195,6 +195,12 @@ jobs:
             name: "Cross linux-arm gnueabihf"
             cross: linux-arm@arm-linux-gnueabihf
 
+          - os: macos-latest
+            cmp: gcc
+            configuration: default
+            name: "Cross macOS x86_64-linux-gnu"
+            cross: linux-x86_64
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -206,6 +212,11 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install qemu-system-x86 g++-mingw-w64-x86-64 gdb
       if: runner.os == 'Linux'
+    - name: Install cross toolchain for macOS
+      if: runner.os == 'macOS' && matrix.cross
+      run: |
+        brew tap messense/macos-cross-toolchains
+        brew install x86_64-unknown-linux-gnu
     - name: Prepare and compile dependencies
       run: python .ci/cue.py prepare
     - name: Build main module
@@ -305,7 +316,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    
+
     - name: Run...
       run: |
         env > env.list

--- a/configure/os/CONFIG.darwin-aarch64.linux-x86_64
+++ b/configure/os/CONFIG.darwin-aarch64.linux-x86_64
@@ -1,6 +1,6 @@
-# CONFIG.darwin-x86.linux-x86_64
+# CONFIG.darwin-aarch64.linux-x86_64
 #------------------------------------------------------------------------------
-# Definitions for darwin-x86 host - linux-x86_64 target builds
+# Definitions for darwin-aarch64 host - linux-x86_64 target builds
 # Sites may override these definitions in CONFIG_SITE
 #------------------------------------------------------------------------------
 

--- a/configure/os/CONFIG.darwin-x86.linux-x86_64
+++ b/configure/os/CONFIG.darwin-x86.linux-x86_64
@@ -1,0 +1,33 @@
+# CONFIG.darwin-x86.linux-x86_64
+#------------------------------------------------------------------------------
+# Definitions for darwin-x86 host - linux-x86_64 target builds
+# Sites may override these definitions in CONFIG_SITE
+#------------------------------------------------------------------------------
+# To make this configuration work "out of the box", you need to install
+# the Linux cross toolchain using Homebrew:
+#
+#       brew install x86_64-unknown-linux-gnu
+#
+# Author:
+#   Jerzy Jamróz, 2024
+#
+#------------------------------------------------------------------------------
+
+include $(CONFIG)/os/CONFIG.Common.linux-x86_64
+
+GNU_DIR = /usr/local/opt/x86_64-unknown-linux-gnu/toolchain
+GNU_TARGET = x86_64-linux-gnu
+
+COMMANDLINE_LIBRARY ?= READLINE
+
+ARCH_DEP_CPPFLAGS += -pipe
+ARCH_DEP_CXXFLAGS += -std=c++17
+
+ARCH_DEP_LDFLAGS += -Wl,--as-needed
+ARCH_DEP_LDFLAGS += -Wl,--hash-style=gnu
+
+# Expand "ARCH DEPENDENT" flags for your target
+## ARCH_DEP_CPPFLAGS += -mtune=corei7
+
+# Optional debug information
+## ARCH_DEP_LDFLAGS += -Wl,--verbose

--- a/configure/os/CONFIG.darwinCommon.linux-x86_64
+++ b/configure/os/CONFIG.darwinCommon.linux-x86_64
@@ -1,0 +1,36 @@
+# CONFIG.darwinCommon.linux-x86_64
+#------------------------------------------------------------------------------
+# Definitions for darwinCommon host - linux-x86_64 target builds
+# Sites may override these definitions in CONFIG_SITE
+#------------------------------------------------------------------------------
+# To make this configuration work "out of the box", you need to install
+# the Linux cross toolchain using Homebrew:
+#
+#       brew tap messense/macos-cross-toolchains
+#       brew install x86_64-unknown-linux-gnu
+#
+# Author:
+#   Jerzy Jamróz, 2024
+#
+#------------------------------------------------------------------------------
+
+include $(CONFIG)/os/CONFIG.Common.linux-x86_64
+
+HOMEBREW_DIR := $(shell brew --prefix 2>/dev/null)
+
+GNU_DIR = $(HOMEBREW_DIR)/opt/x86_64-unknown-linux-gnu/toolchain
+GNU_TARGET = x86_64-linux-gnu
+
+COMMANDLINE_LIBRARY ?= READLINE
+
+ARCH_DEP_CPPFLAGS += -pipe
+ARCH_DEP_CXXFLAGS += -std=c++17
+
+ARCH_DEP_LDFLAGS += -Wl,--as-needed
+ARCH_DEP_LDFLAGS += -Wl,--hash-style=gnu
+
+# Expand "ARCH DEPENDENT" flags for your target
+## ARCH_DEP_CPPFLAGS += -mtune=corei7
+
+# Optional debug information
+## ARCH_DEP_LDFLAGS += -Wl,--verbose


### PR DESCRIPTION
* darwin-x86 host - linux-x86_64 target builds.
* darwin-aarch64 host - linux-x86_64 target builds.
* If all is ok, I will prepare the `.md` release notes.