### PR TITLE
add indent_size to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,4 +15,5 @@ insert_final_newline = false
 # and remove all trailing spaces
 [*.{c,cc,cpp,h,hpp,pl,py,yml}]
 indent_style = space
+indent_size = 1
 trim_trailing_whitespace = true


### PR DESCRIPTION
Without `indent_size`, `eclint` ignores `indent_style` (which is a [bug](https://github.com/greut/eclint/issues/11)).
We prefer 4 spaces but many comment blocks are indented 1 space like this:
```
/*
 * Some comment
 */
```
These would all trigger `eclint`.