### PR TITLE
Implement `TOUT` (timeout) common record field

### DIFF
--- a/documentation/new-notes/PR-803.md
+++ b/documentation/new-notes/PR-803.md
@@ -1,0 +1,10 @@
+### New common record field `TOUT`
+
+If `TOUT` contains a number > 0, it specifies a timeout in seconds during which
+a record must be processed. Otherwise it raises an INVALID/TIMEOUT alarm.
+The timeout is restarted each time the record processes and is disabled while
+the IOC is paused.
+
+This is helpful in particular for records processed in irregular intervals by
+`"I/O Intr"`, `"Event"` or by other records and where one wants to detect when
+processing ceases to happen.

--- a/documentation/new-notes/PR-803.md
+++ b/documentation/new-notes/PR-803.md
@@ -1,10 +1,16 @@
 ### New common record field `TOUT`
 
 If `TOUT` contains a number > 0, it specifies a timeout in seconds during which
-a record must be processed. Otherwise it raises an INVALID/TIMEOUT alarm.
-The timeout is restarted each time the record processes and is disabled while
-the IOC is paused.
+record processing must have started. Otherwise the record updates its time
+stamp and then raises an INVALID/TIMEOUT alarm.
 
-This is helpful in particular for records processed in irregular intervals by
-`"I/O Intr"`, `"Event"` or by other records and where one wants to detect when
-processing ceases to happen.
+The timeout starts at iocRun or whenever the TOUT field is set to a value > 0
+and is restarted each time the record has finished processing.
+It is disabled while the IOC is paused.
+
+The timeout does not run while the record is disabled or while an asynchronous
+record is still active.
+
+This feature is helpful in particular for records processed in irregular
+intervals by `"I/O Intr"`, `"Event"` or by other records and where one wants to
+detect when processing ceases to happen.

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -485,12 +485,14 @@ static void dbProcessTimeoutCallback(void* arg)
     dbCommon *precord = (dbCommon *)arg;
     unsigned short monitor_mask;
 
+    dbScanLock(precord);
     recGblSetSevrMsg(precord, TIMEOUT_ALARM, INVALID_ALARM, "dbProcessTimeout");
     monitor_mask = recGblResetAlarms(precord);
     monitor_mask |= DBE_VALUE|DBE_LOG;
     db_post_events(precord,
         ((char *)precord) + precord->rdes->pvalFldDes->offset,
         monitor_mask);
+    dbScanUnlock(precord);
 }
 
 static void dbProcessTimeoutCallbackQueueInit(void* arg)

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -486,6 +486,7 @@ static void dbProcessTimeoutCallback(void* arg)
     unsigned short monitor_mask;
 
     dbScanLock(precord);
