### PR TITLE
improve dfanout record

### DIFF
--- a/documentation/new-notes/PR-688.md
+++ b/documentation/new-notes/PR-688.md
@@ -1,0 +1,6 @@
+### `dfanout` improvements
+
+The dfanout record now has invalid output handling with the usual fields
+`IVOA` and `IVOV` just like other output records.
+
+The number of output links has been increased from 8 to 16.

--- a/modules/database/src/std/rec/dfanoutRecord.dbd.pod
+++ b/modules/database/src/std/rec/dfanoutRecord.dbd.pod
@@ -10,9 +10,12 @@
 =title Data Fanout Record (dfanout)
 
 The Data Fanout or "dfanout" record is used to forward data to up to
-eight other records. It's similar to the fanout record except that the
-capability to forward data has been added to it. If has no associated
+16 other records. It's similar to the fanout record except that the
+capability to forward data has been added to it. It has no associated
 device support.
+
+Since UNRELEASED the number of output links has been increased
+from 8 to 16 and IVOA and IVOV fields have been added.
 
 =head2 Parameter Fields
 
@@ -58,7 +61,7 @@ undergoes no conversions before it is sent out to the output links.
 
 =head3 Write Parameters
 
-The OUTA-OUTH fields specify where VAL is to be sent. Each field that is to
+The OUTA-OUTP fields specify where VAL is to be sent. Each field that is to
 forward data must specify an address to another record. See L<Address
 Specification|https://docs.epics-controls.org/en/latest/process-database/EPICS_Process_Database_Concepts.html#address-specification>
 for information on specifying links.
@@ -88,7 +91,7 @@ If SELM is C<Mask>, then SELN will be treated as a bit mask. If bit zero
 OUTB will be written to, and so on. Thus when SELN==5, both OUTC and OUTA
 will be written to.
 
-=fields SELL, SELM, SELN, OUTA - OUTH
+=fields SELL, SELM, SELN, OUTA - OUTP
 
 =head3 Operator Display Parameters
 
@@ -128,7 +131,12 @@ Parameters> for more about the record name (NAME) and description (DESC) fields.
 
 The possible alarm conditions for data fanouts are the SCAN, READ, INVALID,
 and limit alarms. The SCAN and READ alarms are called by the record
-routines. The limit alarms are configured by the user in the HIHI, LOLO,
+routines. The IVOA field specifies the action to take in this case.
+
+For an explanation of the IVOA and IVOV fields, see
+L<Invalid Output Action Fields|dbCommonOutput/Invalid Output Action Fields>.
+
+The limit alarms are configured by the user in the HIHI, LOLO,
 HIGH, and LOW fields using floating point values. The limit alarms apply 
 only to the VAL field. The severity for each of these limits is specified
 in the corresponding field (HHSV, LLSV, HSV, LSV) and can be either
@@ -140,7 +148,7 @@ for a complete explanation of record alarms and of the standard fields.
 L<Alarm Fields|dbCommonRecord/Alarm Fields> lists other fields related
 to alarms that are common to all record types.
 
-=fields HIHI, HIGH, LOW, LOLO, HHSV, HSV, LSV, LLSV, HYST
+=fields HIHI, HIGH, LOW, LOLO, HHSV, HSV, LSV, LLSV, HYST, IVOA, IVOV
 
 =head3 Monitor Parameters
 
@@ -224,6 +232,46 @@ hysteresis factors for monitor callbacks.
 	}
 	field(OUTH,DBF_OUTLINK) {
 		prompt("Output Spec H")
+		promptgroup("50 - Output")
+		interest(1)
+	}
+	field(OUTI,DBF_OUTLINK) {
+		prompt("Output Spec I")
+		promptgroup("50 - Output")
+		interest(1)
+	}
+	field(OUTJ,DBF_OUTLINK) {
+		prompt("Output Spec J")
+		promptgroup("50 - Output")
+		interest(1)
+	}
+	field(OUTK,DBF_OUTLINK) {
+		prompt("Output Spec K")
+		promptgroup("50 - Output")
+		interest(1)
+	}
+	field(OUTL,DBF_OUTLINK) {
+		prompt("Output Spec L")
+		promptgroup("50 - Output")
+		interest(1)
+	}
+	field(OUTM,DBF_OUTLINK) {
+		prompt("Output Spec M")
+		promptgroup("50 - Output")
+		interest(1)
+	}
+	field(OUTN,DBF_OUTLINK) {
+		prompt("Output Spec N")
+		promptgroup("50 - Output")
+		interest(1)
+	}
+	field(OUTO,DBF_OUTLINK) {
+		prompt("Output Spec O")
+		promptgroup("50 - Output")
+		interest(1)
+	}
+	field(OUTP,DBF_OUTLINK) {
+		prompt("Output Spec P")
 		promptgroup("50 - Output")
 		interest(1)
 	}
@@ -353,6 +401,17 @@ hysteresis factors for monitor callbacks.
 		special(SPC_NOMOD)
 		interest(3)
 	}
