### PR TITLE
Ci win cplusplus

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -171,19 +171,6 @@ jobs:
             name: "Win-22 MSC-22 c++17"
             extra: "CMD_CXXFLAGS='-analyze -Zc:__cplusplus -std:c++17'"
 
-# pvData does not build with MVSC c++20
-#          - os: windows-2022
-#            cmp: vs2022
-#            configuration: debug
-#            name: "Win-22 MSC-22 c++20"
-#            extra: "CMD_CXXFLAGS='-analyze -Zc:__cplusplus -std:c++20'"
-#
-#          - os: windows-2022
-#            cmp: vs2022
-#            configuration: debug
-#            name: "Win-22 MSC-22 c++latest"
-#            extra: "CMD_CXXFLAGS='-analyze -Zc:__cplusplus -std:c++latest'"
-
           - os: windows-2022
             cmp: vs2022
             configuration: static-debug

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -157,13 +157,13 @@ jobs:
             cmp: vs2022
             configuration: debug
             name: "Win-22 MSC-22"
-            extra: "CMD_CXXFLAGS=-analysis"
+            extra: "CMD_CXXFLAGS=-analyze"
 
           - os: windows-2022
             cmp: vs2022
             configuration: static-debug
             name: "Win-22 MSC-22, static"
-            extra: "CMD_CXXFLAGS=-analysis"
+            extra: "CMD_CXXFLAGS=-analyze"
 
           - os: windows-2022
             cmp: vs2022

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -161,6 +161,31 @@ jobs:
 
           - os: windows-2022
             cmp: vs2022
+            configuration: debug
+            name: "Win-22 MSC-22 c++14"
+            extra: "CMD_CXXFLAGS='-analyze -Zc:__cplusplus -std:c++17'"
+
+          - os: windows-2022
+            cmp: vs2022
+            configuration: debug
+            name: "Win-22 MSC-22 c++17"
+            extra: "CMD_CXXFLAGS='-analyze -Zc:__cplusplus -std:c++17'"
+
+# pvData does not build with MVSC c++20
+#          - os: windows-2022
+#            cmp: vs2022
+#            configuration: debug
+#            name: "Win-22 MSC-22 c++20"
+#            extra: "CMD_CXXFLAGS='-analyze -Zc:__cplusplus -std:c++20'"
+#
+#          - os: windows-2022
+#            cmp: vs2022
+#            configuration: debug
+#            name: "Win-22 MSC-22 c++latest"
+#            extra: "CMD_CXXFLAGS='-analyze -Zc:__cplusplus -std:c++latest'"
+
+          - os: windows-2022
+            cmp: vs2022
             configuration: static-debug
             name: "Win-22 MSC-22, static"
             extra: "CMD_CXXFLAGS=-analyze"


### PR DESCRIPTION
New ci builds for Windows using option [`-Zc:__cplusplus`](https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170):
  * -std:c++14 (the default)
  * -std:c++17
  * [currently commented out](https://github.com/epics-base/pvDataCPP/issues/99): -std:c++20
  * currently commented out: [-std:c++latest](https://learn.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=msvc-170#stdclatest)

Additionally, I have changed the [unknown (probably misspelled) command line option `-analysis`](https://github.com/epics-base/epics-base/issues/720) to [`-analyze`](https://learn.microsoft.com/en-us/cpp/build/reference/analyze-code-analysis?view=msvc-170).