+    epicsTimeGetCurrent(&precord->time);
     recGblSetSevrMsg(precord, TIMEOUT_ALARM, INVALID_ALARM, "dbProcessTimeout");
     monitor_mask = recGblResetAlarms(precord);
     monitor_mask |= DBE_VALUE|DBE_LOG;

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -501,7 +501,9 @@ static void dbProcessTimeoutCallback(void* arg)
 static void dbProcessTimeoutCallbackQueueInit(void* arg)
 {
     epicsTimerQueueId* pqueue = (epicsTimerQueueId*)arg;
-    *pqueue = epicsTimerQueueAllocate(1, epicsThreadPriorityScanLow);
+    unsigned int priority;
+    epicsThreadLowestPriorityLevelAbove(epicsThreadPriorityScanHigh, &priority);
+    *pqueue = epicsTimerQueueAllocate(1, priority);
 }
 
 void dbProcessTimeoutStart(dbCommon *precord)

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -131,6 +131,11 @@ long dbPutSpecial(DBADDR *paddr,int pass)
                 scanAdd(precord);
         }else if((special==SPC_AS) && (pass==1)) {
             if(spcAsCallback) (*spcAsCallback)(precord);
+        }else if(special==SPC_TOUT) {
+            if(pass==0)
+                dbProcessTimeoutCancel(precord);
+            else
+                dbProcessTimeoutStart(precord);
         }
     }else {
         if( prset && (pspecial = (prset->special))) {
@@ -473,6 +478,48 @@ int dbGetFieldIndex(const struct dbAddr *paddr)
     return paddr->pfldDes->indRecordType;
 }
 
+static void dbProcessTimeoutCallback(void* arg)
+{
+    dbCommon *precord = (dbCommon *)arg;
+    unsigned short monitor_mask;
+
+    recGblSetSevrMsg(precord, TIMEOUT_ALARM, INVALID_ALARM, "dbProcessTimeout");
+    monitor_mask = recGblResetAlarms(precord);
+    monitor_mask |= DBE_VALUE|DBE_LOG;
+    db_post_events(precord,
+        ((char *)precord) + precord->rdes->pvalFldDes->offset,
+        monitor_mask);
+}
+
+static void dbProcessTimeoutCallbackQueueInit(void* arg)
+{
+    epicsTimerQueueId* pqueue = (epicsTimerQueueId*)arg;
+    *pqueue = epicsTimerQueueAllocate(1, epicsThreadPriorityScanLow);
+}
+
+void dbProcessTimeoutStart(dbCommon *precord)
+{
+    static epicsThreadOnceId dbProcessTimeoutQueueOnceId = EPICS_THREAD_ONCE_INIT;
+    static epicsTimerQueueId dbProcessTimeoutQueue = NULL;
+
+    if (precord->tout <= 0)
+        return;
+
+    epicsThreadOnce(&dbProcessTimeoutQueueOnceId, dbProcessTimeoutCallbackQueueInit, &dbProcessTimeoutQueue);
+
+    if (!precord->toid) {
+        precord->toid = epicsTimerQueueCreateTimer(dbProcessTimeoutQueue,
+            dbProcessTimeoutCallback, precord);
+    }
+    epicsTimerStartDelay(precord->toid, precord->tout);
+}
+
+void dbProcessTimeoutCancel(dbCommon *precord)
+{
+    if (precord->toid)
+        epicsTimerCancel(precord->toid);
+}
+
 /*
  *   Process the record.
  *     1.  Check for breakpoints.
@@ -493,6 +540,9 @@ long dbProcess(dbCommon *precord)
     int set_trace = FALSE;
     dbFldDes *pdbFldDes;
     int callNotifyCompletion = FALSE;
+
+    if (precord->toid)
+        dbProcessTimeoutCancel(precord);
 
     ptrace = dbLockSetAddrTrace(precord);
     /*
@@ -622,6 +672,8 @@ all_done:
     if (callNotifyCompletion && precord->ppn)
         dbNotifyCompletion(precord);
 
+    if (precord->tout > 0)
+        dbProcessTimeoutStart(precord);
     return status;
 }
 

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -381,7 +381,9 @@ static void getOptions(DBADDR *paddr, char **poriginal, long *options,
         }
         if( (*options) & DBR_UNITS ) {
             memset(pbuffer,'\0',dbr_units_size);
-            if( prset && prset->get_units ){
+            if (paddr->special == SPC_TOUT) {
+                pbuffer[0] = 's';
+            } else if (prset && prset->get_units) {
                 (*prset->get_units)(paddr, pbuffer);
                 pbuffer[DB_UNITS_SIZE-1] = '\0';
             } else {

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -506,23 +506,27 @@ void dbProcessTimeoutStart(dbCommon *precord)
 {
     static epicsThreadOnceId dbProcessTimeoutQueueOnceId = EPICS_THREAD_ONCE_INIT;
     static epicsTimerQueueId dbProcessTimeoutQueue = NULL;
+    dbCommonPvt* pvt;
 
     if (precord->tout <= 0)
         return;
 
     epicsThreadOnce(&dbProcessTimeoutQueueOnceId, dbProcessTimeoutCallbackQueueInit, &dbProcessTimeoutQueue);
 
-    if (!precord->toid) {
-        precord->toid = epicsTimerQueueCreateTimer(dbProcessTimeoutQueue,
+    pvt = dbRec2Pvt(precord);
+
+    if (!pvt->inactivityTimeout) {
+        pvt->inactivityTimeout = epicsTimerQueueCreateTimer(dbProcessTimeoutQueue,
             dbProcessTimeoutCallback, precord);
     }
-    epicsTimerStartDelay(precord->toid, precord->tout);
+    epicsTimerStartDelay(pvt->inactivityTimeout, precord->tout);
 }
 
 void dbProcessTimeoutCancel(dbCommon *precord)
 {
-    if (precord->toid)
-        epicsTimerCancel(precord->toid);
+    dbCommonPvt* pvt = dbRec2Pvt(precord);
+    if (pvt->inactivityTimeout)
+        epicsTimerCancel(pvt->inactivityTimeout);
 }
 
 /*
@@ -546,8 +550,7 @@ long dbProcess(dbCommon *precord)
     dbFldDes *pdbFldDes;
     int callNotifyCompletion = FALSE;
 
-    if (precord->toid)
-        dbProcessTimeoutCancel(precord);
+    dbProcessTimeoutCancel(precord);
 
     ptrace = dbLockSetAddrTrace(precord);
     /*

--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -483,16 +483,18 @@ int dbGetFieldIndex(const struct dbAddr *paddr)
 static void dbProcessTimeoutCallback(void* arg)
 {
     dbCommon *precord = (dbCommon *)arg;
-    unsigned short monitor_mask;
 
     dbScanLock(precord);
-    epicsTimeGetCurrent(&precord->time);
-    recGblSetSevrMsg(precord, TIMEOUT_ALARM, INVALID_ALARM, "dbProcessTimeout");
-    monitor_mask = recGblResetAlarms(precord);
-    monitor_mask |= DBE_VALUE|DBE_LOG;
-    db_post_events(precord,
-        ((char *)precord) + precord->rdes->pvalFldDes->offset,
-        monitor_mask);
+    if (!precord->pact && precord->stat != DISABLE_ALARM) {
+        unsigned short monitor_mask;
+        epicsTimeGetCurrent(&precord->time);
+        recGblSetSevrMsg(precord, TIMEOUT_ALARM, INVALID_ALARM, "dbProcessTimeout");
+        monitor_mask = recGblResetAlarms(precord);
+        monitor_mask |= DBE_VALUE|DBE_LOG;
+        db_post_events(precord,
+            ((char *)precord) + precord->rdes->pvalFldDes->offset,
+            monitor_mask);
+    }
     dbScanUnlock(precord);
 }
 
@@ -508,7 +510,7 @@ void dbProcessTimeoutStart(dbCommon *precord)
     static epicsTimerQueueId dbProcessTimeoutQueue = NULL;
     dbCommonPvt* pvt;
 
-    if (precord->tout <= 0)
+    if (precord->pact || precord->stat == DISABLE_ALARM || precord->tout <= 0)
         return;
 
     epicsThreadOnce(&dbProcessTimeoutQueueOnceId, dbProcessTimeoutCallbackQueueInit, &dbProcessTimeoutQueue);
@@ -674,14 +676,15 @@ long dbProcess(dbCommon *precord)
         dbPrint(precord);
     }
 
+    /* restart inactivity timeout */
+    if (precord->tout > 0)
+        dbProcessTimeoutStart(precord);
 all_done:
     if (set_trace)
         *ptrace = 0;
     if (callNotifyCompletion && precord->ppn)
         dbNotifyCompletion(precord);
 
-    if (precord->tout > 0)
-        dbProcessTimeoutStart(precord);
     return status;
 }
 

