### PR TITLE
Soft Time Part device support

### DIFF
--- a/modules/database/src/std/dev/devSoft.dbd
+++ b/modules/database/src/std/dev/devSoft.dbd
@@ -54,6 +54,7 @@ device(stringout,CONSTANT,devSoSoftCallback,"Async Soft Channel")
 
 device(ai,      INST_IO,devTimestampAI,"Soft Timestamp")
 device(stringin,INST_IO,devTimestampSI,"Soft Timestamp")
+device(ai,      INST_IO,devTimePartAI ,"Soft Time Part")
 
 device(ai,	INST_IO,devAiGeneralTime,"General Time")
 device(bo,	INST_IO,devBoGeneralTime,"General Time")

--- a/modules/database/src/std/dev/devTimestamp.c
+++ b/modules/database/src/std/dev/devTimestamp.c
@@ -12,11 +12,15 @@
  *   Original Author:   Eric Norum
  */
 
+#include <string.h>
+
 #include "dbDefs.h"
 #include "epicsTime.h"
 #include "alarm.h"
 #include "devSup.h"
 #include "recGbl.h"
+#include "errlog.h"
+#include "cantProceed.h"
 
 #include "aiRecord.h"
 #include "stringinRecord.h"
@@ -71,3 +75,113 @@ stringindset devTimestampSI = {
     read_stringin
 };
 epicsExportAddress(dset, devTimestampSI);
+
+
+/* ai record */
+
+typedef enum {
+    tp_invalid = 0,
+    tp_sec,
+    tp_min,
+    tp_hour,
+    tp_mday,
+    tp_wday,
+    tp_mon,
+    tp_year,
+    tp_isdst,
+} timePart;
+
+typedef struct {
+    int gm;
+    timePart part;
+} timePartPvt;
+
+static long init_timepart (struct dbCommon *pcom)
+{
+    aiRecord *prec = (aiRecord*)pcom;
+    timePartPvt *pvt = callocMustSucceed(1, sizeof(*pvt), "TimePart");
+
+    char *spec = prec->inp.value.instio.string;
+
+    char *sep = strchr(spec, '.');
+    if(sep) {
+        *sep = '\0';
+        if(strcmp(spec, "gm")==0) {
+            pvt->gm = 1;
+        } else if(strcmp(spec, "local")==0) {
+            pvt->gm = 0;
+        } else {
+            errlogPrintf("%s.INP: unknown zone: %s\n", prec->name, spec);
+            // treat as local time
+        }
+        *sep = '.';
+        spec = sep+1; // skip past '.'
+    } else {
+        pvt->gm = 0; // default to local time
+    }
+
+#define IF(PART) if(strcmp(spec, #PART)==0) { pvt->part = tp_ ## PART ; }
+
+    IF(sec)
+    else IF(min)
+    else IF(hour)
+    else IF(mday)
+    else IF(wday)
+    else IF(mon)
+    else IF(year)
+    else IF(isdst)
+#undef IF
+
+    prec->dpvt = pvt;
+
+    return 0;
+}
+
+static long read_timepart (aiRecord *prec)
+{
+    timePartPvt *pvt = prec->dpvt;
+
+    recGblGetTimeStamp(prec);
+    struct tm t;
+    unsigned long ns;
+    int err;
+
+    if(pvt->gm) {
+        err = epicsTimeToGMTM(&t, &ns, &prec->time);
+    } else {
+        err = epicsTimeToTM(&t, &ns, &prec->time);
+    }
+    if(!err) {
+        switch(pvt->part) {
+        case tp_invalid:
+            recGblSetSevrMsg(prec, READ_ALARM, INVALID_ALARM, "bad INP");
+            err = 1;
+            break;
+        case tp_sec:
+            prec->val = t.tm_sec; break;
+        case tp_min:
+            prec->val = t.tm_sec/60.0 + t.tm_min; break;
+        case tp_hour:
+            prec->val = (t.tm_sec/60.0 + t.tm_min)/60.0 + t.tm_hour; break;
+        case tp_wday:
+            prec->val = ((t.tm_sec/60.0 + t.tm_min)/60.0 + t.tm_hour)/24.0 + t.tm_wday; break;
+        case tp_mday:
+            prec->val = ((t.tm_sec/60.0 + t.tm_min)/60.0 + t.tm_hour)/24.0 + t.tm_mday; break;
+        case tp_mon:
+            prec->val = t.tm_mon; break;
+        case tp_year:
+            prec->val = t.tm_year; break;
+        case tp_isdst:
+            prec->val = t.tm_isdst; break;
+        }
+    }
+
+    return err ? err : 2;
+}
+
+static
+aidset devTimePartAI = {
+    {6, NULL, NULL, init_timepart, NULL},
+    read_timepart,  NULL
+};
+epicsExportAddress(dset, devTimePartAI);


### PR DESCRIPTION
Adds an `ai` DTYP `Soft Time Part` which wrap a call to `epicsTimeToTM()` or `epicsTimeToGMTM()`.  My motivation was wanting to trigger processing at a certain time of day and/or time of week (see below).  Likes *nix `cron` daemon.  I could almost accomplish this with `ai` `Soft Timestamp` and a modulo operation, except for those pesky timezone offsets.

Doing a separate support module seems excessive for such a small piece of code, and I see some similarity with the other bits of `devTimestamp.c`, so I propose adding to Base.

INP spec is: `@[<ref>.]<part>`, where `<ref>` is either `local` or `gm`.  `<part>` is one of the parts of `struct tm`: `sec`, `min`, `hour`, `wday`, `mday`, `mon`, `year`, or `isdst`.

So `@local.wday` is the fractional number of days.  `@gm.hour` gives the fractional hours since GMT midnight.  These are according to (I think) the system locale.  eg. for me, `@local.wday` at Monday 12:00 is `1.5`.

```
record(ai, "TST:PHAS") {
    field(DTYP, "Soft Time Part")
    field(SCAN, "1 second")
    field(INP , "@local.wday")
    field(FLNK, "TST:COMP")
}
record(ao, "TST:TGT") {
    field(VAL, "$(TGT=)")
}
record(calcout, "TST:COMP") {
    field(INPA, "TST:PHAS")
    field(INPB, "TST:TGT")
    field(CALC, "A>=B")
    field(OUT , "TST:SEQ_ PP")
    field(OOPT, "Transition To Non-zero")
}
record(seq, "TST:SEQ_") {
    field(TPRO, "1")
}
```