### PR TITLE
appveyor: remove global email notification

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -122,10 +122,4 @@ on_failure:
 #---------------------------------#
 
 notifications:
-
-  - provider: Email
-    to:
-      - core-talk@aps.anl.gov
-    on_build_success: false
-
   - provider: GitHubPullRequest

--- a/.appveyor/epics-base-7.yml
+++ b/.appveyor/epics-base-7.yml
@@ -129,10 +129,4 @@ on_failure:
 #---------------------------------#
 
 notifications:
-
-  - provider: Email
-    to:
-      - core-talk@aps.anl.gov
-    on_build_success: false
-
   - provider: GitHubPullRequest


### PR DESCRIPTION
Do not pester core-talk with build failures from forks.  Remove core-talk from global appveyor notifications.  If core-talk notifications are still desired, instead switch to global or per-project notification [configured](https://www.appveyor.com/docs/notifications/#global-email-notifications) through the web ui.

I think `GitHubPullRequest` is still reasonable in the versioned `appveyor.yml`s, although this too could be moved to the per-project configuration.