### PR TITLE
fix(aao, aai): change VAL field type from DOUBLE[] to FTVL[]

### DIFF
--- a/modules/database/src/std/rec/aSubRecord.dbd.pod
+++ b/modules/database/src/std/rec/aSubRecord.dbd.pod
@@ -353,7 +353,7 @@ INPA,...,INPU.
 		extra("void *a")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTA
+		#=type Set by FTA[NOA]
 	}
 	field(B,DBF_NOACCESS) {
 		prompt("Input value B")
@@ -363,7 +363,7 @@ INPA,...,INPU.
 		extra("void *b")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTB
+		#=type Set by FTB[NOB]
 	}
 	field(C,DBF_NOACCESS) {
 		prompt("Input value C")
@@ -373,7 +373,7 @@ INPA,...,INPU.
 		extra("void *c")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTC
+		#=type Set by FTC[NOC]
 	}
 	field(D,DBF_NOACCESS) {
 		prompt("Input value D")
@@ -383,7 +383,7 @@ INPA,...,INPU.
 		extra("void *d")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTD
+		#=type Set by FTD[NOD]
 	}
 	field(E,DBF_NOACCESS) {
 		prompt("Input value E")
@@ -393,7 +393,7 @@ INPA,...,INPU.
 		extra("void *e")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTE
+		#=type Set by FTE[NOE]
 	}
 	field(F,DBF_NOACCESS) {
 		prompt("Input value F")
@@ -403,7 +403,7 @@ INPA,...,INPU.
 		extra("void *f")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTF
+		#=type Set by FTF[NOF]
 	}
 	field(G,DBF_NOACCESS) {
 		prompt("Input value G")
@@ -413,7 +413,7 @@ INPA,...,INPU.
 		extra("void *g")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTG
+		#=type Set by FTG[NOG]
 	}
 	field(H,DBF_NOACCESS) {
 		prompt("Input value H")
@@ -423,7 +423,7 @@ INPA,...,INPU.
 		extra("void *h")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTH
+		#=type Set by FTH[NOH]
 	}
 	field(I,DBF_NOACCESS) {
 		prompt("Input value I")
@@ -433,7 +433,7 @@ INPA,...,INPU.
 		extra("void *i")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTI
+		#=type Set by FTI[NOI]
 	}
 	field(J,DBF_NOACCESS) {
 		prompt("Input value J")
@@ -443,7 +443,7 @@ INPA,...,INPU.
 		extra("void *j")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTJ
+		#=type Set by FTJ[NOJ]
 	}
 	field(K,DBF_NOACCESS) {
 		prompt("Input value K")
@@ -453,7 +453,7 @@ INPA,...,INPU.
 		extra("void *k")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTK
+		#=type Set by FTK[NOK]
 	}
 	field(L,DBF_NOACCESS) {
 		prompt("Input value L")
@@ -463,7 +463,7 @@ INPA,...,INPU.
 		extra("void *l")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTL
+		#=type Set by FTL[NOL]
 	}
 	field(M,DBF_NOACCESS) {
 		prompt("Input value M")
@@ -473,7 +473,7 @@ INPA,...,INPU.
 		extra("void *m")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTM
+		#=type Set by FTM[NOM]
 	}
 	field(N,DBF_NOACCESS) {
 		prompt("Input value N")
@@ -483,7 +483,7 @@ INPA,...,INPU.
 		extra("void *n")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTN
+		#=type Set by FTN[NON]
 	}
 	field(O,DBF_NOACCESS) {
 		prompt("Input value O")
@@ -493,7 +493,7 @@ INPA,...,INPU.
 		extra("void *o")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTO
+		#=type Set by FTO[NOO]
 	}
 	field(P,DBF_NOACCESS) {
 		prompt("Input value P")
@@ -503,7 +503,7 @@ INPA,...,INPU.
 		extra("void *p")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTP
+		#=type Set by FTP[NOP]
 	}
 	field(Q,DBF_NOACCESS) {
 		prompt("Input value Q")
@@ -513,7 +513,7 @@ INPA,...,INPU.
 		extra("void *q")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTQ
+		#=type Set by FTQ[NOQ]
 	}
 	field(R,DBF_NOACCESS) {
 		prompt("Input value R")
@@ -523,7 +523,7 @@ INPA,...,INPU.
 		extra("void *r")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTR
+		#=type Set by FTR[NOR]
 	}
 	field(S,DBF_NOACCESS) {
 		prompt("Input value S")
@@ -533,7 +533,7 @@ INPA,...,INPU.
 		extra("void *s")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTS
+		#=type Set by FTS[NOS]
 	}
 	field(T,DBF_NOACCESS) {
 		prompt("Input value T")
@@ -543,7 +543,7 @@ INPA,...,INPU.
 		extra("void *t")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTT
+		#=type Set by FTT[NOT]
 	}
 	field(U,DBF_NOACCESS) {
 		prompt("Input value U")
@@ -553,7 +553,7 @@ INPA,...,INPU.
 		extra("void *u")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTU
+		#=type Set by FTU[NOU]
 	}
 
 =head3 Input Value Data Types
