### PR TITLE
add HOST_BUILD option to CONFIG_SITE

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -139,6 +139,11 @@ HOST_WARN=YES
 #  Must be either YES or NO.
 CROSS_WARN=YES
 
+# Always build for the host architecture in addition to cross targets.
+# This will be forced on for EPICS base to ensure that host tools (i.e. msi) are available.
+#  Must be either YES or NO.
+HOST_BUILD=YES
+
 # Installation directory, if you want Base to be installed into a
 #  different location then uncomment and set this.
 #INSTALL_LOCATION=<fullpathname>

--- a/configure/RULES_ARCHS
+++ b/configure/RULES_ARCHS
@@ -16,8 +16,21 @@ ACTIONS += install
 ACTIONS += buildInstall
 ACTIONS += runtests tapfiles clean-tests test-results junitfiles
 
+# Force host build for EPICS base and associated modules
+ifeq ($(BASE_TOP),YES)
+HOST_BUILD=YES
+endif
+ifeq ($(PARENT_MODULE),EPICS_BASE)
+HOST_BUILD=YES
+endif
+
+ifeq ($(HOST_BUILD),NO)
+BUILD_ARCHS := $(filter-out $(EPICS_HOST_ARCH),$(BUILD_ARCHS))
+endif
+
 actionArchTargets = $(foreach action, $(ACTIONS), \
     $(addprefix $(action)$(DIVIDER), $(BUILD_ARCHS)))
+
 
 cleanArchTargets = $(addprefix clean$(DIVIDER), $(BUILD_ARCHS))
 
@@ -38,10 +51,18 @@ endif
 
 CROSS_ARCHS += $(CROSS1) $(CROSS2)
 
+ifeq ($(HOST_BUILD),NO)
+define DEP_template
+  $(2) :
+  $(1)$(DIVIDER)$(2) : O.$(2)
+endef
+else
 define DEP_template
   $(2) : $(EPICS_HOST_ARCH)
   $(1)$(DIVIDER)$(2) : $(1)$(DIVIDER)$(EPICS_HOST_ARCH) O.$(2)
 endef
+endif
+
 $(foreach action, $(ACTIONS), \
     $(foreach arch, $(CROSS_ARCHS), \
         $(eval $(call DEP_template,$(action),$(arch)))))


### PR DESCRIPTION
## Description

If HOST_BUILD=YES, the previous behavior of the EPICS build system is preserved. Cross targets will depend on the $(EPICS_HOST_ARCH) targets.

If HOST_BUILD=NO, cross targets will build independently of $(EPICS_HOST_ARCH), except for EPICS base where the option is forcefully enabled.

## Rationale 

This is useful for situations where you only want to cross compile instead of building for the host architecture too. For example, Yocto/BitBake recipes require some fanangling to work correctly with EPICS packages since they're always producing and installing binaries for the target _and_ build host. For areaDetector packages, where lots of dependencies start to get pulled in, building for the host architecture starts to become a real problem. The build machine ends up needing a bunch of packages installed just so that it can cross compile.

I'm aware of some caveats with this idea, but I don't think I have the full picture. Feedback would be greatly appreciated.