### PR TITLE
appveyor use python3.8

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,8 +82,9 @@ matrix:
 #---------------------------------#
 
 install:
+  - cmd: set PATH=C:\Python38-x64;%PATH%
   - cmd: git submodule update --init --recursive
-  - cmd: pip install git+https://github.com/mdavidsaver/ci-core-dumper#egg=ci-core-dumper
+  - cmd: python -m pip install git+https://github.com/mdavidsaver/ci-core-dumper#egg=ci-core-dumper
   - cmd: python .ci/cue.py prepare
 
 build_script:

--- a/.appveyor/epics-base-7.yml
+++ b/.appveyor/epics-base-7.yml
@@ -89,8 +89,9 @@ matrix:
 #---------------------------------#
 
 install:
+  - cmd: set PATH=C:\Python38-x64;%PATH%
   - cmd: git submodule update --init --recursive
-  - cmd: pip install git+https://github.com/mdavidsaver/ci-core-dumper#egg=ci-core-dumper
+  - cmd: python -m pip install git+https://github.com/mdavidsaver/ci-core-dumper#egg=ci-core-dumper
   - cmd: python .ci/cue.py prepare
 
 build_script:


### PR DESCRIPTION
As of https://github.com/mdavidsaver/ci-core-dumper/commit/d51465afc25b5289fd0b1abfcbb7bb9fb433058d ci-core-dumper requires python >= 3.8, which is [available](https://www.appveyor.com/docs/windows-images-software/#python) on appveyor images beginning with 2015.