@@ -2378,7 +2378,7 @@ record can locate them.  The simplest way is as follows:
 
     #include <registryFunction.h>
     #include <epicsExport.h>
-    
+
     static long my_asub_routine(aSubRecord *prec) {
         ...
     }

--- a/modules/database/src/std/rec/aSubRecord.dbd.pod
+++ b/modules/database/src/std/rec/aSubRecord.dbd.pod
@@ -1161,7 +1161,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *vala")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVA
+		#=type Set by FTVA[NOVA]
 	}
 	field(VALB,DBF_NOACCESS) {
 		prompt("Output value B")
@@ -1171,7 +1171,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valb")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVB
+		#=type Set by FTVB[NOVB]
 	}
 	field(VALC,DBF_NOACCESS) {
 		prompt("Output value C")
@@ -1181,7 +1181,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valc")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVC
+		#=type Set by FTVC[NOVC]
 	}
 	field(VALD,DBF_NOACCESS) {
 		prompt("Output value D")
@@ -1191,7 +1191,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *vald")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVD
+		#=type Set by FTVD[NOVD]
 	}
 	field(VALE,DBF_NOACCESS) {
 		prompt("Output value E")
@@ -1201,7 +1201,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *vale")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVE
+		#=type Set by FTVE[NOVE]
 	}
 	field(VALF,DBF_NOACCESS) {
 		prompt("Output value F")
@@ -1211,7 +1211,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valf")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVF
+		#=type Set by FTVF[NOVF]
 	}
 	field(VALG,DBF_NOACCESS) {
 		prompt("Output value G")
@@ -1221,7 +1221,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valg")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVG
+		#=type Set by FTVG[NOVG]
 	}
 	field(VALH,DBF_NOACCESS) {
 		prompt("Output value H")
@@ -1231,7 +1231,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valh")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVH
+		#=type Set by FTVH[NOVH]
 	}
 	field(VALI,DBF_NOACCESS) {
 		prompt("Output value I")
@@ -1241,7 +1241,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *vali")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVI
+		#=type Set by FTVI[NOVI]
 	}
 	field(VALJ,DBF_NOACCESS) {
 		prompt("Output value J")
@@ -1251,7 +1251,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valj")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVJ
+		#=type Set by FTVJ[NOVJ]
 	}
 	field(VALK,DBF_NOACCESS) {
 		prompt("Output value K")
@@ -1261,7 +1261,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valk")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVK
+		#=type Set by FTVK[NOVK]
 	}
 	field(VALL,DBF_NOACCESS) {
 		prompt("Output value L")
@@ -1271,7 +1271,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *vall")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVL
+		#=type Set by FTVL[NOVL]
 	}
 	field(VALM,DBF_NOACCESS) {
 		prompt("Output value M")
@@ -1281,7 +1281,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valm")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVM
+		#=type Set by FTVM[NOVM]
 	}
 	field(VALN,DBF_NOACCESS) {
 		prompt("Output value N")
@@ -1291,7 +1291,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valn")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVN
+		#=type Set by FTVN[NOVN]
 	}
 	field(VALO,DBF_NOACCESS) {
 		prompt("Output value O")
@@ -1301,7 +1301,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valo")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVO
+		#=type Set by FTVO[NOVO]
 	}
 	field(VALP,DBF_NOACCESS) {
 		prompt("Output value P")
@@ -1311,7 +1311,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valp")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVP
+		#=type Set by FTVP[NOVP]
 	}
 	field(VALQ,DBF_NOACCESS) {
 		prompt("Output value Q")
@@ -1321,7 +1321,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valq")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVQ
+		#=type Set by FTVQ[NOVQ]
 	}
 	field(VALR,DBF_NOACCESS) {
 		prompt("Output value R")
@@ -1331,7 +1331,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valr")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVR
+		#=type Set by FTVR[NOVR]
 	}
 	field(VALS,DBF_NOACCESS) {
 		prompt("Output value S")
@@ -1341,7 +1341,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *vals")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVS
+		#=type Set by FTVS[NOVS]
 	}
 	field(VALT,DBF_NOACCESS) {
 		prompt("Output value T")
@@ -1351,7 +1351,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valt")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVT
+		#=type Set by FTVT[NOVT]
 	}
 	field(VALU,DBF_NOACCESS) {
 		prompt("Output value U")
@@ -1361,7 +1361,7 @@ be sent through the OUTA ... OUTU links during record processing.
 		extra("void *valu")
 		#=read Yes
 		#=write Yes
-		#=type Set by FTVU
+		#=type Set by FTVU[NOVU]
 	}
 
 =head3 Old Value Fields

