### PR TITLE
configure: ensure output file only updated on success

### DIFF
--- a/configure/CONFIG_COMMON
+++ b/configure/CONFIG_COMMON
@@ -337,7 +337,10 @@ COMPILE.cpp = $(CCC) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES)
 
 #--------------------------------------------------
 # C preprocessor command
-PREPROCESS.cpp = $(CPP) $(CPPFLAGS) $(INCLUDES) $< > $@
+define PREPROCESS.cpp
+$(CPP) $(CPPFLAGS) $(INCLUDES) $< > $@.stdout
+$(MV) $@.stdout $@
+endef
 
 #--------------------------------------------------
 # genVersion header defaults

--- a/configure/RULES.Db
+++ b/configure/RULES.Db
@@ -124,7 +124,10 @@ ACF_CPPFLAGS = $(ACF_CPPFLAGS_$(GNU))
 ACF_INCLUDES = -I. $(TARGET_INCLUDES) $(USR_INCLUDES)\
                 $(SRC_INCLUDES) -I$(INSTALL_DB)
 ACFDEPENDS_CMD = $(MKMF) -m $@ $(ACF_INCLUDES) $(COMMONDEP_TARGET) $<
-ACF_CMD = $(CPP) $(ACF_CPPFLAGS) $(ACF_INCLUDES) $< > $@
+define ACF_CMD
+$(CPP) $(ACF_CPPFLAGS) $(ACF_INCLUDES) $< > $@.stdout
+$(MV) $@.stdout $@
+endef
 
 #---------------------------------------------------------------
 # dependencies
@@ -219,68 +222,82 @@ realclean: clean
 
 %Record.h$(DEP): $(COMMON_DIR)/%Record.dbd $(DBDTORECTYPEH_dep)
 	@$(RM) $@