+	field(IVOA,DBF_MENU) {
+		prompt("INVALID output action")
+		promptgroup("50 - Output")
+		interest(2)
+		menu(menuIvoa)
+	}
+	field(IVOV,DBF_DOUBLE) {
+		prompt("INVALID output value")
+		promptgroup("50 - Output")
+		interest(2)
+	}
 
 =head2 Record Support
 
@@ -411,32 +470,38 @@ is called.
 =over
 
 =item 1.
-The C<process()> routine first checks that DOL is not a constant link and
-that OMSL is set to "closed_loop". If so, it retrieves a value through DOL
-and places it into VAL. If no errors occur, UDF is set to FALSE.
+
+If OMSL is "closed_loop" and DOL is not a constant link read the new value
+of VAL from DOL. If no errors occur, UDF is set to FALSE.
 
 =item 2.
-PACT is set TRUE, and the record's timestamp is set.
+
+PACT is set TRUE and the record's timestamp is set.
 
 =item 3.
+
 A value is fetched from SELL and placed into SELN.
 
 =item 4.
+
 Alarms ranges are checked against the contents of the VAL field.
 
 =item 5.
-VAL is then sent through the OUTA-OUTH links by calling C<dbPutLink()> for
-each link, conditional on the setting of SELM and the value in SELN.
+
+Check severity and then send the value through the OUTA-OUTP links, depending
+on the setting of SELM and the value in SELN.
+
+See L<Invalid Output Action Fields|dbCommonOutput/Invalid Output Action Fields>
+for information on how INVALID alarms affect output records.
 
 =item 6.
+
 Value and archive monitors are posted on the VAL field if appropriate based on
 the settings of MDEL and ADEL respectively.
 
 =item 7.
-The data fanout's forward link FLNK is processed.
 
-=item 6.
-PACT is set FALSE, and the C<process()> routine returns.
+Scan forward link if necessary, set PACT FALSE, and return.
 
 =back
 

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -22,13 +22,10 @@ static const char *dfanout_receivers[] = {"test_dfanout_outa", "test_dfanout_out
     "test_dfanout_oute", "test_dfanout_outf",
     "test_dfanout_outg", "test_dfanout_outh"};
 
