### PR TITLE
better guesses for wrong field names

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1233,7 +1233,6 @@ static void dbRecordField(char *name,char *value)
                 {
                     /* range map */
                     size_t l2 = strlen(dbFieldConfusionMap[i^1]);
-                    memset(buf, 0, sizeof(buf));
                     strncpy(buf, dbFieldConfusionMap[i^1], sizeof(buf)-1);
                     buf[l2-3] += name[l-3] - fld[l-3];
                     buf[l2-2] = 0;
@@ -1264,10 +1263,10 @@ static void dbRecordField(char *name,char *value)
                     if (temp.pflddes->interest)
                         sim *= 1.0 - 0.1 * temp.pflddes->interest; /* 10% less likely per interest level */
 
-                    long status = 0;
-                    char* end = &quote;
                     if (*value != quote) {
                         /* value given, check match to field type */
+                        long status = 0;
+                        char* end = &quote;
                         switch (temp.pflddes->field_type) {
                             epicsAny dummy;
                             case DBF_CHAR:

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -1209,7 +1209,15 @@ static void dbRecordField(char *name,char *value)
             double bestSim = -1.0;
             const dbFldDes *bestFld = NULL;
             dbCopyEntryContents(pdbentry, &temp);
+            const char* guess =
+                strcmp(name, "OUT") == 0 ? "INP" :
+                strcmp(name, "INP") == 0 ? "OUT" :
+                NULL;
             for(status = dbFirstField(&temp, 0); !status; status = dbNextField(&temp, 0)) {
+                if (guess && strcmp(temp.pflddes->name, guess) == 0) {
+                    bestFld = temp.pflddes;
+                    break;
+                }
                 double sim = epicsStrSimilarity(name, temp.pflddes->name);
                 if(!bestFld || sim > bestSim) {
                     bestSim = sim;


### PR DESCRIPTION
Sometimes mistakes are not just typos.
One of my most frequent field name errors is to use `INP` instead of `OUT` and vice versa.
In that case, I find the message
```
ERROR: ao record RECORDNAME doesn't have a field 'INP'
    Did you mean "PINI"?  (Process at iocInit)
```
much less helpful than
```
    Did you mean "OUT"?  (Output Specification)
```

The same approach may be extended for `ZNAM` vs `ZRST` and similar.