### PR TITLE
Avoid early expiration of timers on !vxWorks

### DIFF
--- a/modules/libcom/src/timer/timer.cpp
+++ b/modules/libcom/src/timer/timer.cpp
@@ -65,7 +65,11 @@ void timer::start ( epicsTimerNotify & notify, const epicsTime & expire )
 void timer::privateStart ( epicsTimerNotify & notify, const epicsTime & expire )
 {
     this->pNotify = & notify;
-    this->exp = expire - ( this->queue.notify.quantum () / 2.0 );
+    this->exp = expire
+#ifdef TIMER_QUANTUM_BIAS
+            - ( this->queue.notify.quantum () / 2.0 )
+#endif
+            ;
 
     bool reschedualNeeded = false;
     if ( this->curState == stateActive ) {

--- a/modules/libcom/src/timer/timerPrivate.h
+++ b/modules/libcom/src/timer/timerPrivate.h
@@ -35,6 +35,15 @@
 #   define debugPrintf(ARGSINPAREN)
 #endif
 
+/* For historical reasons, round down expiration time on vxWorks and RTEMS.
+ * This allows timers which expire on every tick.
+ * Otherwise, the fastest timer period is 2x the tick interval.
+ * This results in timers expiring early.
+ */
+#if defined(vxWorks) || defined(__rtems__)
+#  define TIMER_QUANTUM_BIAS 1
+#endif
+
 template < class T > class epicsGuard;
 
 class timer : public epicsTimer, public tsDLNode < timer > {

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -10,6 +10,9 @@
 TOP = ../../..
 include $(TOP)/configure/CONFIG
 
+# allow tests to peek at private headers
+USR_CPPFLAGS += -I$(TOP)/modules/libcom/src
+
 PROD_LIBS += Com
 PROD_SYS_LIBS_WIN32 += ws2_32 advapi32 user32
 PROD_SYS_LIBS_solaris += socket nsl


### PR DESCRIPTION
Address #106 on non-RTOS targets.