### PR TITLE
avoid overreporting available CPUs

### DIFF
--- a/documentation/new-notes/PR-788.md
+++ b/documentation/new-notes/PR-788.md
@@ -6,3 +6,16 @@ That fixes the problem that an IOC which was started with a limited affinity
 mask (e.g. using `taskset`) and that called `callbackParallelThreads` with an
 argument of 0 in the startup script, had started more parallel callback
 threads than it has CPU cores available.
+
+The iocsh function `callbackParallelThreads` now also accepts positive or
+negative percentages for `count`, referring to the availabple number of cores
+and always rounding the number of used cores down with a minimum of 1.
+
+#### Examples
+
+```text
+# use up to 25% of available cpu cores for callback threads
+callbackParallelThreads 25%
+# keep at least 10% of available cpu cores unused for callback threads
+callbackParallelThreads -10%
+```

--- a/documentation/new-notes/PR-788.md
+++ b/documentation/new-notes/PR-788.md
@@ -1,0 +1,8 @@
+### epicsThreadGetCPUs and callbackParallelThreads
+
+On systems that support it (e.g. recent Linux systems), `epicsThreadGetCPUs()`
+now takes the current cpu affinity mask of the calling thread into acount.
+That fixes the problem that an IOC which was started with a limited affinity
+mask (e.g. using `taskset`) and that called `callbackParallelThreads` with an
+argument of 0 in the startup script, had started more parallel callback
+threads than it has CPU cores available.

--- a/modules/database/src/ioc/db/callback.h
+++ b/modules/database/src/ioc/db/callback.h
@@ -199,7 +199,10 @@ DBCORE_API void callbackQueueShow(const int reset);
  * Calling with count<0 computes the count based on the number of CPU cores
  * currently available to the calling thread,
  * eg. Passing -2 on an 8 core system will start 6 worker threads.
- * In all cases, at least one worker thread will always run.
+ * The iocsh wrapper also accepts positive or negative percentages for count,
+ * which allows to refer to a fraction of the currently available CPU cores,
+ * always rounding the number of created threads down.
+ * In any case, at least one worker thread will always run.
  *
  * An empty prio name or the special value "*" will modify all priorities.
  * Otherwise, only the named priority is modified.

--- a/modules/database/src/ioc/db/callback.h
+++ b/modules/database/src/ioc/db/callback.h
@@ -193,18 +193,21 @@ DBCORE_API void callbackQueueShow(const int reset);
  * By default, only one thread is run for each priority (3 in total).
  *
  * Calling with count==0 will take the count from the callbackParallelThreadsDefault
- * global variable (default default is 2).
+ * global variable (initialized to the number of CPU cores initially available to
+ * the main thread).
  * Calling with count>0 sets the number of worker threads directly.
- * Calling with count<0 computes the count based on the number of CPU cores on the host.
+ * Calling with count<0 computes the count based on the number of CPU cores
+ * currently available to the calling thread,
  * eg. Passing -2 on an 8 core system will start 6 worker threads.
  * In all cases, at least one worker thread will always run.
  *
- * A special prio name of "*" will modify all priorities.
+ * An empty prio name or the special value "*" will modify all priorities.
  * Otherwise, only the named priority is modified.
+ * The prio names are case insensitive.
  *
  * @param count If zero, reset to default (callbackParallelThreadsDefault global/iocsh variable).
  *              If positive, exact number of worker threads to create.
- *              If negative, number of worker threads less than core count.
+ *              If negative, reserve this many CPUs to _not_ run parallel callback threads.
  * @param prio Priority name.  eg. "*", "LOW", "MEDIUM" or "HIGH".
  * @return zero on success, non-zero if called after iocInit() or with invalid arguments.
  *

--- a/modules/database/src/ioc/db/dbIocRegister.c
+++ b/modules/database/src/ioc/db/dbIocRegister.c
@@ -10,6 +10,8 @@
 
 #define EPICS_PRIVATE_API
 