-	@$(DBTORECORDTYPEH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@
+	@$(DBTORECORDTYPEH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@.stdout
+	@$(MV) $@.stdout $@
 
 %Record.h$(DEP): %Record.dbd $(DBDTORECTYPEH_dep)
 	@$(RM) $@
-	@$(DBTORECORDTYPEH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@
+	@$(DBTORECORDTYPEH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@.stdout
+	@$(MV) $@.stdout $@
 
 %Record.h$(DEP): ../%Record.dbd $(DBDTORECTYPEH_dep)
 	@$(RM) $@
-	@$(DBTORECORDTYPEH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@
+	@$(DBTORECORDTYPEH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@.stdout
+	@$(MV) $@.stdout $@
 
 menu%.h$(DEP): $(COMMON_DIR)/menu%.dbd $(DBDTOMENUH_dep)
 	@$(RM) $@
-	@$(DBTOMENUH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@
+	@$(DBTOMENUH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@.stdout
+	@$(MV) $@.stdout $@
 
 menu%.h$(DEP): menu%.dbd $(DBDTOMENUH_dep)
 	@$(RM) $@
-	@$(DBTOMENUH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@
+	@$(DBTOMENUH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@.stdout
+	@$(MV) $@.stdout $@
 
 menu%.h$(DEP): ../menu%.dbd $(DBDTOMENUH_dep)
 	@$(RM) $@
-	@$(DBTOMENUH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@
+	@$(DBTOMENUH) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@.stdout
+	@$(MV) $@.stdout $@
 
 %.dbd$(DEP): %.dbd.pod
 	@$(RM) $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" > $@
+	@echo "$(COMMONDEP_TARGET): ../Makefile" > $@.stdout
+	@$(MV) $@.stdout $@
 
 %.dbd$(DEP): %Include.dbd
 	@$(RM) $@
-	@$(DBEXPAND) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@
+	@$(DBEXPAND) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@.stdout
+	@$(MV) $@.stdout $@
 
 %.dbd$(DEP): ../%Include.dbd
 	@$(RM) $@
-	@$(DBEXPAND) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@
+	@$(DBEXPAND) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@.stdout
+	@$(MV) $@.stdout $@
 
 %.dbd$(DEP): $($*_DBD)
 	@$(RM) $@
-	@$(DBEXPAND) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $($*_DBD) > $@
-	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@
+	@$(DBEXPAND) -D $(DBDFLAGS) -o $(COMMONDEP_TARGET) $($*_DBD) > $@.stdout
+	@echo "$(COMMONDEP_TARGET): ../Makefile" >> $@.stdout
+	@$(MV) $@.stdout $@
 
 %.db$(DEP): %$(SUBST_SUFFIX)
 	@$(RM) $@
-	$(MSI3_15) -D $(DBFLAGS) -o $(COMMONDEP_TARGET) -S$< $(TEMPLATE_FILENAME) > $@
+	$(MSI3_15) -D $(DBFLAGS) -o $(COMMONDEP_TARGET) -S$< $(TEMPLATE_FILENAME) > $@.stdout
+	@$(MV) $@.stdout $@
 
 %.db$(DEP): ../%$(SUBST_SUFFIX)
 	@$(RM) $@
-	$(MSI3_15) -D $(DBFLAGS) -o $(COMMONDEP_TARGET) -S$< $(TEMPLATE_FILENAME) > $@
+	$(MSI3_15) -D $(DBFLAGS) -o $(COMMONDEP_TARGET) -S$< $(TEMPLATE_FILENAME) > $@.stdout
+	@$(MV) $@.stdout $@
 
 %.db$(DEP): %$(TEMPL_SUFFIX)
 	@$(RM) $@
-	$(MSI3_15) -D $(DBFLAGS) -o $(COMMONDEP_TARGET) $< > $@
+	$(MSI3_15) -D $(DBFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@$(MV) $@.stdout $@
 
 %.db$(DEP): ../%$(TEMPL_SUFFIX)
 	@$(RM) $@
-	$(MSI3_15) -D $(DBFLAGS) -o $(COMMONDEP_TARGET) $< > $@
+	$(MSI3_15) -D $(DBFLAGS) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	@$(MV) $@.stdout $@
 
 %.acf$(DEP): %.acs
 	@$(RM) $@
@@ -483,8 +500,9 @@ $(COMMON_DIR)/%.html: ../%.pl $(PODTOHTML_dep)
 
 $(COMMON_DIR)/%.db: $(COMMON_DIR)/%.edf
 	$(E2DB) $(E2DB_SYSFLAGS) $(E2DB_FLAGS) -n $*.VAR $<
-	@$(REPLACEVAR) < $*.VAR > $@
+	@$(REPLACEVAR) < $*.VAR > $@.stdout
 	@$(RM) $*.VAR
+	@$(MV) $@.stdout $@
 
 $(COMMON_DIR)/%.db: %$(SUBST_SUFFIX)
 	$(ECHO) "Inflating database from $< $(TEMPLATE_FILENAME)"

--- a/configure/RULES_BUILD
+++ b/configure/RULES_BUILD
@@ -338,12 +338,13 @@ $(INSTALL_LIB):
 # C++ munching for VxWorks
 
 %.nm: %$(EXE)
-	@$(RM) $@
-	$(NM) $<  > $@
+	$(NM) $< > $@.stdout
+	$(MV) $@.stdout $@
 
 %.nm: %$(OBJ)
 	@$(RM) $@
-	$(NM) $<  > $@
+	$(NM) $< > $@.stdout
+	$(MV) $@.stdout $@
 
 %_ctdt.c: %.nm $(TOOLS)/munch.pl
 	@$(RM) $@

--- a/configure/RULES_MODULES
+++ b/configure/RULES_MODULES
@@ -43,7 +43,8 @@ $(RELEASE_LOCAL): Makefile $(CONFIG)/CONFIG_SITE \
     $(wildcard $(CONFIG)/CONFIG_SITE.local)
 	$(ECHO) "Creating $@ with"
 	$(ECHO) "    $(PARENT_MODULE) = $(INSTALL_ABSOLUTE)"
-	@echo $(PARENT_MODULE) = $(INSTALL_ABSOLUTE)> $@
+	@echo "$(PARENT_MODULE) = $(INSTALL_ABSOLUTE)" > $@.stdout
+	@$(MV) $@.stdout $@
 
 .PHONY: RELEASE.host
 

--- a/configure/os/CONFIG.Common.vxWorksCommon
+++ b/configure/os/CONFIG.Common.vxWorksCommon
@@ -164,7 +164,10 @@ COMPILE.ctdt = $(CC) -c $(CPPFLAGS) $(CFLAGS_ctdt) $(INCLUDES) $(SOURCE_FLAG)
 #--------------------------------------------------
 # C preprocessor command
 VXCPPFLAGS = $(filter-out $(OP_SYS_INCLUDE_CPPFLAGS),$(CPPFLAGS))
-PREPROCESS.cpp = $(CPP) $(VXCPPFLAGS) $(INCLUDES) $< > $@
+define PREPROCESS.cpp
+$(CPP) $(VXCPPFLAGS) $(INCLUDES) $< > $@.stdout
+$(MV) $@.stdout $@
+endef
 
 #--------------------------------------------------
 # Use LEDLIB for command-line editing

--- a/modules/database/src/ioc/db/RULES
+++ b/modules/database/src/ioc/db/RULES
@@ -15,8 +15,8 @@ THESE_RULES := $(IOCDIR)/db/RULES
 
 dbCommon.h$(DEP): $(COMMON_DIR)/dbCommonRecord.dbd $(THESE_RULES) \
     $(DBDTORECTYPEH_dep)
-	@$(RM) $@
-	@$(DBTORECORDTYPEH) -D -I ../db  -I $(COMMON_DIR) -o $(COMMONDEP_TARGET) $< > $@
+	@$(DBTORECORDTYPEH) -D -I ../db  -I $(COMMON_DIR) -o $(COMMONDEP_TARGET) $< > $@.stdout
+	$(MV) $@.stdout $@
 
 $(COMMON_DIR)/dbCommonRecord.html: ../db/dbCommon.dbd.pod
 

--- a/modules/database/src/std/rec/RULES
+++ b/modules/database/src/std/rec/RULES
@@ -8,8 +8,8 @@
 # This is a Makefile fragment, see src/ioc/Makefile.
 
 stdRecords.dbd$(DEP): $(STDDIR)/rec/Makefile $(STDDIR)/rec/RULES
-	@$(RM) $@
-	@echo "$(COMMON_DIR)/stdRecords.dbd:" > $@
+	@echo "$(COMMON_DIR)/stdRecords.dbd:" > $@.stdout
+	$(MV) $@.stdout $@
 
 $(COMMON_DIR)/stdRecords.dbd: $(STDDIR)/rec/Makefile $(STDDIR)/rec/RULES
 

--- a/modules/database/src/std/softIoc/RULES
+++ b/modules/database/src/std/softIoc/RULES
@@ -19,5 +19,5 @@ softMain$(DEP): epicsInstallDir.h
 
 epicsInstallDir.h: $(TOP)/configure/CONFIG_SITE*
 	$(ECHO) "FINAL_LOCATION=$(FINAL_LOCATION)"
-	$(PERL) $(STDDIR)/softIoc/makeInstallDir.pl "$(FINAL_LOCATION)" > $@
-
+	$(PERL) $(STDDIR)/softIoc/makeInstallDir.pl "$(FINAL_LOCATION)" > $@.stdout
+	$(MV) $@.stdout $@

--- a/modules/libcom/test/Makefile
+++ b/modules/libcom/test/Makefile
@@ -364,4 +364,5 @@ epicsLoadTest$(DEP): epicsInstallDir.h
 # use INSTALL_LOCATION instead of FINAL_LOCATION since test executables are not installed.
 epicsInstallDir.h: $(TOP)/configure/CONFIG_SITE*
 	$(ECHO) "INSTALL_LOCATION=$(INSTALL_LOCATION)"
-	$(PERL) $(TOP)/modules/database/src/std/softIoc/makeInstallDir.pl "$(INSTALL_LOCATION)" > $@
+	$(PERL) $(TOP)/modules/database/src/std/softIoc/makeInstallDir.pl "$(INSTALL_LOCATION)" > $@.stdout
+	$(MV) $@.stdout $@


### PR DESCRIPTION
Ensure that Make rule failure does not erroneously update the timestamp on `$@`.  (see https://github.com/epics-base/epics-base/issues/765#issuecomment-3693491270)

eg. After running `false > $@`, the output file modification time will be updated.  So despite failure, a repeated "make" will consider the target up to date.

Handle this by accumulating output to `$@.tmp`, then move to `$@` as a final step.

Most cases are straightforward substitutions local to one recipe.  A few others are command snippets defined in variables.  All but one can be handled as a [multi-line variable](https://www.gnu.org/software/make/manual/make.html#Multi_002dLine).

This last one is only relevant on solaris, where `HDEPENDS_COMPFLAGS` contains `> $@`.

https://github.com/epics-base/epics-base/blob/12c56ffc954e4cde72c43174ebd11ccd0d523c1e/configure/os/CONFIG.solarisCommon.solarisCommon#L58-L59

On all other targets `HDEPENDS_COMPFLAGS` is either no used, or takes the GCC form.

https://github.com/epics-base/epics-base/blob/12c56ffc954e4cde72c43174ebd11ccd0d523c1e/configure/CONFIG.gnuCommon#L69-L70

Switching to a multi-line variable is not compatible with the usage:

https://github.com/epics-base/epics-base/blob/12c56ffc954e4cde72c43174ebd11ccd0d523c1e/configure/RULES_BUILD#L239-L241

I am not inclined to spend time on a solaris specific enhancement.