--- a/modules/database/src/ioc/db/dbAccessDefs.h
+++ b/modules/database/src/ioc/db/dbAccessDefs.h
@@ -217,6 +217,15 @@ DBCORE_API long dbScanPassive(
 DBCORE_API long dbProcess(struct dbCommon *precord);
 DBCORE_API long dbNameToAddr(const char *pname, struct dbAddr *paddr);
 
+/** Start process timeout on record
+ * If the TOUT field is > 0 make record raise INVALID/TIMEOUT alarm
+ * If not being processed for TOUT seconds.
+ *
+ * \since UNRELEASED
+ */
+DBCORE_API void dbProcessTimeoutStart(struct dbCommon *precord);
+DBCORE_API void dbProcessTimeoutCancel(struct dbCommon *precord);
+
 /** Initialize DBADDR from a dbEntry
  * Also handles SPC_DBADDR processing. This is really an internal
  * routine for use by dbNameToAddr() and dbChannelCreate().

--- a/modules/database/src/ioc/db/dbCommon.dbd.pod
+++ b/modules/database/src/ioc/db/dbCommon.dbd.pod
@@ -570,13 +570,6 @@ seconds, the record will raise an C<INVALID/TIMEOUT> alarm.
 		special(SPC_TOUT)
 		interest(1)
 	}
-	%#include "epicsTimer.h"
-	field(TOID,DBF_NOACCESS) {
-		prompt("Timout Timer ID")
-		special(SPC_NOMOD)
-		interest(4)
-		extra("epicsTimerId        toid")
-	}
 	%#include "epicsTime.h"
 	field(TIME,DBF_NOACCESS) {
 		prompt("Time")

--- a/modules/database/src/ioc/db/dbCommon.dbd.pod
+++ b/modules/database/src/ioc/db/dbCommon.dbd.pod
@@ -533,7 +533,11 @@ copy the time stamp, not the User Tag). If the link points to any other field,
 that field's value is read and stored in the TSE field which is then used to
 provide the time stamp as described above.
 
-=fields ASG, ASP, DISP, DTYP, MLOK, MLIS, PPN, PPNR, PUTF, RDES, RPRO, TIME, UTAG, TSE, TSEL
+The B<TOUT> field can be used to define a timeout in seconds for record inactivity.
+If the field is greater than 0 and the record has not been processed for that many
+seconds, the record will raise an C<INVALID/TIMEOUT> alarm.
+
+=fields ASG, ASP, DISP, DTYP, MLOK, MLIS, PPN, PPNR, PUTF, RDES, RPRO, TIME, UTAG, TOUT, TSE, TSEL
 
 =cut
 
@@ -559,6 +563,19 @@ provide the time stamp as described above.
 		interest(1)
 		menu(menuAlarmSevr)
 		initial("INVALID")
+	}
+	field(TOUT,DBF_DOUBLE) {
+		prompt("Inactivity Timeout")
+		promptgroup("20 - Scan")
+		special(SPC_TOUT)
+		interest(1)
+	}
+	%#include "epicsTimer.h"
+	field(TOID,DBF_NOACCESS) {
+		prompt("Timout Timer ID")
+		special(SPC_NOMOD)
+		interest(4)
+		extra("epicsTimerId        toid")
 	}
 	%#include "epicsTime.h"
 	field(TIME,DBF_NOACCESS) {

--- a/modules/database/src/ioc/db/dbCommonPvt.h
+++ b/modules/database/src/ioc/db/dbCommonPvt.h
@@ -3,22 +3,37 @@
 
 #include <compilerDependencies.h>
 #include <dbDefs.h>
+#include "epicsTimer.h"
 #include "dbCommon.h"
 
 struct epicsThreadOSD;
 
 /** Base internal additional information for every record
+ *  Must be 8 byte aligned.
  */
+#ifdef _WIN32
+#pragma pack(push, 8)
+#endif
 typedef struct dbCommonPvt {
     struct dbRecordNode *recnode;
 
     /* Thread which is currently processing this record */
     struct epicsThreadOSD* procThread;
 
+    /* Timer for inactivity timeout (.TOUT field) */
+    epicsTimerId inactivityTimeout;
+
     /* actually followed by:
      * struct dbCommon common;
      */
-} dbCommonPvt;
+}
+#ifdef __GNUC__
+__attribute__ ((aligned (8)))
+#endif
+dbCommonPvt;
+#ifdef _WIN32
+#pragma pack(pop)
+#endif
 
 static EPICS_ALWAYS_INLINE
 dbCommonPvt* dbRec2Pvt(struct dbCommon *prec)

