### PR TITLE
Fix gcc warning 'stringop-truncation'

### DIFF
--- a/modules/ca/src/perl/Cap5.xs
+++ b/modules/ca/src/perl/Cap5.xs
@@ -613,6 +613,7 @@ void CA_put(SV *ca_ref, SV *val, ...) {
                 break;
             case DBF_STRING:
                 strncpy(data.dbr_string, SvPV_nolen(val), MAX_STRING_SIZE);
+                data.dbr_string[MAX_STRING_SIZE-1] = 0;
                 break;
             }
             status = ca_put(type, pch->chan, &data);
@@ -705,6 +706,7 @@ void CA_put_callback(SV *ca_ref, SV *sub, SV *val, ...) {
                 break;
             case DBF_STRING:
                 strncpy(data.dbr_string, SvPV_nolen(val), MAX_STRING_SIZE);
+                data.dbr_string[MAX_STRING_SIZE-1] = 0;
                 break;
             }
 

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -365,13 +365,14 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
         }
         if( (*options) & DBR_AMSG ) {
             if (!pfl) {
-                STATIC_ASSERT(sizeof(pcommon->amsg)==sizeof(pfl->amsg));
-                strncpy(pbuffer, pcommon->amsg, sizeof(pcommon->amsg)-1);
+                STATIC_ASSERT(sizeof(pcommon->amsg)==DB_AMSG_SIZE);
+                strncpy(pbuffer, pcommon->amsg, DB_AMSG_SIZE);
             } else {
-                strncpy(pbuffer, pfl->amsg,sizeof(pfl->amsg)-1);
+                STATIC_ASSERT(sizeof(pfl->amsg)==DB_AMSG_SIZE);
+                strncpy(pbuffer, pfl->amsg, DB_AMSG_SIZE);
             }
-            pbuffer[sizeof(pcommon->amsg)-1] = '\0';
-            pbuffer += sizeof(pcommon->amsg);
+            pbuffer[DB_AMSG_SIZE-1] = '\0';
+            pbuffer += DB_AMSG_SIZE;
         }
         if( (*options) & DBR_UNITS ) {
             memset(pbuffer,'\0',dbr_units_size);
@@ -851,7 +852,7 @@ static long getLinkValue(DBADDR *paddr, short dbrType,
     {
         const char *rtnString = dbGetString(&dbEntry);
 
-        strncpy(pbuf, rtnString, maxlen-1);
+        strncpy(pbuf, rtnString, maxlen);
         pbuf[maxlen-1] = 0;
         if(dbrType!=DBR_STRING)
             nReq = strlen(pbuf)+1;

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -743,8 +743,8 @@ static long dbAddOnePath (DBBASE *pdbbase, const char *path, unsigned length)
     ppathList = (ELLLIST *)pdbbase->pathPvt;
 
     pdbPathNode = (dbPathNode *)dbCalloc(1, sizeof(dbPathNode));
-    pdbPathNode->directory = (char *)dbCalloc(length+1, sizeof(char));
-    strncpy(pdbPathNode->directory, path, length);
+    pdbPathNode->directory = (char *)dbMalloc(length+1);
+    memcpy(pdbPathNode->directory, path, length);
     pdbPathNode->directory[length] = '\0';
     ellAdd(ppathList, &pdbPathNode->node);
     return 0;

--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -863,7 +863,7 @@ cvtArg (const char *filename, int lineno, char *arg, iocshArgBuf *argBuf,
                 showError(filename, lineno, ANSI_RED("Out of memory!"));
                 return 0;
             }
-            strncpy(argBuf->sval, arg, slen);
+            memcpy(argBuf->sval, arg, slen + 1);
         } else {
           argBuf->sval = NULL;
         }

--- a/modules/libcom/src/osi/epicsTime.cpp
+++ b/modules/libcom/src/osi/epicsTime.cpp
@@ -256,7 +256,7 @@ size_t epicsStdCall epicsTimeToStrftime (char *pBuff, size_t bufLength, const ch
                     if ( tmpLen >= bufLenLeft ) {
                         tmpLen = bufLenLeft - 1;
                     }
-                    strncpy ( pBufCur, pOVF, tmpLen );
+                    memcpy ( pBufCur, pOVF, tmpLen );
                     pBufCur[tmpLen] = '\0';
                     pBufCur += tmpLen;
                     bufLenLeft -= tmpLen;
@@ -268,7 +268,7 @@ size_t epicsStdCall epicsTimeToStrftime (char *pBuff, size_t bufLength, const ch
                 if ( tmpLen >= bufLenLeft ) {
                     tmpLen = bufLenLeft - 1;
                 }
-                strncpy ( pBufCur, pDoesntFit, tmpLen );
+                memcpy ( pBufCur, pDoesntFit, tmpLen );
                 pBufCur[tmpLen] = '\0';
                 pBufCur += tmpLen;
                 bufLenLeft -= tmpLen;

--- a/modules/libcom/src/osi/osiSock.c
+++ b/modules/libcom/src/osi/osiSock.c
@@ -73,7 +73,7 @@ unsigned epicsStdCall sockAddrToA (
             return len;
         }
         else {
-            strncpy ( pBuf, "<Ukn Addr Type>", bufSize-1 );
+            memcpy ( pBuf, pErrStr, bufSize-1 );
             pBuf[bufSize-1] = '\0';
             return bufSize-1;
         }

--- a/modules/libcom/test/epicsStackTraceTest.c
+++ b/modules/libcom/test/epicsStackTraceTest.c
@@ -93,7 +93,7 @@ static void logClient(void *ptr, const char *msg)
 
     if ( sz > mx )
         sz = mx;
-    strncpy( td->buf+td->pos, msg, sz );
+    memcpy( td->buf+td->pos, msg, sz );
     td->pos += sz;
 }
 


### PR DESCRIPTION
* When using `strncpy()`, always use full `length` (not `length-1`) and set `target_string[length-1] = 0;` immediately afterwards.
* Do not use `sizeof(source)`
* Use `memcpy()` instead if possible, e.g. if `strlen()` had been used before to calculate `length`.