### PR TITLE
fix dir dependency

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -17,7 +17,7 @@ database_DEPEND_DIRS = ca
 
 # Submodules for bundle build
 SUBMODULES += pvData
-pvData_DEPEND_DIRS = libcom
+pvData_DEPEND_DIRS = libcom database
 
 SUBMODULES += pvAccess
 pvAccess_DEPEND_DIRS = pvData database


### PR DESCRIPTION
`pvData` depends on `database` because the tests include `iocInit.h` via `epicsUnitTest.h`.

