### PR TITLE
setup codeowners for the CODEOWNERS and documentation files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github/CODEOWNERS @epics-base/core-devs
+/documentation/ @epics-base/documentation


### PR DESCRIPTION
As discussed during the Diamond Codeathon 2026.

GitHub should be able to validate the CODEOWNERS file, if all the teams mentioned in it have write access to the epics-base repo.