### PR TITLE
windows cl does not accept designated initializers before c++20

### DIFF
--- a/modules/libcom/src/fdmgr/fdManager.cpp
+++ b/modules/libcom/src/fdmgr/fdManager.cpp
@@ -187,18 +187,11 @@ LIBCOM_API void fdManager::process(double delay)
         ++ioPending;
 
 #ifdef FDMGR_USE_POLL
-#if __cplusplus >= 201100L
-        priv->pollfds.emplace_back(pollfd{
-            .fd = iter->getFD(),
-            .events = WIN_POLLEVENT_FILTER(PollEvents[iter->getType()])
-        });
-#else
         struct pollfd pollfd;
         pollfd.fd = iter->getFD();
         pollfd.events = WIN_POLLEVENT_FILTER(PollEvents[iter->getType()]);
         pollfd.revents = 0;
         priv->pollfds.push_back(pollfd);
-#endif
 #endif
 
 #ifdef FDMGR_USE_SELECT


### PR DESCRIPTION
If and only if the Windows `cl` compiler is used with the flag `/Zc:__cplusplus`, it defines the macro `__cplusplus` correctly according to the used C++ standard. (https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170)
Normally (as used in the standard EPICS config files) it will always define `__cplusplus` as `199711L`, even though the default standard is c++14, which disables all `#if __cplusplus>=201103L` code blocks in EPICS.

fdManager uses such a code block but when using  `/Zc:__cplusplus` Windows complains with the error message:
```
fdManager.cpp(192): error C7555: use of designated initializers requires at least '/std:c++20'
```
Both, gcc and clang, understand the used syntax from C++11 on, but I cannot be sure if any other c++ compiler (not only cl) does.
Solution: Remove the preprocessor branch and leave optimizations to the compiler.