### PR TITLE
Improvements to errorlog

### DIFF
--- a/documentation/new-notes/PR-801.md
+++ b/documentation/new-notes/PR-801.md
@@ -1,0 +1,7 @@
+### errlogInit can be run more than once
+
+Previously, running `errlogInit` after initialisation would silently fail. It is
+now possible to call `errlogInit` or `errlogInit2` multiple times in order to
+increase the buffer size.
+
+Note that it is not possible to _shrink_ the buffer size.

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -1164,7 +1164,6 @@ POSIX_Init ( void *argument __attribute__((unused)))
     set_directory (argv[1]);
     epicsEnvSet ("IOC_STARTUP_SCRIPT", argv[1]);
     atexit(exitHandler);
-    errlogFlush();
     printf ("***** Starting EPICS application *****\n");
 
 

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -126,10 +126,10 @@ logReset (void)
     if (fp) {
         char buf[80];
         fp(buf, sizeof buf);
-        errlogPrintf ("Startup after %s.\n", buf);
+        printf ("Startup after %s.\n", buf);
     }
     else {
-        errlogPrintf ("Startup.\n");
+        printf ("Startup.\n");
     }
 }
 
@@ -169,7 +169,7 @@ LogFatal (const char *msg, ...)
 void
 LogRtemsFatal (const char *msg, rtems_status_code sc)
 {
-    errlogPrintf ("%s: %s\n", msg, rtems_status_text (sc));
+    printf ("%s: %s\n", msg, rtems_status_text (sc));
     delayedPanic (msg);
 }
 
@@ -179,7 +179,7 @@ LogRtemsFatal (const char *msg, rtems_status_code sc)
 void
 LogNetFatal (const char *msg, int err)
 {
-    errlogPrintf ("%s: %d\n", msg, err);
+    printf ("%s: %d\n", msg, err);
     delayedPanic (msg);
 }
 
@@ -411,7 +411,7 @@ initialize_remote_filesystem(char **argv, int hasLocalFilesystem)
             argv[1] = abspath;
         }
     }
-    errlogPrintf("nfsMount(\"%s\", \"%s\", \"%s\")\n",
+    printf("nfsMount(\"%s\", \"%s\", \"%s\")\n",
                  server_name, server_path, mount_point);
     nfsMount(server_name, server_path, mount_point);
 #endif
@@ -484,7 +484,7 @@ set_directory (const char *commandline)
     if (chdir (directoryPath) < 0)
         LogFatal ("Can't set initial directory(%s): %s\n", directoryPath, strerror(errno));
     else
-        errlogPrintf("chdir(\"%s\")\n", directoryPath);
+        printf("chdir(\"%s\")\n", directoryPath);
     free(directoryPath);
 }
 

--- a/modules/libcom/RTEMS/score/rtems_init.c
+++ b/modules/libcom/RTEMS/score/rtems_init.c
@@ -684,7 +684,6 @@ Init (rtems_task_argument ignored)
     set_directory (argv[1]);
     epicsEnvSet ("IOC_STARTUP_SCRIPT", argv[1]);
     atexit(exitHandler);
-    errlogFlush();
     printf ("***** Starting EPICS application *****\n");
     result = main ((sizeof argv / sizeof argv[0]) - 1, argv);
     printf ("***** IOC application terminating *****\n");

--- a/modules/libcom/RTEMS/score/rtems_init.c
+++ b/modules/libcom/RTEMS/score/rtems_init.c
@@ -63,10 +63,10 @@ logReset (void)
     if (fp) {
         char buf[80];
         fp(buf, sizeof buf);
-        errlogPrintf ("Startup after %s.\n", buf);
+        printf ("Startup after %s.\n", buf);
     }
     else {
-        errlogPrintf ("Startup.\n");
+        printf ("Startup.\n");
     }
 }
 
@@ -341,7 +341,7 @@ initialize_remote_filesystem(char **argv, int hasLocalFilesystem)
             argv[1] = abspath;
         }
     }
-    errlogPrintf("nfsMount(\"%s\", \"%s\", \"%s\")\n",
+    printf("nfsMount(\"%s\", \"%s\", \"%s\")\n",
                  server_name, server_path, mount_point);
     nfsMount(server_name, server_path, mount_point);
 #endif
@@ -414,7 +414,7 @@ set_directory (const char *commandline)
     if (chdir (directoryPath) < 0)
         LogFatal ("Can't set initial directory(%s): %s\n", directoryPath, strerror(errno));
     else
-        errlogPrintf("chdir(\"%s\")\n", directoryPath);
+        printf("chdir(\"%s\")\n", directoryPath);
     free(directoryPath);
 }
 

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -639,19 +639,22 @@ void errlogBufResize(struct initArgs config)
     }
 
     epicsMutexMustLock(pvt.msgQueueLock);
+    char *oldlogbuf = pvt.log->base;
+    char *oldprintbuf = pvt.print->base;
 
     memcpy(logbuf, pvt.log->base, pvt.bufSize);
-    free(pvt.log->base);
     pvt.log->base = logbuf;
 
     memcpy(printbuf, &pvt.print->base, pvt.bufSize);
-    free(pvt.print->base);
     pvt.print->base = printbuf;
 
     pvt.bufSize = config.bufsize;
     pvt.maxMsgSize = config.maxMsgSize;
 
     epicsMutexUnlock(pvt.msgQueueLock);
+
+    free(oldlogbuf);
+    free(oldprintbuf);
 }
 
 int errlogInit2(int bufsize, int maxMsgSize)

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -77,6 +77,7 @@ typedef struct {
 } buffer_t;
 
 static struct {
+    epicsThreadId tid;
     epicsMutexId bufSizeLock;
     /* guarded by bufSizeLock, allowing them to be resized after initialisation */
     size_t maxMsgSize;
@@ -563,7 +564,6 @@ static void errlogInitPvt(void *arg)
 {
     struct initArgs *pconfig = (struct initArgs *) arg;
 
-    epicsThreadId tid = NULL;
     epicsThreadOpts topts = EPICS_THREAD_OPTS_INIT;
 
     topts.priority = epicsThreadPriorityLow;
@@ -574,6 +574,7 @@ static void errlogInitPvt(void *arg)
      * cantProceed() calls us.
      */
 
+    pvt.tid = NULL;
     pvt.errlogInitFailed = TRUE;
     pvt.bufSizeLock = epicsMutexCreate();
     pvt.bufSize = pconfig->bufsize;
@@ -601,11 +602,11 @@ static void errlogInitPvt(void *arg)
             && pvt.log->base
             && pvt.print->base
             ) {
-        tid = epicsThreadCreateOpt("errlog", (EPICSTHREADFUNC)errlogThread, 0, &topts);
+        pvt.tid = epicsThreadCreateOpt("errlog", (EPICSTHREADFUNC)errlogThread, 0, &topts);
     }
-    if (tid) {
+    if (pvt.tid) {
         pvt.errlogInitFailed = FALSE;
-        epicsAtExit(errlogExitHandler, tid);
+        epicsAtExit(errlogExitHandler, pvt.tid);
     }
 }
 
@@ -670,6 +671,11 @@ int errlogInit2(int bufsize, int maxMsgSize)
 
     // Don't resize the buffer for any of the calls to errlogInit(0)
     if (bufsize == 0) return 0;
+
+    if (epicsThreadGetIdSelf() == pvt.tid) {
+        fprintf(stderr, "Cannot resize buffer from callback function.\n");
+        return -1;
+    }
 
     epicsMutexMustLock(pvt.bufSizeLock);
     if (pvt.bufSize != config.bufsize || pvt.maxMsgSize != config.maxMsgSize) {

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -583,6 +583,33 @@ static void errlogInitPvt(void *arg)
     }
 }
 
