### PR TITLE
[DOCS] Remove hoverxref extension as it is deprecated.

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -28,7 +28,6 @@ author = "The EPICS Collaboration"
 # ones.
 
 extensions = [
-    "hoverxref.extension",
     "breathe",
     "sphinx.ext.mathjax",
     "sphinx.ext.ifconfig",
@@ -62,23 +61,6 @@ intersphinx_mapping = {
     "epics": ("https://docs.epics-controls.org/en/latest/", None),
 }
 intersphinx_disabled_reftypes = ["*"]
-hoverxref_role_types = {
-    "hoverxref": "tooltip",
-    "ref": "modal",
-    "confval": "tooltip",
-    "mod": "modal",
-    "class": "modal",
-    "obj": "tooltip",
-}
-
-hoverxref_intersphinx_types = {
-    "readthedocs": "modal",
-    "sphinx": "tooltip",
-}
-
-hoverxref_domains = [
-    "py",
-]
 
 # Enabled Markdown extensions.
 # See here for what they do:

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -2,5 +2,4 @@ sphinx==7.2.6
 myst-parser==2.0.0
 breathe==4.35.0
 sphinx_copybutton==0.5.2
-sphinx-hoverxref==1.3.0
 sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
The Sphinx extension `hoverxref` is deprecated: https://github.com/readthedocs/sphinx-hoverxref

> Warning
>
>This extension has been deprecated. Users are advised to enable the "Link previews" option in "Settings" > "Addons" > >"Link previews" in the Read the Docs admin dashboard for their project to get the same functionality as this extension.
>
>For more information, please see:
>
>https://docs.readthedocs.com/platform/stable/link-previews.html
>https://about.readthedocs.com/blog/2024/07/addons-by-default/

As discussed in #783 this is one of the issues with the current sphinx build.