### PR TITLE
Fix MSI tests when INSTALL_LOCATION is set

### DIFF
--- a/modules/database/test/ioc/dbtemplate/msi.plt
+++ b/modules/database/test/ioc/dbtemplate/msi.plt
@@ -57,10 +57,10 @@ ok(msi('-I. -I.. -S ../t12-substitute.txt'), slurp('../t12-result.txt'));
 delete @ENV{ keys %envs };  # Not really needed
 
 # Substitution file, relative path includes
-ok(msi('-I @TOP@/modules -S ../t13-substitute.txt'), slurp('../t13-result.txt'));
+ok(msi('-I ../.. -S ../t13-substitute.txt'), slurp('../t13-result.txt'));
 
 # Template file, relative path includes
-ok(msi('-I @TOP@/modules ../t14-template.txt'), slurp('../t14-result.txt'));
+ok(msi('-I ../.. ../t14-template.txt'), slurp('../t14-result.txt'));
 
 # Test support routines
 

--- a/modules/database/test/ioc/dbtemplate/t13-substitute.txt
+++ b/modules/database/test/ioc/dbtemplate/t13-substitute.txt
@@ -1,3 +1,3 @@
-file database/test/ioc/dbtemplate/t13-template.txt {
+file dbtemplate/t13-template.txt {
     { a=foo }
 }

--- a/modules/database/test/ioc/dbtemplate/t14-template.txt
+++ b/modules/database/test/ioc/dbtemplate/t14-template.txt
@@ -1,5 +1,5 @@
 This is t14-template.txt
 
-include "database/test/ioc/dbtemplate/t14-include.txt"
+include "dbtemplate/t14-include.txt"
 
 End of t14-template.txt


### PR DESCRIPTION
If INSTALL_LOCATION is set, then `@TOP@` is set to it when using expandVars.pl; this means that the msi tests that look for source files do not correctly find them.

Fixes #622 