### PR TITLE
Use OP_SYS_LDFLAGS for -Wl,--gc-sections

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS-beagleboneblack
+++ b/configure/os/CONFIG.Common.RTEMS-beagleboneblack
@@ -9,7 +9,7 @@ RTEMS_BSP = beagleboneblack
 RTEMS_TARGET_CPU = arm
 GNU_TARGET = arm-rtems
 
-OP_SYS_LDLIBS += -Wl,--gc-sections
+OP_SYS_LDFLAGS += -Wl,--gc-sections
 ARCH_DEP_LDFLAGS = -L$(RTEMS_BASE)/$(GNU_TARGET)$(RTEMS_VERSION)/beagleboneblack/lib/
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS

--- a/configure/os/CONFIG.Common.RTEMS-pc686
+++ b/configure/os/CONFIG.Common.RTEMS-pc686
@@ -20,7 +20,6 @@ define MUNCH_CMD
 	$(RTEMS_TOOLS)/bin/$(OBJCOPY_FOR_TARGET) -O binary -R .comment -S $< $@ 
 endef
 
-OP_SYS_LDLIBS += -Wl,--gc-sections
 ARCH_DEP_LDFLAGS = -L$(RTEMS_BASE)/$(GNU_TARGET)$(RTEMS_VERSION)/pc686/lib/
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS
@@ -28,7 +27,7 @@ include $(CONFIG)/os/CONFIG.Common.RTEMS
 #
 # Put text segment where it will work with etherboot
 #
-OP_SYS_LDFLAGS += -Wl,-Ttext,0x100000
+OP_SYS_LDFLAGS += -Wl,-Ttext,0x100000 -Wl,--gc-sections
 
 
 # This check must appear after the above include

--- a/configure/os/CONFIG.Common.RTEMS-qoriq_e500
+++ b/configure/os/CONFIG.Common.RTEMS-qoriq_e500
@@ -20,7 +20,7 @@ ARCH_DEP_CFLAGS += -DRTEMS_HAS_ALTIVEC
 #ARCH_DEP_CFLAGS += -I$(RTEMS_BASE)/powerpc-rtems5/qoriq_e500/lib/include
 
 #OP_SYS_LDLIBS += -lbspExt #does not use posix stuff ... want to ignore
-OP_SYS_LDLIBS += -Wl,--gc-sections
+OP_SYS_LDFLAGS += -Wl,--gc-sections
 #ARCH_DEP_LDFLAGS = -mcpu=8540 -meabi -msdata=sysv -mstrict-align -mspe -mabi=spe -mfloat-gprs=double 
 ARCH_DEP_LDFLAGS = -L$(RTEMS_BASE)/$(GNU_TARGET)$(RTEMS_VERSION)/$(RTEMS_BSP)/lib
 

--- a/configure/os/CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu
+++ b/configure/os/CONFIG.Common.RTEMS-xilinx_zynq_a9_qemu
@@ -12,7 +12,7 @@ GNU_TARGET = arm-rtems
 #use dhcp/bootp
 ARCH_DEP_CFLAGS += -DMY_DO_BOOTP=NULL
 
-OP_SYS_LDLIBS += -Wl,--gc-sections
+OP_SYS_LDFLAGS += -Wl,--gc-sections
 ARCH_DEP_LDFLAGS = -L$(RTEMS_BASE)/$(GNU_TARGET)$(RTEMS_VERSION)/xilinx_zynq_a9_qemu/lib/
 
 

--- a/configure/os/CONFIG.Common.RTEMS-xilinx_zynq_zedboard
+++ b/configure/os/CONFIG.Common.RTEMS-xilinx_zynq_zedboard
@@ -9,7 +9,7 @@ RTEMS_BSP = xilinx_zynq_zedboard
 RTEMS_TARGET_CPU = arm
 GNU_TARGET = arm-rtems
 
-OP_SYS_LDLIBS += -Wl,--gc-sections
+OP_SYS_LDFLAGS += -Wl,--gc-sections
 ARCH_DEP_LDFLAGS = -L$(RTEMS_BASE)/$(GNU_TARGET)$(RTEMS_VERSION)/xilinx_zynq_zedboard/lib/
 
 


### PR DESCRIPTION
OP_SYS_LDLIBS ends up on the GeSys object link command line, which ends up breaking things. When linking GeSys objects, a symbol root is not defined using -u or -e, which is required for --gc-sections to work.

I'm not sure why `-Wl,--gc-sections` was added to `OP_SYS_LDLIBS` in the first place, but switching that over to `OP_SYS_LDFLAGS` seems to work fine. I've only tested with the RTEMS-pc686 target though.