-static testMonitor *monitor;
-
 void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 static void test_all(int val, int exception){
 
-    testMonitorWait(monitor);
     // if exception < 0 or > 8 then it tests all.
     int i;
     for (i = 0; i < NELEMENTS(dfanout_receivers); ++i) {
@@ -39,7 +36,7 @@ static void test_all(int val, int exception){
 }
 
 static void test_all_output(void){
-    
+
     /* set output fields */
     int i;
     for (i = 0; i < NELEMENTS(dfanout_OUT_pvs); ++i) {
@@ -69,10 +66,9 @@ static void test_selm_specified() {
     for (val = 0; val < NELEMENTS(dfanout_receivers); ++val) {
         testdbPutFieldOk("test_dfanout_record.SELN", DBF_LONG, val + 1);
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, val + 1);
-        testMonitorWait(monitor);
 
         testdbGetFieldEqual(dfanout_receivers[val], DBF_LONG, val + 1);
-        
+
         int not_seln, not_seln_val;
         for (not_seln = 0; not_seln < NELEMENTS(dfanout_receivers); ++not_seln) {
             if (not_seln == val) continue;
@@ -101,12 +97,10 @@ static void test_selm_mask() {
 
         testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "All"); //Setting all values to 1 so we know what to compare with.
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 1);
-        testMonitorWait(monitor);
 
         testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "Mask");
         testdbPutFieldOk("test_dfanout_record.SELN", DBF_LONG, mask);
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 9);
-        testMonitorWait(monitor);
 
         int item;
         for (item = 0; item < NELEMENTS(dfanout_receivers); ++item) {
@@ -127,21 +121,19 @@ MAIN(dfanoutTest) {
 
     testPlan(3455);
 
-    testdbPrepare();   
+    testdbPrepare();
     testdbReadDatabase("recTestIoc.dbd", NULL, NULL);
     recTestIoc_registerRecordDeviceDriver(pdbbase);
 
     testdbReadDatabase("dfanoutTest.db", NULL, NULL);
-    
+
     eltc(0);
     testIocInitOk();
     eltc(1);
 
-    monitor = testMonitorCreate("test_dfanout_record", DBE_VALUE, 0);
     test_all_output();
     test_selm_specified();
     test_selm_mask();
-    testMonitorDestroy(monitor);
 
     testIocShutdownOk();
     testdbCleanup();

--- a/modules/database/test/std/rec/dfanoutTest.c
+++ b/modules/database/test/std/rec/dfanoutTest.c
@@ -12,27 +12,36 @@
 #include "epicsThread.h"
 #include "dfanoutRecord.h"
 
-static const char *dfanout_OUT_pvs[] = {"test_dfanout_record.OUTA", "test_dfanout_record.OUTB",
+static const char *dfanout_OUT_pvs[] = {
+    "test_dfanout_record.OUTA", "test_dfanout_record.OUTB",
     "test_dfanout_record.OUTC", "test_dfanout_record.OUTD",
     "test_dfanout_record.OUTE", "test_dfanout_record.OUTF",
-    "test_dfanout_record.OUTG", "test_dfanout_record.OUTH"};
+    "test_dfanout_record.OUTG", "test_dfanout_record.OUTH",
+    "test_dfanout_record.OUTI", "test_dfanout_record.OUTJ",
+    "test_dfanout_record.OUTK", "test_dfanout_record.OUTL",
+    "test_dfanout_record.OUTM", "test_dfanout_record.OUTN",
+    "test_dfanout_record.OUTO", "test_dfanout_record.OUTP"};
 
-static const char *dfanout_receivers[] = {"test_dfanout_outa", "test_dfanout_outb",
+static const char *dfanout_receivers[] = {
+    "test_dfanout_outa", "test_dfanout_outb",
     "test_dfanout_outc", "test_dfanout_outd",
     "test_dfanout_oute", "test_dfanout_outf",
-    "test_dfanout_outg", "test_dfanout_outh"};
+    "test_dfanout_outg", "test_dfanout_outh",
+    "test_dfanout_outi", "test_dfanout_outj",
+    "test_dfanout_outk", "test_dfanout_outl",
+    "test_dfanout_outm", "test_dfanout_outn",
+    "test_dfanout_outo", "test_dfanout_outp"};
 
 void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
 
 static void test_all(int val, int exception){
 
-    // if exception < 0 or > 8 then it tests all.
+    // if mask == -1 then it tests all.
     int i;
     for (i = 0; i < NELEMENTS(dfanout_receivers); ++i) {
         if ( i == exception) continue;
         testdbGetFieldEqual(dfanout_receivers[i], DBF_LONG, val);
     }
-
 }
 
 static void test_all_output(void){
@@ -54,6 +63,7 @@ static void test_all_output(void){
 static void test_selm_specified() {
 
     /* Resetting values */
+    testDiag("Testing Specified");
     testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 0);
     test_all(0, -1);
 
@@ -91,10 +101,11 @@ static void test_selm_mask() {
     testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 0);
     test_all(0, -1);
 
-    /* Resets values. Tests if fields in bitmask have been set */
-    int mask;
-    for (mask = 0; mask <= 255; ++mask) {
-
+    /* Testing all 65535 possible masks seems a bit excessive -- just test some patterns */
+    epicsUInt32 mask = 0x100055aa;
+    while (1) {
+        testDiag("Testing mask 0x%04x", mask);
+        /* Resets values. Tests if fields in bitmask have been set */
         testdbPutFieldOk("test_dfanout_record.SELM", DBF_STRING, "All"); //Setting all values to 1 so we know what to compare with.
         testdbPutFieldOk("test_dfanout_src.VAL", DBF_LONG, 1);
 
@@ -112,14 +123,15 @@ static void test_selm_mask() {
             }
 
         }
-
+        if (!mask) break;
+        mask >>= 1;
     }
 
 }
 
 MAIN(dfanoutTest) {
 
-    testPlan(3455);
+    testPlan(1005);
 
     testdbPrepare();
     testdbReadDatabase("recTestIoc.dbd", NULL, NULL);

--- a/modules/database/test/std/rec/dfanoutTest.db
+++ b/modules/database/test/std/rec/dfanoutTest.db
@@ -31,3 +31,26 @@ record(ai, "test_dfanout_outg") {
 record(ai, "test_dfanout_outh") {
 }
 
+record(ai, "test_dfanout_outi") {
+}
+
+record(ai, "test_dfanout_outj") {
+}
+
+record(ai, "test_dfanout_outk") {
+}
+
+record(ai, "test_dfanout_outl") {
+}
+
+record(ai, "test_dfanout_outm") {
+}
+
+record(ai, "test_dfanout_outn") {
+}
+
+record(ai, "test_dfanout_outo") {
+}
+
+record(ai, "test_dfanout_outp") {
+}

--- a/modules/database/test/std/rec/dfanoutTest.db
+++ b/modules/database/test/std/rec/dfanoutTest.db
@@ -1,10 +1,10 @@
 record(ao, "test_dfanout_src") {
-
+    field(FLNK, "test_dfanout_record")
 }
 
 record(dfanout, "test_dfanout_record") {
     field(OMSL, "closed_loop")
-    field(DOL, "test_dfanout_src CP")
+    field(DOL, "test_dfanout_src")
 }
 
 record(ai, "test_dfanout_outa") {


### PR DESCRIPTION
The dfanout record now has invalid output handling with the usual fields IVOA and IVOV just like other output records.

As SELN already has 16 bits, allow to make use of them. Number of output links increased from 8 (OUTA-OUTH) to 16 (OUTA-OUTP).