### PR TITLE
fix gcc version 11+ problem with epicsGuardRelease

### DIFF
--- a/modules/libcom/src/cxxTemplates/epicsGuard.h
+++ b/modules/libcom/src/cxxTemplates/epicsGuard.h
@@ -169,6 +169,12 @@ inline epicsGuardRelease < T > ::
     // runs and an epicsGuardRelease is still referencing
     // the guard will be detected.
     _guard._pTargetMutex = 0;
+#ifdef __GNUC__
+    // Prevent some strange gcc warning "this pointer is null"
+    // When epicsGuardRelease and epicsGuard go out of scope
+    // directly one after the other
+    asm volatile ("" ::: "memory");
+#endif
     _pTargetMutex->unlock ();
 }
 


### PR DESCRIPTION
Need software memory barrier to prevent gcc from emitting "this pointer is null" warning when epicsGuardRelease and epicsGuard go out of scope directly one after the other as seen in [pvAccessCPP](https://github.com/epics-base/pvAccessCPP/issues/207).