--- a/modules/database/src/ioc/dbStatic/special.h
+++ b/modules/database/src/ioc/dbStatic/special.h
@@ -29,6 +29,7 @@ extern "C" {
 #define SPC_ALARMACK    5       /*Special Alarm Acknowledgement*/
 #define SPC_AS          6       /* Access Security*/
 #define SPC_ATTRIBUTE   7       /* pseudo field, i.e. attribute field*/
+#define SPC_TOUT        8       /*process timeout*/
 /* useful when record support must be notified of a field changing value*/
 #define SPC_MOD         100
 /* used by all records that support a reset field*/
@@ -39,7 +40,7 @@ extern "C" {
 #define SPC_CALC        103     /*The CALC field is being changed*/
 
 
-#define SPC_NTYPES 9
+#define SPC_NTYPES 10
 typedef struct mapspcType{
     char    *strvalue;
     int     value;
@@ -54,6 +55,7 @@ mapspcType pamapspcType[SPC_NTYPES] = {
     {"SPC_SCAN",SPC_SCAN},
     {"SPC_ALARMACK",SPC_ALARMACK},
     {"SPC_AS",SPC_AS},
+    {"SPC_TOUT",SPC_TOUT},
     {"SPC_MOD",SPC_MOD},
     {"SPC_RESET",SPC_RESET},
     {"SPC_LINCONV",SPC_LINCONV},

--- a/modules/database/src/ioc/misc/iocInit.c
+++ b/modules/database/src/ioc/misc/iocInit.c
@@ -246,6 +246,20 @@ int iocBuildIsolated(void)
     return status;
 }
 
+static void doProcessTimoutStart(dbRecordType *pdbRecordType, dbCommon *precord,
+    void *user)
+{
+    if (precord->tout > 0)
+        dbProcessTimeoutStart(precord);
+}
+
+static void doProcessTimoutCancel(dbRecordType *pdbRecordType, dbCommon *precord,
+    void *user)
+{
+    if (precord->tout > 0)
+        dbProcessTimeoutCancel(precord);
+}
+
 int iocRun(void)
 {
     if (iocState != iocPaused && iocState != iocBuilt) {
@@ -253,6 +267,8 @@ int iocRun(void)
         return -1;
     }
     initHookAnnounce(initHookAtIocRun);
+
+    iterateRecords(doProcessTimoutStart, NULL);
 
    /* Enable scan tasks and some driver support functions.  */
     scanRun();
@@ -283,6 +299,9 @@ int iocPause(void)
         errlogPrintf("iocPause: " ERL_WARNING " IOC not running\n");
         return -1;
     }
+
+    iterateRecords(doProcessTimoutCancel, NULL);
+
     initHookAnnounce(initHookAtIocPause);
 
     if (iocBuildMode == buildServers) {
@@ -722,6 +741,8 @@ static void doFreeRecord(dbRecordType *pdbRecordType, dbCommon *precord,
 int iocShutdown(void)
 {
     if (iocState == iocVoid) return 0;
+
+    iterateRecords(doProcessTimoutCancel, NULL);
 
     initHookAnnounce(initHookAtShutdown);
 


### PR DESCRIPTION
If `TOUT` contains a number > 0, it specifies a timeout in seconds during which a record must be processed. Otherwise it raises an `INVALID/TIMEOUT` alarm. The timeout is restarted each time the record processes and is disabled while the IOC is paused.

This is helpful in particular for records processed in irregular intervals by `"I/O Intr"`, `"Event"` or by other records and where one wants to detect when processing ceases to happen.