### PR TITLE
switch to editorconfig-checker

### DIFF
--- a/.github/workflows/check-editorconfig.yml
+++ b/.github/workflows/check-editorconfig.yml
@@ -8,6 +8,11 @@ jobs:
   editorconfig:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: EditorConfig-Action
-        uses: greut/eclint-action@v0
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up editorconfig-checker
+        uses: editorconfig-checker/action-editorconfig-checker@main
+
+      - name: Run editorconfig-checker
+        run: editorconfig-checker


### PR DESCRIPTION
Unfortunately `eclint` does not check `indent_style` without `indent_size`

And block comments like
```
/*
 * Comment
 */
```
with 1 space before the `*` don't allow to specify any useful value for `indent_size` like for example 4 without causing lots of lint errors.

See [action-editorconfig-checker](https://github.com/editorconfig-checker/action-editorconfig-checker?tab=readme-ov-file#example-workflow).