--- a/modules/database/src/std/rec/aaiRecord.dbd.pod
+++ b/modules/database/src/std/rec/aaiRecord.dbd.pod
@@ -7,7 +7,7 @@
 # in file LICENSE that is included with this distribution.
 #*************************************************************************
 
-=title Array Analog Input (aai)
+=title Array Input (aai)
 
 The array input record type is used to read array data. The array data can
 contain any of the supported data types. The record is in many ways similar to the

--- a/modules/database/src/std/rec/aaiRecord.dbd.pod
+++ b/modules/database/src/std/rec/aaiRecord.dbd.pod
@@ -9,7 +9,7 @@
 
 =title Array Analog Input (aai)
 
-The array analog input record type is used to read array data. The array data can
+The array input record type is used to read array data. The array data can
 contain any of the supported data types. The record is in many ways similar to the
 waveform record. It allows, however, the device support to allocate the array
 storage.
@@ -31,14 +31,14 @@ The record-specific fields are described below, grouped by functionality.
 
 =head3 Scan Parameters
 
-The array analog input record has the standard fields for specifying under what
+The array input record has the standard fields for specifying under what
 circumstances the record will be processed.
 These fields are described in L<Scan Fields|dbCommonRecord/Scan Fields>.
 
 =head3 Read Parameters
 
 These fields are configurable by the user to specify how and from where the record
-reads its data. The INP field determines from where the array analog input gets
+reads its data. The INP field determines from where the array input gets
 its input. It can be a hardware address, a channel access or database link, or a
 constant. Only in records that use soft device support can the INP field be a
 channel access link, a database link, or a constant. Otherwise, the INP field must
@@ -83,7 +83,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 
 =head3 Alarm Parameters
 
-The array analog input record has the alarm parameters common to all record types.
+The array input record has the alarm parameters common to all record types.
 
 =head3 Monitor Parameters
 
@@ -108,11 +108,11 @@ These are the possible choices for the C<APST> and C<MPST> fields:
 
 =head3 Run-time Parameters
 
-These parameters are used by the run-time code for processing the array analog
+These parameters are used by the run-time code for processing the array
 input record. They are not configured using a configuration tool. Only the VAL
 field is modifiable at run-time.
 
-VAL references the array where the array analog input record stores its data. The
+VAL references the array where the array input record stores its data. The
 BPTR field holds the address of the array.
 
 The NORD field holds a counter of the number of elements that have been read
@@ -439,7 +439,7 @@ Scan forward link if necessary, set PACT FALSE, and return.
 
 =head3 Fields Of Interest To Device Support
 
-Each array analog input record record must have an associated set of device
+Each array input record record must have an associated set of device
 support routines. The primary responsibility of the device support routines is to
 obtain a new array value whenever C<read_aai()> is called. The device support
 routines are primarily interested in the following fields:

--- a/modules/database/src/std/rec/aaiRecord.dbd.pod
+++ b/modules/database/src/std/rec/aaiRecord.dbd.pod
@@ -294,7 +294,7 @@ Scan forward link if necessary, set PACT FALSE, and return.
 
 =cut
 
-	include "dbCommon.dbd" 
+	include "dbCommon.dbd"
     %
     %/* Declare Device Support Entry Table */
     %struct aaiRecord;
@@ -311,7 +311,7 @@ Scan forward link if necessary, set PACT FALSE, and return.
 		special(SPC_DBADDR)
 		pp(TRUE)
 		extra("void *		val")
-		#=type DOUBLE[NELM]
+		#=type Set by FTVL[NELM]
 		#=read Yes
 		#=write Yes
 	}

