### PR TITLE
Allow CA clients to determine the server protocol version

### DIFF
--- a/modules/ca/src/client/cac.h
+++ b/modules/ca/src/client/cac.h
@@ -203,6 +203,7 @@ public:
     void destroyIIU ( tcpiiu & iiu );
 
     const char * pLocalHostName ();
+    const resTable < tcpiiu, caServerID > & getServerTable();
 
 private:
     epicsSingleton < localHostName > :: reference _refLocalHostName;
@@ -422,6 +423,12 @@ inline double cac ::
 {
     guard.assertIdenticalMutex ( this->mutex );
     return this->connTMO;
+}
+
+inline const resTable < tcpiiu, caServerID > & cac ::
+    getServerTable()
+{
+    return this->serverTable;
 }
 
 #endif // ifndef INC_cac_H

--- a/modules/ca/src/client/cacChannel.cpp
+++ b/modules/ca/src/client/cacChannel.cpp
@@ -129,6 +129,13 @@ unsigned cacChannel::getHostName (
     return 0u;
 }
 
+unsigned cacChannel::getHostMinorProtocol ( 
+    epicsGuard < epicsMutex > &) const throw ()
+{
+    epicsThreadOnce ( & cacChannelIdOnce, cacChannelSetup, 0);
+    return 0u;
+}
+
 // the default is to assume that it is a locally hosted channel
 const char * cacChannel::pHostName (
     epicsGuard < epicsMutex > & ) const throw ()

--- a/modules/ca/src/client/cacIO.h
+++ b/modules/ca/src/client/cacIO.h
@@ -246,7 +246,8 @@ public:
     // !! deprecated, avoid use  !!
     virtual const char * pHostName (
         epicsGuard < epicsMutex > & guard ) const throw ();
-
+    virtual unsigned getHostMinorProtocol (
+        epicsGuard < epicsMutex > &) const throw () ;
     // exceptions
     class badString {};
     class badType {};

