### PR TITLE
Move all EPICS_IOC_LOG related env vars to CONFIG_SITE_ENV

### DIFF
--- a/configure/CONFIG_ENV
+++ b/configure/CONFIG_ENV
@@ -49,9 +49,5 @@ EPICS_CAS_IGNORE_ADDR_LIST=""
 # Servers to disable
 EPICS_IOC_IGNORE_SERVERS=""
 
-# Log Server:
-# EPICS_IOC_LOG_PORT Log server port number etc.
-EPICS_IOC_LOG_PORT=7004
-
 # Posix priority scheduling
 EPICS_ALLOW_POSIX_THREAD_PRIORITY_SCHEDULING=YES

--- a/configure/CONFIG_SITE_ENV
+++ b/configure/CONFIG_SITE_ENV
@@ -76,6 +76,8 @@ IOCSH_HISTSIZE=50
 IOCSH_HISTEDIT_DISABLE=
 
 # Log Server:
+# EPICS_IOC_LOG_PORT 
+#	Log server port number etc.
 # EPICS_IOC_LOG_INET 
 #	Log server ip addr.
 # EPICS_IOC_LOG_FILE_NAME 
@@ -87,6 +89,7 @@ IOCSH_HISTEDIT_DISABLE=
 #       path name in response to SIGHUP - the new path name will
 #       replace any path name supplied in EPICS_IOC_LOG_FILE_NAME
 
+EPICS_IOC_LOG_PORT=7004
 EPICS_IOC_LOG_INET=
 EPICS_IOC_LOG_FILE_NAME=
 EPICS_IOC_LOG_FILE_COMMAND=


### PR DESCRIPTION
This PR was written in case maintainers are in agreement with my suggestion in #728. In practice, AFAIK, this should not change any functionality of epics-base, but I do think it makes more sense in terms of organization.

(But, also, selfishly, it'll make using iocStats a bit easier for me).