### PR TITLE
Draft: Always include EPICS base "module" configuration files

### DIFF
--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -76,7 +76,7 @@ RELEASE_TOPS := $(shell $(CONVERTRELEASE) -T $(TOP) releaseTops)
 ifdef T_A
   # Information from the target's compiler
   #
-  -include $(EPICS_BASE)/cfg/TOOLCHAIN.$(EPICS_HOST_ARCH).$(T_A)
+  -include $(CONFIG)/TOOLCHAIN.$(EPICS_HOST_ARCH).$(T_A)
 
   #  Cross compile specific definitions
   #
@@ -117,6 +117,15 @@ ifneq ($(CONFIG),$(TOP)/configure)
     include $(RELEASE_CFG_CONFIGS)
   endif
 endif
+
+include $(CONFIG)/CONFIG_LIBCOM_MODULE
+include $(CONFIG)/CONFIG_LIBCOM_VERSION
+
+include $(CONFIG)/CONFIG_CA_MODULE
+include $(CONFIG)/CONFIG_CA_VERSION
+
+include $(CONFIG)/CONFIG_DATABASE_MODULE
+include $(CONFIG)/CONFIG_DATABASE_VERSION
 
 # Include $(INSTALL_CFG)/CONFIG* definitions
 #

--- a/configure/Makefile
+++ b/configure/Makefile
@@ -21,16 +21,7 @@ CONFIGS += $(subst ../,,$(wildcard ../os/CONFIG_SITE.*))
 CONFIGS += $(subst ../,,$(wildcard ../RELEASE*))
 CONFIGS += $(subst ../,,$(wildcard ../RULES*))
 
-CFG += CONFIG_LIBCOM_MODULE
-CFG += CONFIG_LIBCOM_VERSION
-
-CFG += CONFIG_CA_MODULE
-CFG += CONFIG_CA_VERSION
-
-CFG += CONFIG_DATABASE_MODULE
-CFG += CONFIG_DATABASE_VERSION
-
-CFG += TOOLCHAIN.$(EPICS_HOST_ARCH).$(T_A)
+CONFIGS += TOOLCHAIN.$(EPICS_HOST_ARCH).$(T_A)
 
 include $(TOP)/configure/RULES
 


### PR DESCRIPTION
EPICS base offers a path to install custom configuration files using the `CFG` variable. This is also used to install a few files from the EPICS build system. However, this setup provides a source of conflict between EPICS base and any modules that want to do this.

Since the EPICS cfg files are always included (EPICS_BASE must be defined in RELEASE), it makes sense to simply install these as regular configuration files instead of cfg/ files.

Resolves #724 