### PR TITLE
added __attribute__((__malloc__)) for gcc and clang

### DIFF
--- a/modules/libcom/src/misc/cantProceed.h
+++ b/modules/libcom/src/misc/cantProceed.h
@@ -67,7 +67,7 @@ void cantProceed(
  * Will never return NULL otherwise.
  */
 LIBCOM_API void * callocMustSucceed(size_t count, size_t size,
-    const char *errorMessage);
+    const char *errorMessage) EPICS_MALLOC(1,2);
 /** \brief A malloc() which suspends on error.
  * \param size Size of block to allocate.
  * \param errorMessage Context added to logged error message
@@ -76,7 +76,8 @@ LIBCOM_API void * callocMustSucceed(size_t count, size_t size,
  * Will always return NULL for a zero length allocation.
  * Will never return NULL otherwise.
  */
-LIBCOM_API void * mallocMustSucceed(size_t size, const char *errorMessage);
+LIBCOM_API void * mallocMustSucceed(size_t size, const char *errorMessage)
+    EPICS_MALLOC(1);
 /** @} */
 
 #ifdef __cplusplus

--- a/modules/libcom/src/osi/compiler/clang/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/clang/compilerSpecific.h
@@ -63,4 +63,9 @@
  */
 #define EPICS_NORETURN __attribute__((noreturn))
 
+/*
+ * malloc marker takes 1 or 2 args: (index of size) or (index of count, index of element size)
+ */
+#define EPICS_MALLOC(...) __attribute__((__malloc__, __alloc_size__(__VA_ARGS__)))
+
 #endif  /* ifndef compilerSpecific_h */

--- a/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
+++ b/modules/libcom/src/osi/compiler/gcc/compilerSpecific.h
@@ -69,4 +69,13 @@
 #define EPICS_NORETURN __attribute__((noreturn))
 #endif
 
+/*
+ * malloc marker takes 1 or 2 args: (index of size) or (index of count, index of element size)
+ */
+#if __GNUC__ * 100 + __GNUC_MINOR__  >= 403
+#define EPICS_MALLOC(...) __attribute__((__malloc__, __alloc_size__(__VA_ARGS__)))
+#else
+#define EPICS_MALLOC(...) __attribute__((__malloc__))
+#endif
+
 #endif  /* ifndef compilerSpecific_h */

--- a/modules/libcom/src/osi/compilerDependencies.h
+++ b/modules/libcom/src/osi/compilerDependencies.h
@@ -56,6 +56,10 @@
 #   define EPICS_NORETURN
 #endif
 
+#ifndef EPICS_MALLOC
+#   define EPICS_MALLOC(...)
+#endif
+
 #ifndef EPICS_FUNCTION
 #if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901)) || (defined(__cplusplus) && __cplusplus>=201103L)
 #  define EPICS_FUNCTION __func__


### PR DESCRIPTION
The macro `EPICS_MALLOC` expands to `__attribute__((__malloc__))` for gcc and clang.
It is used to mark `mallocMustSucceed()` and `callocMustSucceed()`.