### PR TITLE
flex/antelope: fix #line directives

### DIFF
--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -274,15 +274,13 @@ $(TESTPRODNAME) $(PRODNAME): %$(EXE): | $(INSTALL_LIB)
 
 YACCOPT ?= $($*_YACCOPT)
 #
-# rename the y.tab.h file only if we
+# rename the y.h file only if we
 # are creating it
 #
 %.c: %.y
-	@$(RM) $*.tab.c
-	@$(RM) $*.tab.h
+	@$(RM) $*.c
+	@$(RM) $*.h
 	$(YACC) -b$* $(YACCOPT) $<
-	$(MV) $*.tab.c $*.c
-	$(if $(findstring -d, $(YACCOPT)),$(MV) $*.tab.h $*.h,)
 
 # must be a separate rule since when not using '-d' the
 # prefix for .h will be different then .c

--- a/modules/libcom/src/flex/Flex.doc
+++ b/modules/libcom/src/flex/Flex.doc
@@ -976,7 +976,7 @@
      the next input token.  The routine is supposed to return the type of the
      next token as well as putting any associated value in the global yylval.
      To use flex with yacc, one specifies the -d option to yacc to instruct
-     it to generate the file y.tab.h containing definitions of all the
+     it to generate the file y.h containing definitions of all the
      %tokens appearing in the yacc input.  This file is then included in the
 
    Version 2.3                                                             17
@@ -987,7 +987,7 @@
      of the scanner might look like:
 
          %{
-         #include "y.tab.h"
+         #include "y.h"
          %}
 
          %%

--- a/modules/libcom/src/flex/flexdoc.html
+++ b/modules/libcom/src/flex/flexdoc.html
@@ -1018,14 +1018,14 @@
      supposed  to  return  the  type of the next token as well as
      putting any associated value in the global  yylval.  To  use
      <I>flex</I>  with  <I>yacc</I>,  one  specifies  the  -d option to <I>yacc</I> to
-     instruct it to generate the file y.tab.h containing  defini-
+     instruct it to generate the file y.h containing  defini-
      tions  of all the %tokens appearing in the <I>yacc</I> input.  This
      file is then included in the <I>flex</I> scanner.  For example,  if
      one of the tokens is "TOK_NUMBER", part of the scanner might
      look like:
 
          %{
-         #include "y.tab.h"
+         #include "y.h"
          %}
 
          %%

--- a/modules/libcom/src/yacc/NEW_FEATURES
+++ b/modules/libcom/src/yacc/NEW_FEATURES
@@ -1,5 +1,5 @@
      The -r option has been implemented.  The -r option tells Yacc to
-put the read-only tables in y.tab.c and the code and variables in
+put the read-only tables in y.c and the code and variables in
 y.code.c.  Keith Bostic asked for this option so that :yyfix could be
 eliminated.
 

--- a/modules/libcom/src/yacc/antelope.c
+++ b/modules/libcom/src/yacc/antelope.c
@@ -34,9 +34,9 @@ char *verbose_file_name;
 FILE *action_file;      /*  a temp file, used to save actions associated    */
                         /*  with rules until the parser is written          */
 FILE *code_file;        /*  y.code.c (used when the -r option is specified) */
-FILE *defines_file;     /*  y.tab.h                                         */
+FILE *defines_file;     /*  y.h                                         */
 FILE *input_file;       /*  the input file                                  */
-FILE *output_file;      /*  y.tab.c                                         */
+FILE *output_file;      /*  y.c                                         */
 FILE *text_file;        /*  a temp file, used to save text until all        */
                         /*  symbols have been defined                       */
 FILE *union_file;       /*  a temp file, used to save the union             */

--- a/modules/libcom/src/yacc/defs.h
+++ b/modules/libcom/src/yacc/defs.h
@@ -46,8 +46,8 @@
 /* defines for constructing filenames */
 
 #define CODE_SUFFIX     ".code.c"
-#define DEFINES_SUFFIX  ".tab.h"
-#define OUTPUT_SUFFIX   ".tab.c"
+#define DEFINES_SUFFIX  ".h"
+#define OUTPUT_SUFFIX   ".c"
 #define VERBOSE_SUFFIX  ".output"
 
 


### PR DESCRIPTION
Partially address #749.  Change antelope/flex output file suffix to remote `.tab`.