+#include <string.h>
+
 #include "iocsh.h"
 
 #include "callback.h"
@@ -27,6 +29,9 @@
 #include "dbState.h"
 #include "db_test.h"
 #include "dbTest.h"
+#include "epicsStdlib.h"
+#include "epicsStdio.h"
+#include "errlog.h"
 
 DBCORE_API extern int callbackParallelThreadsDefault;
 
@@ -503,7 +508,7 @@ static void callbackQueueShowCallFunc(const iocshArgBuf *args)
 }
 
 /* callbackParallelThreads */
-static const iocshArg callbackParallelThreadsArg0 = { "no of threads", iocshArgInt};
+static const iocshArg callbackParallelThreadsArg0 = { "no of threads", iocshArgString};
 static const iocshArg callbackParallelThreadsArg1 = { "priority", iocshArgString};
 static const iocshArg * const callbackParallelThreadsArgs[2] =
     {&callbackParallelThreadsArg0,&callbackParallelThreadsArg1};
@@ -513,7 +518,25 @@ static const iocshFuncDef callbackParallelThreadsFuncDef = {"callbackParallelThr
                                                             "or one of LOW, MEDIUM, or HIGH.\n"};
 static void callbackParallelThreadsCallFunc(const iocshArgBuf *args)
 {
-    iocshSetError(callbackParallelThreads(args[0].ival, args[1].sval));
+    epicsInt32 num = 0;
+    if (args[0].sval) {
+        char* end;
+        long status = epicsParseInt32(args[0].sval, &num, 10, &end);
+        if (status || (end[0] && strcmp(end, "%") != 0))
+        {
+            fprintf(epicsGetStderr(),
+                ANSI_RED("Invalid integer '%s'.\n"), args[0].sval);
+            iocshSetError(-1);
+            return;
+        }
+        if (end[0] == '%') {
+            /* round down, min 1 */
+            if (num < 0) num += 100;
+            if (num > 0) num = num * epicsThreadGetCPUs() / 100;
+            if (num <= 0) num = 1;
+        }
+    }
+    iocshSetError(callbackParallelThreads(num, args[1].sval));
 }
 
 /* dbStateCreate */

--- a/modules/libcom/src/osi/os/posix/osdThread.c
+++ b/modules/libcom/src/osi/os/posix/osdThread.c
@@ -1123,6 +1123,12 @@ LIBCOM_API double epicsStdCall epicsThreadSleepQuantum ()
 LIBCOM_API int epicsThreadGetCPUs(void)
 {
     long ret;
+#ifdef CPU_COUNT
+    cpu_set_t mask;
+    ret = sched_getaffinity(0, sizeof(mask), &mask);
+    if (ret == 0)
+        return CPU_COUNT(&mask);
+#endif
 #ifdef _SC_NPROCESSORS_ONLN
     ret = sysconf(_SC_NPROCESSORS_ONLN);
     if (ret > 0)

--- a/modules/libcom/src/pool/threadPool.c
+++ b/modules/libcom/src/pool/threadPool.c
@@ -338,7 +338,7 @@ LIBCOM_API epicsThreadPool* epicsThreadPoolGetShared(epicsThreadPoolConfig *opts
         opts = &defopts;
     }
     /* shared pools must have a minimum allowed number of workers.
-     * Use the number of CPU cores
+     * Use the number of CPU cores currently available to the calling thread.
      */
     if (opts->maxThreads < N)
         opts->maxThreads = N;


### PR DESCRIPTION
If the IOC has been started with a limited set of CPU cores (e.g. using `taskset`), `callbackParallelThreadsDefault` should reflect this. Otherwise, `callbackParallelThreads` will create more callback threads than available CPU cores, resulting in possible performance degradation.

On Linux at least, `sysconf(_SC_NPROCESSORS_ONLN)` does not take the cpu affinity mask into account.
I do not know how MacOS and RTEMS handle this. They do not have `sched_getaffinity()` (neither do older Linux systems).