--- a/modules/ca/src/client/cadef.h
+++ b/modules/ca/src/client/cadef.h
@@ -1465,6 +1465,7 @@ LIBCA_API unsigned epicsStdCall ca_get_host_name ( chid pChan,
  *
  * \param[in] pChan channel identifier
  * \returns The minor protocol version number.
+ * If the channel is disconnected CA_UKN_MINOR_VERSION is returned.
  */
 LIBCA_API unsigned epicsStdCall ca_host_minor_protocol (chid pChan);
 

--- a/modules/ca/src/client/cadef.h
+++ b/modules/ca/src/client/cadef.h
@@ -1460,6 +1460,16 @@ LIBCA_API const char * epicsStdCall ca_host_name (chid channel);
 LIBCA_API unsigned epicsStdCall ca_get_host_name ( chid pChan, 
     char *pBuf, unsigned bufLength );
 
+/** \brief Return the minor protocol version number used by the host to
+ *  which a channel is cuurently connected.   
+ *
+ * \param[in] pChan channel identifier
+ * \returns The minor protocol version number.
+ */
+LIBCA_API unsigned epicsStdCall ca_host_minor_protocol (chid pChan);
+
+#define HAS_CA_HOST_MINOR_PROTOCOL
+
 /** \brief Call their function with their argument whenever
  *  a new fd is added or removed.
  *

--- a/modules/ca/src/client/nciu.cpp
+++ b/modules/ca/src/client/nciu.cpp
@@ -410,6 +410,13 @@ const char * nciu::pHostName (
     return this->piiu->pHostName ( guard );
 }
 
+unsigned nciu::getHostMinorProtocol (
+    epicsGuard < epicsMutex > & guard) const throw ()
+{
+    return this->piiu->getHostMinorProtocol (
+        guard );
+}
+
 bool nciu::ca_v42_ok (
     epicsGuard < epicsMutex > & guard ) const
 {

--- a/modules/ca/src/client/nciu.h
+++ b/modules/ca/src/client/nciu.h
@@ -183,6 +183,8 @@ public:
     unsigned getHostName (
         epicsGuard < epicsMutex > &,
         char * pBuf, unsigned bufLen ) const throw ();
+    unsigned getHostMinorProtocol (
+        epicsGuard < epicsMutex > &) const throw ();
     void writeException (
         epicsGuard < epicsMutex > &, epicsGuard < epicsMutex > &,
         int status, const char *pContext, unsigned type, arrayElementCount count );

--- a/modules/ca/src/client/netiiu.cpp
+++ b/modules/ca/src/client/netiiu.cpp
@@ -116,6 +116,12 @@ const char * netiiu::pHostName (
     return pHostNameNetIIU;
 }
 
+unsigned netiiu::getHostMinorProtocol ( 
+    epicsGuard < epicsMutex > & ) const throw ()
+{
+    return 0u;
+}
+
 osiSockAddr netiiu::getNetworkAddress (
     epicsGuard < epicsMutex > & ) const
 {

--- a/modules/ca/src/client/netiiu.cpp
+++ b/modules/ca/src/client/netiiu.cpp
@@ -119,7 +119,7 @@ const char * netiiu::pHostName (
 unsigned netiiu::getHostMinorProtocol ( 
     epicsGuard < epicsMutex > & ) const throw ()
 {
-    return 0u;
+  return CA_UKN_MINOR_VERSION;
 }
 
 osiSockAddr netiiu::getNetworkAddress (

--- a/modules/ca/src/client/netiiu.h
+++ b/modules/ca/src/client/netiiu.h
@@ -43,6 +43,8 @@ public:
         unsigned bufLength ) const throw () = 0;
     virtual const char * pHostName (
         epicsGuard < epicsMutex > & ) const throw () = 0;
+    virtual unsigned getHostMinorProtocol ( 
+        epicsGuard < epicsMutex > & ) const throw ();
     virtual bool ca_v41_ok (
         epicsGuard < epicsMutex > & ) const = 0;
     virtual bool ca_v42_ok (

--- a/modules/ca/src/client/oldAccess.h
+++ b/modules/ca/src/client/oldAccess.h
@@ -64,6 +64,8 @@ public:
         chid pChan, char * pBuf, unsigned bufLength );
     friend const char * epicsStdCall ca_host_name (
         chid pChan );
+    friend unsigned epicsStdCall ca_host_minor_protocol (
+        chid pChan );
     friend const char * epicsStdCall ca_name (
         chid pChan );
     friend void epicsStdCall ca_set_puser (

--- a/modules/ca/src/client/oldChannelNotify.cpp
+++ b/modules/ca/src/client/oldChannelNotify.cpp
@@ -194,6 +194,16 @@ const char * epicsStdCall ca_host_name (
 }
 
 /*
+ * ca_host_minorProtocol ()
+ */
+unsigned epicsStdCall ca_host_minor_protocol (
+    chid pChan )
+{
+    epicsGuard < epicsMutex > guard ( pChan->cacCtx.mutexRef () );
+    return pChan->io.getHostMinorProtocol( guard );
+}
+
+/*
  * ca_set_puser ()
  */
 void epicsStdCall ca_set_puser (

--- a/modules/ca/src/client/tcpiiu.cpp
+++ b/modules/ca/src/client/tcpiiu.cpp
@@ -1804,6 +1804,13 @@ const char * tcpiiu::pHostName (
     return this->hostNameCacheInstance.pointer ();
 }
 
+unsigned tcpiiu::getHostMinorProtocol ( 
+    epicsGuard < epicsMutex > & guard) const throw ()
+{   
+    guard.assertIdenticalMutex ( this->mutex );
+    return this->minorProtocolVersion;
+}
+
 void tcpiiu::disconnectAllChannels (
     epicsGuard < epicsMutex > & cbGuard,
     epicsGuard < epicsMutex > & guard,

--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -1342,6 +1342,12 @@ const char * udpiiu::pHostName (
     return netiiu::pHostName ( cacGuard );
 }
 
+unsigned udpiiu::getHostMinorProtocol ( 
+    epicsGuard < epicsMutex > & cacGuard ) const throw ()
+{
+    return netiiu::getHostMinorProtocol ( cacGuard );
+}
+
 bool udpiiu::ca_v42_ok (
     epicsGuard < epicsMutex > & cacGuard ) const
 {

--- a/modules/ca/src/client/udpiiu.h
+++ b/modules/ca/src/client/udpiiu.h
@@ -239,7 +239,9 @@ private:
         unsigned bufLength ) const throw ();
     const char * pHostName (
         epicsGuard < epicsMutex > & ) const throw ();
-        bool ca_v41_ok (
+    unsigned getHostMinorProtocol ( 
+        epicsGuard < epicsMutex > & ) const throw ();
+    bool ca_v41_ok (
         epicsGuard < epicsMutex > & ) const;
     bool ca_v42_ok (
         epicsGuard < epicsMutex > & ) const;

--- a/modules/ca/src/client/virtualCircuit.h
+++ b/modules/ca/src/client/virtualCircuit.h
@@ -168,6 +168,8 @@ public:
     unsigned getHostName (
         epicsGuard < epicsMutex > &,
         char *pBuf, unsigned bufLength ) const throw ();
+    unsigned getHostMinorProtocol ( 
+        epicsGuard < epicsMutex > &) const throw ();
     bool alive (
         epicsGuard < epicsMutex > & ) const;
     bool connecting (


### PR DESCRIPTION
Adds a call to the CA client API that allows a client to determine the server's protocol minor version number. This is needed to allow the ca-nameserver to report a server's protocol version correctly to a client.