### PR TITLE
Multiline errlog

### DIFF
--- a/documentation/new-notes/PR-679.md
+++ b/documentation/new-notes/PR-679.md
@@ -1,0 +1,8 @@
+### Apply log prefix to each line
+
+If multi-line ioc log messages are sent with `errlogPrintf()`, apply
+`logClientPrefix` (e.g. set by `iocLogPrefix`) to each line in order to help
+browsing the log files.
+Also strip off any leading newlines which some calls have.
+
+Extend `errlog` iocsh command to interpret escape chars (just like `echo`).

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -291,8 +291,12 @@ static void errlogInit2CallFunc(const iocshArgBuf *args)
 }
 
 /* errlog */
-IOCSH_STATIC_FUNC void errlog(const char *message)
+IOCSH_STATIC_FUNC void errlog(char *message)
 {
+    if (message)
+        dbTranslateEscape(message, message); /* in-place is safe */
+    else
+        message = "";
     errlogPrintfNoConsole("%s\n", message);
 }
 

--- a/modules/libcom/src/log/logClient.c
+++ b/modules/libcom/src/log/logClient.c
@@ -49,8 +49,8 @@ typedef struct {
     epicsEventId        stateChangeNotify;
     epicsEventId        shutdownNotify;
     unsigned            connectCount;
-    unsigned            nextMsgIndex;
-    unsigned            backlog;
+    size_t              nextMsgIndex;
+    size_t              backlog;
     unsigned            connected;
     unsigned            shutdown;
     unsigned            shutdownConfirm;
@@ -244,8 +244,15 @@ void epicsStdCall logClientSend ( logClientId id, const char * message )
 
 void epicsStdCall logClientFlush ( logClientId id )
 {
-    unsigned nSent;
+    size_t nSent;
+#ifdef WIN32
+    /* Windows send() expects and returns int */
     int status = 0;
+#define LIMITED_LEN(len) (int)(len <= INT_MAX ? len : INT_MAX)
+#else
+    ssize_t status = 0;
+#define LIMITED_LEN(len) len
+#endif
 
     logClient * pClient = ( logClient * ) id;
 
@@ -258,7 +265,7 @@ void epicsStdCall logClientFlush ( logClientId id )
     nSent = pClient->backlog;
     while ( nSent < pClient->nextMsgIndex && pClient->connected ) {
         status = send ( pClient->sock, pClient->msgBuf + nSent,
-            pClient->nextMsgIndex - nSent, 0 );
+            LIMITED_LEN(pClient->nextMsgIndex - nSent), 0 );
         if ( status < 0 ) break;
         nSent += status;
     }
@@ -561,7 +568,7 @@ void epicsStdCall logClientShow (logClientId id, unsigned level)
             pClient->connectCount);
     }
     if (level>1) {
-        printf ("log client: %u bytes in buffer\n", pClient->nextMsgIndex);
+        printf ("log client: %zu bytes in buffer\n", pClient->nextMsgIndex);
         if (pClient->nextMsgIndex)
             printf("-------------------------\n"
                 "%.*s-------------------------\n",
@@ -590,7 +597,7 @@ void epicsStdCall iocLogPrefix(const char * prefix)
     }
 
     if (prefix) {
-        unsigned prefixLen = strlen(prefix);
+        size_t prefixLen = strlen(prefix);
         if (prefixLen > 0) {
             char * localCopy = malloc(prefixLen+1);
             strcpy(localCopy, prefix);

--- a/modules/libcom/src/log/logClient.c
+++ b/modules/libcom/src/log/logClient.c
@@ -168,12 +168,9 @@ static void logClientDestroy (logClientId id)
 /*
  * This method requires the pClient->mutex be owned already.
  */
-static void sendMessageChunk(logClient * pClient, const char * message) {
-    unsigned strSize;
-
-    strSize = strlen ( message );
+static void sendMessageChunk(logClient * pClient, const char * message, size_t strSize) {
     while ( strSize ) {
-        unsigned msgBufBytesLeft =
+        size_t msgBufBytesLeft =
             sizeof ( pClient->msgBuf ) - pClient->nextMsgIndex;
 
         if ( msgBufBytesLeft < strSize && pClient->nextMsgIndex != 0u && pClient->connected)
@@ -202,17 +199,44 @@ static void sendMessageChunk(logClient * pClient, const char * message) {
 void epicsStdCall logClientSend ( logClientId id, const char * message )
 {
     logClient * pClient = ( logClient * ) id;
+    size_t prefixLength;
 
     if ( ! pClient || ! message ) {
+        return;
+    }
+    while (*message == '\n') {
+        message++; /* skip initial newlines */
+    }
+    if (!*message) {
         return;
     }
 
     epicsMutexMustLock ( pClient->mutex );
 
     if (logClientPrefix) {
-        sendMessageChunk(pClient, logClientPrefix);
+        prefixLength = strlen(logClientPrefix);
+    } else {
+        prefixLength = 0;
     }
-    sendMessageChunk(pClient, message);
+    do {
+        /* apply logClientPrefix to each line */
+        size_t lineLength;
+        char* lineEnd = strchr(message, '\n');
+        if (lineEnd) {
+            lineLength = lineEnd + 1 - message;
+        } else {
+            lineLength = strlen(message);
+        }
+        if (prefixLength) {
+            sendMessageChunk(pClient, logClientPrefix, prefixLength);
+        }
+        sendMessageChunk(pClient, message, lineLength);
+        if (!lineEnd) {
+            /* terminate last line if necessary */
+            sendMessageChunk(pClient, "\n", 1);
+        }
+        message += lineLength;
+    } while (*message);
 
     epicsMutexUnlock (pClient->mutex);
 }

--- a/modules/libcom/test/epicsErrlogTest.c
+++ b/modules/libcom/test/epicsErrlogTest.c
@@ -98,14 +98,16 @@ static SOCKET sock;
 static SOCKET insock;
 
 static const char* prefixactualmsg[]= {
-                     "A message without prefix",
-                     "A message with prefix",
-                     "DONE"
+                     "\n\nA message without prefix",
+                     "A multi-line message\nwith prefix\n",
+                     "DONE\n"
                      };
 static const char *prefixstring = "fac=LI21 ";
-static const char prefixexpectedmsg[] = "A message without prefix"
-                     "fac=LI21 A message with prefix"
-                     "fac=LI21 DONE"
+static const char prefixexpectedmsg[] =
+                     "A message without prefix\n"
+                     "fac=LI21 A multi-line message\n"
+                     "fac=LI21 with prefix\n"
+                     "fac=LI21 DONE\n"
                      ;
 static char prefixmsgbuffer[1024];
 


### PR DESCRIPTION
If multi-line ioc log messages are sent with `errlogPrintf()`, apply `logClientPrefix` (e.g. set by `iocLogPrefix`) to each line in order to help browsing the log files.
Also add newline to end of message if missing and strip off any leading newlines which some calls have.

Extend `errlog` iocsh command to interpret escape chars (just like `echo`).

Also fix a potential problem with message length > UINT_MAX and related Windows compiler warnings.