### PR TITLE
Implement epicsMessageQueueSend/epicsMessageQueueReceive to resolve link error

### DIFF
--- a/modules/libcom/src/osi/os/RTEMS-posix/osdMessageQueue.c
+++ b/modules/libcom/src/osi/os/RTEMS-posix/osdMessageQueue.c
@@ -74,6 +74,22 @@ LIBCOM_API void epicsStdCall epicsMessageQueueDestroy(
   free(id);
 }
 
+LIBCOM_API int epicsStdCall epicsMessageQueueSend(
+        epicsMessageQueueId id,
+        void *message,
+        unsigned int messageSize)
+{
+    return mq_send(id->id, (const char*)message, messageSize, 0);
+}
+
+LIBCOM_API int epicsStdCall epicsMessageQueueReceive(
+        epicsMessageQueueId id,
+        void *message,
+        unsigned int messageSize)
+{
+    return mq_receive(id->id, (char*)message, messageSize, NULL);
+}
+
 
 LIBCOM_API int epicsStdCall epicsMessageQueueTrySend(
     epicsMessageQueueId id,

--- a/modules/libcom/src/osi/os/RTEMS-posix/osdMessageQueue.h
+++ b/modules/libcom/src/osi/os/RTEMS-posix/osdMessageQueue.h
@@ -23,6 +23,4 @@ struct epicsMessageQueueOSD {
     mqd_t   id;
     char    name[24];
 };
-#define epicsMessageQueueSend(q,m,l) (mq_send((q)->id, (const char*)(m), (l), 0))
-#define epicsMessageQueueReceive(q,m,s) (mq_receive((q)->id, (char*)(m), (s), NULL))
 


### PR DESCRIPTION
These were defined as macros in the RTEMS `osdMessageQueue.h`, but declared as function prototypes in the `epicsMessageQueue.h` public header. We need to implement them as C functions for these to actually be usable.