### PR TITLE
fix parallel build link problem

### DIFF
--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -197,7 +197,7 @@ $(sort $(DIRECTORY_TARGETS)):
 	$(MKDIR) $@
 
 # Install LIB_INSTALLS libraries before linking executables
-$(TESTPRODNAME) $(PRODNAME): | $(INSTALL_LIB_INSTALLS)
+$(TESTPRODNAME) $(PRODNAME): | $(INSTALL_LIB_INSTALLS) $(TESTSHRLIBNAME)
 
 # Install built libraries too, unless Makefile says to wait
 ifneq ($(DELAY_INSTALL_LIBS),YES)


### PR DESCRIPTION
When running parallel `make` with more than 2 jobs (I often use `make -j4`) I regularly see linker errors in the tests like this:
```
modules/database/test/ioc/db/O.linux-x86_64/libdbTestIoc.so: file not recognized: File truncated
```
Re-running `make`usually fixes the problem because meanwhile the shared test library contains data.
It is always a `TESTLIBRARY` that is incomplete.
This PR seems to fix that problem.