+static
+int errlogClampConfig(struct initArgs *config, int bufsize, int maxMsgSize)
+{
+    int clamped = 0;
+
+    if (bufsize < MIN_BUFFER_SIZE)
+    {
+        // This is to deal with the fact that errlogInit() is often called with arg 0
+        clamped = bufsize == 0 ? 0 : 1;
+        bufsize = MIN_BUFFER_SIZE;
+    }
+    config->bufsize = bufsize;
+
+    if (maxMsgSize > MAX_MESSAGE_SIZE(bufsize))
+    {
+        clamped = 1;
+        maxMsgSize = MAX_MESSAGE_SIZE(bufsize);
+    }
+    if (maxMsgSize < MIN_MESSAGE_SIZE)
+    {
+        clamped = 1;
+        maxMsgSize = MIN_MESSAGE_SIZE;
+    }
+    config->maxMsgSize = maxMsgSize;
+
+    return clamped;
+}
 
 int errlogInit2(int bufsize, int maxMsgSize)
 {
@@ -592,15 +619,9 @@ int errlogInit2(int bufsize, int maxMsgSize)
     if (pvt.atExit)
         return 0;
 
-    if (bufsize < MIN_BUFFER_SIZE)
-        bufsize = MIN_BUFFER_SIZE;
-    config.bufsize = bufsize;
-
-    if (maxMsgSize > MAX_MESSAGE_SIZE(bufsize))
-        maxMsgSize = MAX_MESSAGE_SIZE(bufsize);
-    if (maxMsgSize < MIN_MESSAGE_SIZE)
-        maxMsgSize = MIN_MESSAGE_SIZE;
-    config.maxMsgSize = maxMsgSize;
+    if (errlogClampConfig(&config, bufsize, maxMsgSize)) {
+        fprintf(stderr, "Warning: errlog config clamped from (%zu, %zu) to (%zu, %zu)\n", bufsize, maxMsgSize, config.bufsize, config.maxMsgSize);
+    }
 
     epicsThreadOnce(&errlogOnceFlag, errlogInitPvt, &config);
     if (pvt.errlogInitFailed) {
@@ -619,6 +640,7 @@ int errlogBufResize(int bufsize, int maxMsgSize)
 {
     char* logbuf = NULL;
     char* printbuf = NULL;
+    struct initArgs config;
 
     epicsMutexMustLock(pvt.bufSizeLock);
 
@@ -629,16 +651,12 @@ int errlogBufResize(int bufsize, int maxMsgSize)
         return -1;
     }
 
-    if (bufsize < MIN_BUFFER_SIZE)
-        bufsize = MIN_BUFFER_SIZE;
+    if (errlogClampConfig(&config, bufsize, maxMsgSize)) {
+        fprintf(stderr, "Warning: errlog config clamped from (%zu, %zu) to (%zu, %zu)\n", bufsize, maxMsgSize, config.bufsize, config.maxMsgSize);
+    }
 
-    if (maxMsgSize > MAX_MESSAGE_SIZE(bufsize))
-        maxMsgSize = MAX_MESSAGE_SIZE(bufsize);
-    if (maxMsgSize < MIN_MESSAGE_SIZE)
-        maxMsgSize = MIN_MESSAGE_SIZE;
-
-    logbuf = calloc(1, bufsize);
-    printbuf = calloc(1, bufsize);
+    logbuf = calloc(1, config.bufsize);
+    printbuf = calloc(1, config.bufsize);
 
     epicsMutexMustLock(pvt.msgQueueLock);
 
@@ -650,8 +668,8 @@ int errlogBufResize(int bufsize, int maxMsgSize)
     free(pvt.print->base);
     pvt.print->base = printbuf;
 
-    pvt.bufSize = bufsize;
-    pvt.maxMsgSize = maxMsgSize;
+    pvt.bufSize = config.bufsize;
+    pvt.maxMsgSize = config.maxMsgSize;
 
     epicsMutexUnlock(pvt.msgQueueLock);
     epicsMutexUnlock(pvt.bufSizeLock);

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -77,6 +77,7 @@ typedef struct {
 } buffer_t;
 
 static struct {
+    epicsMutexId bufSizeLock;
     /* const after errlogInit() */
     size_t maxMsgSize;
     /* alloc size of both buffer_t::base */
@@ -548,6 +549,7 @@ static void errlogInitPvt(void *arg)
      */
 
     pvt.errlogInitFailed = TRUE;
+    pvt.bufSizeLock = epicsMutexCreate();
     pvt.bufSize = pconfig->bufsize;
     pvt.maxMsgSize = pconfig->maxMsgSize;
     ellInit(&pvt.listenerList);
@@ -566,6 +568,7 @@ static void errlogInitPvt(void *arg)
     errSymBld();    /* Better not to do this lazily... */
 
     if(pvt.waitForWork
+            && pvt.bufSizeLock
             && pvt.listenerLock
             && pvt.msgQueueLock
             && pvt.waitForSeq
@@ -610,6 +613,32 @@ int errlogInit2(int bufsize, int maxMsgSize)
 int errlogInit(int bufsize)
 {
     return errlogInit2(bufsize, DEFAULT_MAX_MSG_SIZE);
+}
+
+void errlogBufResize(int bufsize, int maxMsgSize)
+{
+    if (bufsize < MIN_BUFFER_SIZE)
+        bufsize = MIN_BUFFER_SIZE;
+    if (maxMsgSize < MIN_MESSAGE_SIZE)
+        maxMsgSize = MIN_MESSAGE_SIZE;
+    else if (maxMsgSize > MAX_MESSAGE_SIZE)
+        maxMsgSize = MAX_MESSAGE_SIZE;
+
+    errlogFlush();
+
+    epicsMutexMustLock(pvt.bufSizeLock);
+    epicsMutexMustLock(pvt.msgQueueLock);
+
+    pvt.bufSize = bufsize;
+    pvt.maxMsgSize = maxMsgSize;
+
+    free(pvt.log->base);
+    pvt.log->base = callocMustSucceed(1, pvt.bufSize, "Failed to allocate memory for errorlog buffer");
+    free(pvt.print->base);
+    pvt.print->base = callocMustSucceed(1, pvt.bufSize, "Failed to allocate memory for errorlog buffer");
+
+    epicsMutexUnlock(pvt.msgQueueLock);
+    epicsMutexUnlock(pvt.bufSizeLock);
 }
 
 void errlogFlush(void)

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -641,6 +641,34 @@ void errlogBufResize(int bufsize, int maxMsgSize)
     epicsMutexUnlock(pvt.bufSizeLock);
 }
 
+void errlogShow(int level)
+{
+    epicsMutexMustLock(pvt.bufSizeLock);
+    printf("Error log:\n");
+    printf("  buffer size: %zu\n", pvt.bufSize);
+    printf("  max message size: %zu\n", pvt.maxMsgSize);
+    epicsMutexUnlock(pvt.bufSizeLock);
+
+    if (level > 0)
+    {
+        epicsMutexMustLock(pvt.listenerLock);
+        printf("  number of listeners: %u\n", pvt.listenerList.count);
+        epicsMutexUnlock(pvt.listenerLock);
+    }
+
+    if (level > 1)
+    {
+        epicsMutexMustLock(pvt.msgQueueLock);
+        printf("  buffer(log) contents:\n");
+        printf("%s\n", pvt.log->base);
+        printf("%*s^\n", (int)pvt.log->pos, "");
+        printf("  buffer(print) contents:\n");
+        printf("%s\n", pvt.print->base);
+        printf("%*s^\n", (int)pvt.print->pos, "");
+        epicsMutexUnlock(pvt.msgQueueLock);
+    }
+}
+
 void errlogFlush(void)
 {
     /* wait for both buffers to be handled to know that all currently

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -44,7 +44,7 @@
 #define MIN_BUFFER_SIZE 2560
 #define DEFAULT_MAX_MSG_SIZE 512
 #define MIN_MESSAGE_SIZE 256
-#define MAX_MESSAGE_SIZE 0x00ffffff
+#define MAX_MESSAGE_SIZE(bufsize) ((bufsize) / 5)
 
 /* errlog buffers contain null terminated strings, each prefixed
  * with a 1 byte header containing flags.
@@ -596,10 +596,10 @@ int errlogInit2(int bufsize, int maxMsgSize)
         bufsize = MIN_BUFFER_SIZE;
     config.bufsize = bufsize;
 
+    if (maxMsgSize > MAX_MESSAGE_SIZE(bufsize))
+        maxMsgSize = MAX_MESSAGE_SIZE(bufsize);
     if (maxMsgSize < MIN_MESSAGE_SIZE)
         maxMsgSize = MIN_MESSAGE_SIZE;
-    else if (maxMsgSize > MAX_MESSAGE_SIZE)
-        maxMsgSize = MAX_MESSAGE_SIZE;
     config.maxMsgSize = maxMsgSize;
 
     epicsThreadOnce(&errlogOnceFlag, errlogInitPvt, &config);
@@ -632,10 +632,10 @@ int errlogBufResize(int bufsize, int maxMsgSize)
     if (bufsize < MIN_BUFFER_SIZE)
         bufsize = MIN_BUFFER_SIZE;
 
+    if (maxMsgSize > MAX_MESSAGE_SIZE(bufsize))
+        maxMsgSize = MAX_MESSAGE_SIZE(bufsize);
     if (maxMsgSize < MIN_MESSAGE_SIZE)
         maxMsgSize = MIN_MESSAGE_SIZE;
-    else if (maxMsgSize > MAX_MESSAGE_SIZE)
-        maxMsgSize = MAX_MESSAGE_SIZE;
 
     logbuf = calloc(1, bufsize);
     printbuf = calloc(1, bufsize);

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -41,7 +41,8 @@
 #include "osiUnistd.h"
 
 
-#define MIN_BUFFER_SIZE 1280
+#define MIN_BUFFER_SIZE 2560
+#define DEFAULT_MAX_MSG_SIZE 512
 #define MIN_MESSAGE_SIZE 256
 #define MAX_MESSAGE_SIZE 0x00ffffff
 
@@ -608,7 +609,7 @@ int errlogInit2(int bufsize, int maxMsgSize)
 
 int errlogInit(int bufsize)
 {
-    return errlogInit2(bufsize, MIN_MESSAGE_SIZE);
+    return errlogInit2(bufsize, DEFAULT_MAX_MSG_SIZE);
 }
 
 void errlogFlush(void)

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -563,8 +563,6 @@ static void errlogInitPvt(void *arg)
 {
     struct initArgs *pconfig = (struct initArgs *) arg;
 
-    errlogClampConfig(pconfig);
-
     epicsThreadId tid = NULL;
     epicsThreadOpts topts = EPICS_THREAD_OPTS_INIT;
 
@@ -620,12 +618,6 @@ void errlogBufResize(struct initArgs config)
         return;
     }
 
-    size_t bufsize = config.bufsize;
-    size_t maxMsgSize = config.maxMsgSize;
-    if (errlogClampConfig(&config)) {
-        fprintf(stderr, "Warning: errlog config clamped from (%zu, %zu) to (%zu, %zu)\n", bufsize, maxMsgSize, config.bufsize, config.maxMsgSize);
-    }
-
     char *logbuf = calloc(1, config.bufsize);
     if (!logbuf) {
         fprintf(stderr, ERL_ERROR ": Failed to allocated errlog log buffer.\n");
@@ -664,6 +656,11 @@ int errlogInit2(int bufsize, int maxMsgSize)
 
     if (pvt.atExit)
         return 0;
+
+    if (errlogClampConfig(&config) && (bufsize != 0)) {
+        // No sense warning for every call to errlogInit(0)
+        fprintf(stderr, "Warning: errlog config clamped from (%d, %d) to (%zu, %zu)\n", bufsize, maxMsgSize, config.bufsize, config.maxMsgSize);
+    }
 
     epicsThreadOnce(&errlogOnceFlag, errlogInitPvt, &config);
     if (pvt.errlogInitFailed) {

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -534,9 +534,37 @@ struct initArgs {
     size_t maxMsgSize;
 };
 
+static
+int errlogClampConfig(struct initArgs *config)
+{
+    int clamped = 0;
+
+    if (config->bufsize < MIN_BUFFER_SIZE)
+    {
+        clamped = 1;
+        config->bufsize = MIN_BUFFER_SIZE;
+    }
+
+    if (config->maxMsgSize > MAX_MESSAGE_SIZE(config->bufsize))
+    {
+        clamped = 1;
+        config->maxMsgSize = MAX_MESSAGE_SIZE(config->bufsize);
+    }
+    if (config->maxMsgSize < MIN_MESSAGE_SIZE)
+    {
+        clamped = 1;
+        config->maxMsgSize = MIN_MESSAGE_SIZE;
+    }
+
+    return clamped;
+}
+
 static void errlogInitPvt(void *arg)
 {
     struct initArgs *pconfig = (struct initArgs *) arg;
+
+    errlogClampConfig(pconfig);
+
     epicsThreadId tid = NULL;
     epicsThreadOpts topts = EPICS_THREAD_OPTS_INIT;
 
@@ -583,80 +611,32 @@ static void errlogInitPvt(void *arg)
     }
 }
 
+// This function must be called with pvt.bufSizeLock held
 static
-int errlogClampConfig(struct initArgs *config, int bufsize, int maxMsgSize)
+void errlogBufResize(struct initArgs config)
 {
-    int clamped = 0;
-
-    if (bufsize < MIN_BUFFER_SIZE)
-    {
-        // This is to deal with the fact that errlogInit() is often called with arg 0
-        clamped = bufsize == 0 ? 0 : 1;
-        bufsize = MIN_BUFFER_SIZE;
+    if (config.bufsize < pvt.bufSize) {
+        fprintf(stderr, "Warning: Cannot shrink buffer size.\n");
+        return;
     }
-    config->bufsize = bufsize;
 
-    if (maxMsgSize > MAX_MESSAGE_SIZE(bufsize))
-    {
-        clamped = 1;
-        maxMsgSize = MAX_MESSAGE_SIZE(bufsize);
-    }
-    if (maxMsgSize < MIN_MESSAGE_SIZE)
-    {
-        clamped = 1;
-        maxMsgSize = MIN_MESSAGE_SIZE;
-    }
-    config->maxMsgSize = maxMsgSize;
-
-    return clamped;
-}
-
-int errlogInit2(int bufsize, int maxMsgSize)
-{
-    static epicsThreadOnceId errlogOnceFlag = EPICS_THREAD_ONCE_INIT;
-    struct initArgs config;
-
-    if (pvt.atExit)
-        return 0;
-
-    if (errlogClampConfig(&config, bufsize, maxMsgSize)) {
+    size_t bufsize = config.bufsize;
+    size_t maxMsgSize = config.maxMsgSize;
+    if (errlogClampConfig(&config)) {
         fprintf(stderr, "Warning: errlog config clamped from (%zu, %zu) to (%zu, %zu)\n", bufsize, maxMsgSize, config.bufsize, config.maxMsgSize);
     }
 
-    epicsThreadOnce(&errlogOnceFlag, errlogInitPvt, &config);
-    if (pvt.errlogInitFailed) {
-        fprintf(stderr,"errlogInit failed\n");
-        exit(1);
+    char *logbuf = calloc(1, config.bufsize);
+    if (!logbuf) {
+        fprintf(stderr, ERL_ERROR ": Failed to allocated errlog log buffer.\n");
+        return;
     }
-    return 0;
-}
-
-int errlogInit(int bufsize)
-{
-    return errlogInit2(bufsize, DEFAULT_MAX_MSG_SIZE);
-}
-
-int errlogBufResize(int bufsize, int maxMsgSize)
-{
-    char* logbuf = NULL;
-    char* printbuf = NULL;
-    struct initArgs config;
-
-    epicsMutexMustLock(pvt.bufSizeLock);
-
-    // Only increasing the buffer size is allowed!
-    if (bufsize < pvt.bufSize) {
-        epicsMutexUnlock(pvt.bufSizeLock);
-        fprintf(stderr, "Shrinking the errorlog buffer is not allowed.\n");
-        return -1;
+    char *printbuf = calloc(1, config.bufsize);
+    if (!printbuf) {
+        free(logbuf);
+        fprintf(stderr, ERL_ERROR ": Failed to allocated errlog print buffer.\n");
+        return;
     }
-
-    if (errlogClampConfig(&config, bufsize, maxMsgSize)) {
-        fprintf(stderr, "Warning: errlog config clamped from (%zu, %zu) to (%zu, %zu)\n", bufsize, maxMsgSize, config.bufsize, config.maxMsgSize);
-    }
-
-    logbuf = calloc(1, config.bufsize);
-    printbuf = calloc(1, config.bufsize);
 
     epicsMutexMustLock(pvt.msgQueueLock);
 
@@ -672,7 +652,37 @@ int errlogBufResize(int bufsize, int maxMsgSize)
     pvt.maxMsgSize = config.maxMsgSize;
 
     epicsMutexUnlock(pvt.msgQueueLock);
+}
+
+int errlogInit2(int bufsize, int maxMsgSize)
+{
+    static epicsThreadOnceId errlogOnceFlag = EPICS_THREAD_ONCE_INIT;
+    struct initArgs config = {bufsize, maxMsgSize};
+
+    if (pvt.atExit)
+        return 0;
+
+    epicsThreadOnce(&errlogOnceFlag, errlogInitPvt, &config);
+    if (pvt.errlogInitFailed) {
+        fprintf(stderr,"errlogInit failed\n");
+        exit(1);
+    }
+
+    // Don't resize the buffer for any of the calls to errlogInit(0)
+    if (bufsize == 0) return 0;
+
+    epicsMutexMustLock(pvt.bufSizeLock);
+    if (pvt.bufSize != config.bufsize || pvt.maxMsgSize != config.maxMsgSize) {
+        // We are resizing the buffer after initialisation
+        errlogBufResize(config);
+    }
     epicsMutexUnlock(pvt.bufSizeLock);
+    return 0;
+}
+
+int errlogInit(int bufsize)
+{
+    return errlogInit2(bufsize, DEFAULT_MAX_MSG_SIZE);
 }
 
 void errlogShow(int level)

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -78,10 +78,10 @@ typedef struct {
 
 static struct {
     epicsMutexId bufSizeLock;
-    /* const after errlogInit() */
+    /* guarded by bufSizeLock, allowing them to be resized after initialisation */
     size_t maxMsgSize;
-    /* alloc size of both buffer_t::base */
     size_t bufSize;
+
     int    errlogInitFailed;
 
     epicsMutexId listenerLock;
@@ -726,6 +726,7 @@ void errlogFlush(void)
 static void errlogThread(void)
 {
     int wakeFlusher;
+    epicsMutexMustLock(pvt.bufSizeLock);
     epicsMutexMustLock(pvt.msgQueueLock);
     while (1) {
         pvt.flushSeq++;
@@ -735,9 +736,17 @@ static void errlogThread(void)
                 break;
             wakeFlusher = pvt.nFlushers!=0;
             epicsMutexUnlock(pvt.msgQueueLock);
+            // Allow the buffer size to be modified only at this point
+            epicsMutexUnlock(pvt.bufSizeLock);
+
             if(wakeFlusher)
                 epicsEventMustTrigger(pvt.waitForSeq);
+
             epicsEventMustWait(pvt.waitForWork);
+
+            // Block resizing the buffer size
+            epicsMutexMustLock(pvt.bufSizeLock);
+
             epicsMutexMustLock(pvt.msgQueueLock);
 
         } else {
@@ -755,6 +764,8 @@ static void errlogThread(void)
             }
 
             pvt.nLost = 0u;
+            // Note that we are intentionally still holding the buffer size lock
+            // here. The buffer can only be resized when this thread is idle.
             epicsMutexUnlock(pvt.msgQueueLock);
 
             while(pos < print->pos) {
@@ -818,6 +829,7 @@ static void errlogThread(void)
     }
     wakeFlusher = pvt.nFlushers!=0;
     epicsMutexUnlock(pvt.msgQueueLock);
+    epicsMutexUnlock(pvt.bufSizeLock);
     if(wakeFlusher)
         epicsEventMustTrigger(pvt.waitForSeq);
 }

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -615,27 +615,43 @@ int errlogInit(int bufsize)
     return errlogInit2(bufsize, DEFAULT_MAX_MSG_SIZE);
 }
 
-void errlogBufResize(int bufsize, int maxMsgSize)
+int errlogBufResize(int bufsize, int maxMsgSize)
 {
+    char* logbuf = NULL;
+    char* printbuf = NULL;
+
+    epicsMutexMustLock(pvt.bufSizeLock);
+
+    // Only increasing the buffer size is allowed!
+    if (bufsize < pvt.bufSize) {
+        epicsMutexUnlock(pvt.bufSizeLock);
+        fprintf(stderr, "Shrinking the errorlog buffer is not allowed.\n");
+        return -1;
+    }
+
     if (bufsize < MIN_BUFFER_SIZE)
         bufsize = MIN_BUFFER_SIZE;
+
     if (maxMsgSize < MIN_MESSAGE_SIZE)
         maxMsgSize = MIN_MESSAGE_SIZE;
     else if (maxMsgSize > MAX_MESSAGE_SIZE)
         maxMsgSize = MAX_MESSAGE_SIZE;
 
-    errlogFlush();
+    logbuf = calloc(1, bufsize);
+    printbuf = calloc(1, bufsize);
 
-    epicsMutexMustLock(pvt.bufSizeLock);
     epicsMutexMustLock(pvt.msgQueueLock);
+
+    memcpy(logbuf, pvt.log->base, pvt.bufSize);
+    free(pvt.log->base);
+    pvt.log->base = logbuf;
+
+    memcpy(printbuf, &pvt.print->base, pvt.bufSize);
+    free(pvt.print->base);
+    pvt.print->base = printbuf;
 
     pvt.bufSize = bufsize;
     pvt.maxMsgSize = maxMsgSize;
-
-    free(pvt.log->base);
-    pvt.log->base = callocMustSucceed(1, pvt.bufSize, "Failed to allocate memory for errorlog buffer");
-    free(pvt.print->base);
-    pvt.print->base = callocMustSucceed(1, pvt.bufSize, "Failed to allocate memory for errorlog buffer");
 
     epicsMutexUnlock(pvt.msgQueueLock);
     epicsMutexUnlock(pvt.bufSizeLock);

--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -615,7 +615,7 @@ static
 void errlogBufResize(struct initArgs config)
 {
     if (config.bufsize < pvt.bufSize) {
-        fprintf(stderr, "Warning: Cannot shrink buffer size.\n");
+        fprintf(stderr, ERL_WARNING ": Cannot shrink buffer size.\n");
         return;
     }
 
@@ -660,12 +660,12 @@ int errlogInit2(int bufsize, int maxMsgSize)
 
     if (errlogClampConfig(&config) && (bufsize != 0)) {
         // No sense warning for every call to errlogInit(0)
-        fprintf(stderr, "Warning: errlog config clamped from (%d, %d) to (%zu, %zu)\n", bufsize, maxMsgSize, config.bufsize, config.maxMsgSize);
+        fprintf(stderr, ERL_WARNING ": errlog config clamped from (%d, %d) to (%zu, %zu)\n", bufsize, maxMsgSize, config.bufsize, config.maxMsgSize);
     }
 
     epicsThreadOnce(&errlogOnceFlag, errlogInitPvt, &config);
     if (pvt.errlogInitFailed) {
-        fprintf(stderr,"errlogInit failed\n");
+        fprintf(stderr, ERL_ERROR ": errlogInit failed\n");
         exit(1);
     }
 
@@ -673,7 +673,7 @@ int errlogInit2(int bufsize, int maxMsgSize)
     if (bufsize == 0) return 0;
 
     if (epicsThreadGetIdSelf() == pvt.tid) {
-        fprintf(stderr, "Cannot resize buffer from callback function.\n");
+        fprintf(stderr, ERL_ERROR ": Cannot resize buffer from callback function.\n");
         return -1;
     }
 
@@ -781,7 +781,7 @@ static void errlogThread(void)
                 int stripped = 0;
 
                 if((base[0]&ERL_STATE_MASK) != ERL_STATE_READY || mlen>=pvt.bufSize - pos) {
-                    fprintf(stderr, "Logic Error: errlog buffer corruption. %02x, %zu\n",
+                    fprintf(stderr, ERL_ERROR ": errlog buffer corruption. %02x, %zu\n",
                             (unsigned)base[0], mlen);
                     /* try to reset and recover */
                     break;

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -205,18 +205,22 @@ LIBCOM_API int eltc(int yesno);
 LIBCOM_API int errlogSetConsole(FILE *stream);
 
 /**
- * Can be used to initialize the error logging system with a larger buffer. The default buffer size is 1280 bytes.
+ * Can be used to initialize the error logging system with a larger buffer. The default buffer size is 2560 bytes.
  *
  * \param bufsize The desired buffer size
+ *
+ * \since UNRELEASED the default buffer size is 2560.
  */
 LIBCOM_API int errlogInit(int bufsize);
 
 /**
  * errlogInit2 can be used to initialize the error logging system with a larger buffer and maximum message size.
- * The default buffer size is 1280 bytes, and the default maximum message size is 256.
+ * The default buffer size is 2560 bytes, and the default maximum message size is 512.
  *
  * \param bufsize The desired buffer size
  * \param maxMsgSize The desired max message size
+ *
+ * \since UNRELEASED The default buffer size is 2560 and the default maximum message size is 512.
  */
 LIBCOM_API int errlogInit2(int bufsize, int maxMsgSize);
 

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -224,6 +224,15 @@ LIBCOM_API int errlogInit(int bufsize);
  */
 LIBCOM_API int errlogInit2(int bufsize, int maxMsgSize);
 
+/**
+ * errlogBufResize can be used to reinitialize the error logging system with a larger buffer and maximum message size.
+ * The default buffer size is 1280 bytes, and the default maximum message size is 256.
+ *
+ * \param bufsize The desired buffer size
+ * \param maxMsgSize The desired max message size
+ */
+LIBCOM_API int errlogBufResize(int bufsize, int maxMsgSize);
+
 /** Wakes up the errlog task and then waits until all messages are flushed from the queue. */
 LIBCOM_API void errlogFlush(void);
 

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -208,6 +208,7 @@ LIBCOM_API int errlogSetConsole(FILE *stream);
  * Can be used to initialize the error logging system with a larger buffer. The default buffer size is 2560 bytes.
  *
  * \param bufsize The desired buffer size
+ * \return 0 if successful, -1 if called from callback function
  *
  * \since UNRELEASED the default buffer size is 2560.
  */
@@ -219,6 +220,7 @@ LIBCOM_API int errlogInit(int bufsize);
  *
  * \param bufsize The desired buffer size
  * \param maxMsgSize The desired max message size
+ * \return 0 if successful, -1 if called from callback function
  *
  * \since UNRELEASED The default buffer size is 2560 and the default maximum message size is 512.
  */

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -224,15 +224,6 @@ LIBCOM_API int errlogInit(int bufsize);
  */
 LIBCOM_API int errlogInit2(int bufsize, int maxMsgSize);
 
-/**
- * errlogBufResize can be used to reinitialize the error logging system with a larger buffer and maximum message size.
- * The default buffer size is 1280 bytes, and the default maximum message size is 256.
- *
- * \param bufsize The desired buffer size
- * \param maxMsgSize The desired max message size
- */
-LIBCOM_API void errlogBufResize(int bufsize, int maxMsgSize);
-
 /** Wakes up the errlog task and then waits until all messages are flushed from the queue. */
 LIBCOM_API void errlogFlush(void);
 

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -224,6 +224,15 @@ LIBCOM_API int errlogInit(int bufsize);
  */
 LIBCOM_API int errlogInit2(int bufsize, int maxMsgSize);
 
+/**
+ * errlogBufResize can be used to reinitialize the error logging system with a larger buffer and maximum message size.
+ * The default buffer size is 1280 bytes, and the default maximum message size is 256.
+ *
+ * \param bufsize The desired buffer size
+ * \param maxMsgSize The desired max message size
+ */
+LIBCOM_API void errlogBufResize(int bufsize, int maxMsgSize);
+
 /** Wakes up the errlog task and then waits until all messages are flushed from the queue. */
 LIBCOM_API void errlogFlush(void);
 

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -224,15 +224,6 @@ LIBCOM_API int errlogInit(int bufsize);
  */
 LIBCOM_API int errlogInit2(int bufsize, int maxMsgSize);
 
-/**
- * errlogBufResize can be used to reinitialize the error logging system with a larger buffer and maximum message size.
- * The default buffer size is 1280 bytes, and the default maximum message size is 256.
- *
- * \param bufsize The desired buffer size
- * \param maxMsgSize The desired max message size
- */
-LIBCOM_API int errlogBufResize(int bufsize, int maxMsgSize);
-
 /** Wakes up the errlog task and then waits until all messages are flushed from the queue. */
 LIBCOM_API void errlogFlush(void);
 

--- a/modules/libcom/src/error/errlog.h
+++ b/modules/libcom/src/error/errlog.h
@@ -222,7 +222,8 @@ LIBCOM_API int errlogInit(int bufsize);
  * \param maxMsgSize The desired max message size
  * \return 0 if successful, -1 if called from callback function
  *
- * \since UNRELEASED The default buffer size is 2560 and the default maximum message size is 512.
+ * \since UNRELEASED It is possible to enlarge the error log buffer size after initialisation.
+ *                   The default buffer size is 2560 and the default maximum message size is 512.
  */
 LIBCOM_API int errlogInit2(int bufsize, int maxMsgSize);
 

--- a/modules/libcom/src/error/errlogPvt.h
+++ b/modules/libcom/src/error/errlogPvt.h
@@ -1,0 +1,26 @@
+/*************************************************************************\
+* Copyright (c) 2026 European Spallation Source ERIC
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#ifndef INC_errlogPvt_H
+#define INC_errlogPvt_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * errlogShow is used to display the contents of the error log buffers
+ *
+ * \param level How much detail to print out
+ */
+void errlogShow(int level);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*INC_errlogPvt_H*/

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -290,6 +290,22 @@ static void errlogInit2CallFunc(const iocshArgBuf *args)
     errlogInit2(args[0].ival, args[1].ival);
 }
 
+/* errlogBufResize */
+static const iocshArg errlogBufResizeArg0 = { "bufSize",iocshArgInt};
+static const iocshArg errlogBufResizeArg1 = { "maxMsgSize",iocshArgInt};
+static const iocshArg * const errlogBufResizeArgs[] =
+    {&errlogBufResizeArg0, &errlogBufResizeArg1};
+static const iocshFuncDef errlogBufResizeFuncDef = {
+    "errlogBufResize", 2, errlogBufResizeArgs,
+    "Reinitialize error log client buffer size and maximum message size\n"
+    "  bufSize    - size of circular buffer       (default = 1280 bytes)\n"
+    "  maxMsgSize - maximum size of error message (default =  256 bytes)\n"
+};
+static void errlogBufResizeCallFunc(const iocshArgBuf *args)
+{
+    errlogBufResize(args[0].ival, args[1].ival);
+}
+
 /* errlog */
 IOCSH_STATIC_FUNC void errlog(const char *message)
 {
@@ -500,6 +516,7 @@ void epicsStdCall libComRegister(void)
     iocshRegister(&eltcFuncDef, eltcCallFunc);
     iocshRegister(&errlogInitFuncDef,errlogInitCallFunc);
     iocshRegister(&errlogInit2FuncDef,errlogInit2CallFunc);
+    iocshRegister(&errlogBufResizeFuncDef,errlogBufResizeCallFunc);
     iocshRegister(&errlogFuncDef, errlogCallFunc);
     iocshRegister(&iocLogPrefixFuncDef, iocLogPrefixCallFunc);
 

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -291,22 +291,6 @@ static void errlogInit2CallFunc(const iocshArgBuf *args)
     errlogInit2(args[0].ival, args[1].ival);
 }
 
-/* errlogBufResize */
-static const iocshArg errlogBufResizeArg0 = { "bufSize",iocshArgInt};
-static const iocshArg errlogBufResizeArg1 = { "maxMsgSize",iocshArgInt};
-static const iocshArg * const errlogBufResizeArgs[] =
-    {&errlogBufResizeArg0, &errlogBufResizeArg1};
-static const iocshFuncDef errlogBufResizeFuncDef = {
-    "errlogBufResize", 2, errlogBufResizeArgs,
-    "Reinitialize error log client buffer size and maximum message size\n"
-    "  bufSize    - size of circular buffer       (default = 1280 bytes)\n"
-    "  maxMsgSize - maximum size of error message (default =  256 bytes)\n"
-};
-static void errlogBufResizeCallFunc(const iocshArgBuf *args)
-{
-    iocshSetError(errlogBufResize(args[0].ival, args[1].ival));
-}
-
 /* errlogShow */
 static const iocshArg errlogShowArg0 = { "level",iocshArgInt};
 static const iocshArg * const errlogShowArgs[1] = {&errlogShowArg0};
@@ -532,7 +516,6 @@ void epicsStdCall libComRegister(void)
     iocshRegister(&eltcFuncDef, eltcCallFunc);
     iocshRegister(&errlogInitFuncDef,errlogInitCallFunc);
     iocshRegister(&errlogInit2FuncDef,errlogInit2CallFunc);
-    iocshRegister(&errlogBufResizeFuncDef,errlogBufResizeCallFunc);
     iocshRegister(&errlogShowFuncDef,errlogShowCallFunc);
     iocshRegister(&errlogFuncDef, errlogCallFunc);
     iocshRegister(&iocLogPrefixFuncDef, iocLogPrefixCallFunc);

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -267,7 +267,7 @@ static const iocshArg * const errlogInitArgs[1] = {&errlogInitArg0};
 static const iocshFuncDef errlogInitFuncDef = {
     "errlogInit",1,errlogInitArgs,
     "Initialize error log client buffer size\n"
-    "  bufSize - size of circular buffer (default = 1280 bytes)\n"
+    "  bufSize - size of circular buffer (default = 2560 bytes)\n"
 };
 static void errlogInitCallFunc(const iocshArgBuf *args)
 {
@@ -282,8 +282,8 @@ static const iocshArg * const errlogInit2Args[] =
 static const iocshFuncDef errlogInit2FuncDef = {
     "errlogInit2", 2, errlogInit2Args,
     "Initialize error log client buffer size and maximum message size\n"
-    "  bufSize    - size of circular buffer       (default = 1280 bytes)\n"
-    "  maxMsgSize - maximum size of error message (default =  256 bytes)\n"
+    "  bufSize    - size of circular buffer       (default = 2560 bytes)\n"
+    "  maxMsgSize - maximum size of error message (default =  512 bytes)\n"
 };
 static void errlogInit2CallFunc(const iocshArgBuf *args)
 {

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -22,6 +22,7 @@
 #include "osiUnistd.h"
 #include "logClient.h"
 #include "errlog.h"
+#include "errlogPvt.h"
 #include "taskwd.h"
 #include "registry.h"
 #include "epicsGeneralTime.h"
@@ -306,6 +307,21 @@ static void errlogBufResizeCallFunc(const iocshArgBuf *args)
     errlogBufResize(args[0].ival, args[1].ival);
 }
 
+/* errlogShow */
+static const iocshArg errlogShowArg0 = { "level",iocshArgInt};
+static const iocshArg * const errlogShowArgs[1] = {&errlogShowArg0};
+static const iocshFuncDef errlogShowFuncDef = {
+    "errlogShow",1,errlogShowArgs,
+    "Show the contents of the error log private data\n"
+    "level 0 - Show the size of the buffers and max message size\n"
+    "      1 - Show the number of listeners\n"
+    "      2 - Show the contents of the buffer\n"
+};
+static void errlogShowCallFunc(const iocshArgBuf *args)
+{
+    errlogShow(args[0].ival);
+}
+
 /* errlog */
 IOCSH_STATIC_FUNC void errlog(const char *message)
 {
@@ -517,6 +533,7 @@ void epicsStdCall libComRegister(void)
     iocshRegister(&errlogInitFuncDef,errlogInitCallFunc);
     iocshRegister(&errlogInit2FuncDef,errlogInit2CallFunc);
     iocshRegister(&errlogBufResizeFuncDef,errlogBufResizeCallFunc);
+    iocshRegister(&errlogShowFuncDef,errlogShowCallFunc);
     iocshRegister(&errlogFuncDef, errlogCallFunc);
     iocshRegister(&iocLogPrefixFuncDef, iocLogPrefixCallFunc);
 

--- a/modules/libcom/src/iocsh/libComRegister.c
+++ b/modules/libcom/src/iocsh/libComRegister.c
@@ -304,7 +304,7 @@ static const iocshFuncDef errlogBufResizeFuncDef = {
 };
 static void errlogBufResizeCallFunc(const iocshArgBuf *args)
 {
-    errlogBufResize(args[0].ival, args[1].ival);
+    iocshSetError(errlogBufResize(args[0].ival, args[1].ival));
 }
 
 /* errlogShow */

--- a/modules/libcom/test/epicsErrlogTest.c
+++ b/modules/libcom/test/epicsErrlogTest.c
@@ -61,7 +61,8 @@ const char longmsg[]="A0123456789abcdef"
 STATIC_ASSERT(NELEMENTS(longmsg)==324);
 
 static
-const char truncmsg[]="A0123456789abcdef"
+const char truncmsg256[]=
+                      "A0123456789abcdef"
                       "B0123456789abcdef"
                       "C0123456789abcdef"
                       "D0123456789abcdef"
@@ -77,7 +78,28 @@ const char truncmsg[]="A0123456789abcdef"
                       "N0123456789abcdef"
                       "O01<<TRUNCATED>>\n"
                       ;
-STATIC_ASSERT(NELEMENTS(truncmsg)==256);
+STATIC_ASSERT(NELEMENTS(truncmsg256)==256);
+
+static
+const char truncmsg273[]=
+                      "A0123456789abcdef"
+                      "B0123456789abcdef"
+                      "C0123456789abcdef"
+                      "D0123456789abcdef"
+                      "E0123456789abcdef"
+                      "F0123456789abcdef"
+                      "G0123456789abcdef"
+                      "H0123456789abcdef"
+                      "I0123456789abcdef"
+                      "J0123456789abcdef"
+                      "K0123456789abcdef"
+                      "L0123456789abcdef"
+                      "M0123456789abcdef"
+                      "N0123456789abcdef"
+                      "O0123456789abcdef"
+                      "P01<<TRUNCATED>>\n"
+                      ;
+STATIC_ASSERT(NELEMENTS(truncmsg273)==273);
 
 typedef struct {
     unsigned int count;
@@ -198,67 +220,42 @@ void testANSIStrip(void)
 #undef testEscape
 }
 
-static void testErrorMessageMatches(long status, const char *expected)
+static void testLogSizeTrunc(int bufsize, int maxMsgSize, const char *truncmsg)
 {
-    const char *msg = errSymMsg(status);
-    testOk(strcmp(msg, expected) == 0,
-           "Error code %ld returns \"%s\", expected message \"%s\"", status,
-           msg, expected
-          );
-}
-
-static void testGettingExistingErrorSymbol()
-{
-    testErrorMessageMatches(S_err_invCode, "Invalid error symbol code");
-}
-
-static void testGettingNonExistingErrorSymbol()
-{
-    long invented_code = (0x7999 << 16) | 0x9998;
-    testErrorMessageMatches(invented_code, "<Unknown code>");
-}
-
-static void testAddingErrorSymbol()
-{
-    long invented_code = (0x7999 << 16) | 0x9999;
-    errSymbolAdd(invented_code, "Invented Error Message");
-    testErrorMessageMatches(invented_code, "Invented Error Message");
-}
-
-static void testAddingInvalidErrorSymbol()
-{
-    long invented_code = (500 << 16) | 0x1;
-    testOk(errSymbolAdd(invented_code, "No matter"),
-           "Adding error symbol with module code < 501 should fail");
-}
-
-static void testAddingExistingErrorSymbol()
-{
-    testOk(errSymbolAdd(S_err_invCode, "Duplicate"),
-           "Adding an error symbol with an existing error code should fail");
-}
-
-static void testAddingExistingErrorSymbolWithSameMessage()
-{
-    long invented_code = (0x7999 << 16) | 0x9997;
-    errSymbolAdd(invented_code, "Invented Error Message");
-    testOk(!errSymbolAdd(invented_code, "Invented Error Message"),
-           "Adding identical error symbol shouldn't fail");
-}
-
-MAIN(epicsErrlogTest)
-{
-    size_t mlen, i, N;
-    char msg[256];
-    clientPvt pvt, pvt2;
-
-    testPlan(54);
-
-    testANSIStrip();
-
+    char msg[324];
+    clientPvt pvt;
     strcpy(msg, truncmsg);
 
-    errlogInit2(LOGBUFSIZE, 256);
+    errlogInit2(bufsize, maxMsgSize);
+
+    errlogAddListener(&logClient, &pvt);
+
+    testDiag("Check truncation");
+
+    pvt.count = 0;
+    pvt.jam = 0;
+    pvt.jammer = epicsEventMustCreate(epicsEventEmpty);
+    pvt.done = epicsEventMustCreate(epicsEventEmpty);
+
+    pvt.expect = truncmsg;
+    pvt.checkLen = maxMsgSize - 1;
+
+    errlogPrintfNoConsole("%s", longmsg);
+    errlogFlush();
+
+    epicsEventMustWait(pvt.done);
+
+    testEqInt(pvt.count, 1);
+
+    /* Clean up */
+    testOk(1 == errlogRemoveListeners(&logClient, &pvt), "Removed one listener");
+
+    epicsEventDestroy(pvt.jammer);
+    epicsEventDestroy(pvt.done);
+}
+
+static void testLogListeners() {
+    clientPvt pvt, pvt2;
 
     pvt.count = 0;
     pvt2.count = 0;
@@ -337,39 +334,47 @@ MAIN(epicsErrlogTest)
     testEqInt(pvt.count, 2);
     testEqInt(pvt2.count, 2);
 
-    /* Re-add one listener */
-    errlogAddListener(&logClient, &pvt);
+    testOk(0 == errlogRemoveListeners(&logClient, &pvt),
+        "No listener 1 to remove");
 
-    testDiag("Check truncation");
+    epicsEventDestroy(pvt.jammer);
+    epicsEventDestroy(pvt.done);
+    epicsEventDestroy(pvt2.jammer);
+    epicsEventDestroy(pvt2.done);
+}
 
-    pvt.expect = truncmsg;
-    pvt.checkLen = 255;
+static void testLogJammed() {
+    size_t mlen, i, N;
+    char msg[324];
+    clientPvt pvt;
+    strcpy(msg, longmsg);
 
-    errlogPrintfNoConsole("%s", longmsg);
-    errlogFlush();
-
-    epicsEventMustWait(pvt.done);
-    testEqInt(pvt.count, 3);
-
+    pvt.count = 0;
     pvt.expect = NULL;
-
-    testDiag("Check priority");
+    pvt.checkLen = 0;
     /* For the following tests it is important that
      * the buffer should not flush until we request it
      */
     pvt.jam = 1;
+    pvt.jammer = epicsEventMustCreate(epicsEventEmpty);
+    pvt.done = epicsEventMustCreate(epicsEventEmpty);
+
+    /* Re-add one listener */
+    errlogAddListener(&logClient, &pvt);
+
+    testDiag("Check priority");
 
     errlogPrintfNoConsole("%s", longmsg);
 
     testOk(epicsEventWaitWithTimeout(pvt.done, 0.5) == epicsEventWaitTimeout,
         "%d: Listener 1 didn't run", __LINE__);
-    testEqInt(pvt.count, 3);
+    testEqInt(pvt.count, 0);
 
     epicsEventSignal(pvt.jammer);
     errlogFlush();
 
     epicsEventMustWait(pvt.done);
-    testEqInt(pvt.count, 4);
+    testEqInt(pvt.count, 1);
 
     testDiag("Find buffer capacity (%u theoretical)",LOGBUFSIZE);
 
@@ -458,6 +463,70 @@ MAIN(epicsErrlogTest)
     /* Clean up */
     testOk(1 == errlogRemoveListeners(&logClient, &pvt),
         "Removed 1 listener");
+
+    epicsEventDestroy(pvt.jammer);
+    epicsEventDestroy(pvt.done);
+}
+
+static void testErrorMessageMatches(long status, const char *expected)
+{
+    const char *msg = errSymMsg(status);
+    testOk(strcmp(msg, expected) == 0,
+           "Error code %ld returns \"%s\", expected message \"%s\"", status,
+           msg, expected
+          );
+}
+
+static void testGettingExistingErrorSymbol()
+{
+    testErrorMessageMatches(S_err_invCode, "Invalid error symbol code");
+}
+
+static void testGettingNonExistingErrorSymbol()
+{
+    long invented_code = (0x7999 << 16) | 0x9998;
+    testErrorMessageMatches(invented_code, "<Unknown code>");
+}
+
+static void testAddingErrorSymbol()
+{
+    long invented_code = (0x7999 << 16) | 0x9999;
+    errSymbolAdd(invented_code, "Invented Error Message");
+    testErrorMessageMatches(invented_code, "Invented Error Message");
+}
+
+static void testAddingInvalidErrorSymbol()
+{
+    long invented_code = (500 << 16) | 0x1;
+    testOk(errSymbolAdd(invented_code, "No matter"),
+           "Adding error symbol with module code < 501 should fail");
+}
+
+static void testAddingExistingErrorSymbol()
+{
+    testOk(errSymbolAdd(S_err_invCode, "Duplicate"),
+           "Adding an error symbol with an existing error code should fail");
+}
+
+static void testAddingExistingErrorSymbolWithSameMessage()
+{
+    long invented_code = (0x7999 << 16) | 0x9997;
+    errSymbolAdd(invented_code, "Invented Error Message");
+    testOk(!errSymbolAdd(invented_code, "Invented Error Message"),
+           "Adding identical error symbol shouldn't fail");
+}
+
+MAIN(epicsErrlogTest)
+{
+    testPlan(59);
+    errlogInit(0);
+
+    testANSIStrip();
+
+    testLogListeners();
+    testLogSizeTrunc(LOGBUFSIZE, 256, truncmsg256);
+    testLogSizeTrunc(LOGBUFSIZE, 273, truncmsg273);
+    testLogJammed();
 
     osiSockAttach();
     testLogPrefix();


### PR DESCRIPTION
Fixes #747. This does three things:
* Increases the default size of the error log (and makes clear what is a default vs. minimum message size)
* Adds an IOC shell function to allow for resizing the error log buffer sizes
* Adds an IOC shell function to display information about the error log buffer