### PR TITLE
fix: ts{} {} warning: missing initializer for members

### DIFF
--- a/modules/libcom/src/osi/epicsTime.h
+++ b/modules/libcom/src/osi/epicsTime.h
@@ -329,7 +329,7 @@ public:
 
     /** \brief The default constructor sets the time to the EPICS epoch. */
 #if __cplusplus>=201103L
-    constexpr epicsTime() :ts{} {}
+    constexpr epicsTime() :ts{0, 0} {}
 #else
     epicsTime () {
         ts.secPastEpoch = ts.nsec = 0u;


### PR DESCRIPTION
- warning: missing initializer for member ‘epicsTimeStamp::secPastEpoch’ [-Wmissing-field-initializers]
- warning: missing initializer for member ‘epicsTimeStamp::nsec’ [-Wmissing-field-initializers]