### PR TITLE
fix clang warning missing-braces

### DIFF
--- a/modules/libcom/test/fdManagerTest.cpp
+++ b/modules/libcom/test/fdManagerTest.cpp
@@ -73,7 +73,7 @@ public:
     }
     osiSockAddr bind()
     {
-        osiSockAddr addr = {0};
+        osiSockAddr addr = {{0}};
         addr.ia.sin_family = AF_INET;
         addr.ia.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 


### PR DESCRIPTION
```
../fdManagerTest.cpp:76:29: warning: suggest braces around initialization of subobject [-Wmissing-braces]
   76 |         osiSockAddr addr = {0};
      |                             ^
      |                             {}
```