--- a/modules/database/src/std/rec/aaoRecord.dbd.pod
+++ b/modules/database/src/std/rec/aaoRecord.dbd.pod
@@ -9,7 +9,7 @@
 
 =title Array Analog Output (aao)
 
-The array analog output record type is used to write array data. The array data
+The array output record type is used to write array data. The array data
 can contain any of the supported data types. The record is in many ways similar
 to the waveform record but outputs arrays instead of reading them. It also
 allows the device support to allocate the array storage.
@@ -31,7 +31,7 @@ The record-specific fields are described below, grouped by functionality.
 
 =head3 Scan Parameters
 
-The array analog output record has the standard fields for specifying under what
+The array output record has the standard fields for specifying under what
 circumstances the record will be processed.
 These fields are described in L<Scan Fields|dbCommonRecord/Scan Fields>.
 
@@ -40,7 +40,7 @@ These fields are described in L<Scan Fields|dbCommonRecord/Scan Fields>.
 =head3 Write Parameters
 
 These fields are configurable by the user to specify how and where to the record
-writes its data. The OUT field determines where the array analog output writes
+writes its data. The OUT field determines where the array output writes
 its output. It can be a hardware address, a channel access or database link, or
 a constant. Only in records that use soft device support can the OUT field be a
 channel access link, a database link, or a constant. Otherwise, the OUT field
@@ -87,7 +87,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
 
 =head3 Alarm Parameters
 
-The array analog output record has the alarm parameters common to all record
+The array output record has the alarm parameters common to all record
 types.
 
 =head3 Monitor Parameters
@@ -115,11 +115,11 @@ These are the choices available for the C<APST> and C<MPST> fields
 
 =head3 Run-time Parameters
 
-These parameters are used by the run-time code for processing the array analog
+These parameters are used by the run-time code for processing the array
 output record. They are not configured using a configuration tool. Only the VAL
 field is modifiable at run-time.
 
-VAL references the array where the array analog output record stores its data.
+VAL references the array where the array output record stores its data.
 The BPTR field holds the address of the array.
 
 The NORD field holds a counter of the number of elements that have been written
@@ -472,7 +472,7 @@ Scan forward link if necessary, set PACT FALSE, and return.
 
 =head3 Fields Of Interest To Device Support
 
-Each array analog output record record must have an associated set of device
+Each array output record record must have an associated set of device
 support routines. The primary responsibility of the device support routines is
 to write the array data value whenever C<write_aao()> is called. The device
 support routines are primarily interested in the following fields:

--- a/modules/database/src/std/rec/aaoRecord.dbd.pod
+++ b/modules/database/src/std/rec/aaoRecord.dbd.pod
@@ -317,7 +317,7 @@ Scan forward link if necessary, set PACT FALSE, and return.
 
 =cut
 
-	include "dbCommon.dbd" 
+	include "dbCommon.dbd"
     %
     %/* Declare Device Support Entry Table */
     %struct aaoRecord;
@@ -333,7 +333,7 @@ Scan forward link if necessary, set PACT FALSE, and return.
 		special(SPC_DBADDR)
 		pp(TRUE)
 		extra("void *		val")
-		#=type DOUBLE[]
+		#=type Set by FTVL[NELM]
 		#=read Yes
 		#=write Yes
 	}

--- a/modules/database/src/std/rec/aaoRecord.dbd.pod
+++ b/modules/database/src/std/rec/aaoRecord.dbd.pod
@@ -7,7 +7,7 @@
 # in file LICENSE that is included with this distribution.
 #*************************************************************************
 
-=title Array Analog Output (aao)
+=title Array Output (aao)
 
 The array output record type is used to write array data. The array data
 can contain any of the supported data types. The record is in many ways similar

--- a/modules/database/src/std/rec/waveformRecord.dbd.pod
+++ b/modules/database/src/std/rec/waveformRecord.dbd.pod
@@ -403,7 +403,7 @@ routine and NORD is also set at that time.
 		special(SPC_DBADDR)
 		pp(TRUE)
 		extra("void *		val")
-		#=type Set by FTVL
+		#=type Set by FTVL[NELM]
 		#=read Yes
 		#=write Yes
 	}


### PR DESCRIPTION
I realized that `aao` and `aai` records are not actually `analog` records, since they follow the `FTVL` field type.
Out of curiosity - why not simply name them `array records`?