### PR TITLE
Upgrade documentation dependencies, add build guide, switch to `pyproject.toml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-      python: "3.9"
+      python: "3.14"
   apt_packages:
     - graphviz
     - rsync
@@ -21,16 +21,10 @@ build:
 sphinx:
   configuration: documentation/O.Common/rtd-src/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
-# Optionally build your docs in additional formats such as PDF and ePub
-#formats: []
-
 submodules:
     exclude: all
 
 python:
-   install:
-      - requirements: documentation/requirements.txt
+  install:
+    - method: pip
+      path: ./documentation

--- a/documentation/.gitignore
+++ b/documentation/.gitignore
@@ -1,0 +1,13 @@
+.python-version
+/*.lock
+
+# Python-generated files
+__pycache__/
+*.py[oc]
+build/
+dist/
+wheels/
+*.egg-info
+
+# Virtual environments
+.venv

--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -23,6 +23,7 @@ DOCS += README.md
 DOCS += ca-cli.md
 DOCS += RELEASE_NOTES.md
 DOCS += ReleaseChecklist.md
+DOCS += build-docs.md
 
 OLD_NOTES = $(wildcard ../RELEASE-*.md)
 DOCS += $(OLD_NOTES:../%=%)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -44,6 +44,7 @@ targets. You may need the C and C++ compilers to be in your search
 path to do EPICS builds; check the definitions of CC and CCC in
 `base/configure/os/CONFIG.<host>.<host>` if you have problems.
 
+(software-requirements)=
 ### Software requirements
 
 #### GNU make

--- a/documentation/build-docs.md
+++ b/documentation/build-docs.md
@@ -1,0 +1,61 @@
+# Build epics-base's documentation
+
+To build epics-base documentation,
+you need the following dependencies:
+
+- Python with Pip
+- Doxygen
+- Graphviz
+- General epics-base requirements.
+  See {ref}`software-requirements`.
+
+## Setting up the Python environment
+
+Create a new virtual environment under `documentation/.venv`,
+if it doesn't already exists:
+
+```bash
+python -m venv documentation/.venv
+```
+
+Enter the Python environment:
+
+```{eval-rst}
++-------------+------------+--------------------------------------------------+
+| Platform    | Shell      | Command to activate virtual environment          |
++=============+============+==================================================+
+| POSIX       | bash/zsh   | ``source documentation/.venv/bin/activate``      |
+|             +------------+--------------------------------------------------+
+|             | fish       | ``source documentation/.venv/bin/activate.fish`` |
+|             +------------+--------------------------------------------------+
+|             | csh/tcsh   | ``source documentation/.venv/bin/activate.csh``  |
+|             +------------+--------------------------------------------------+
+|             | pwsh       | ``documentation/.venv/bin/Activate.ps1``         |
++-------------+------------+--------------------------------------------------+
+| Windows     | cmd.exe    | ``documentation/.venv\\Scripts\\activate.bat``   |
+|             +------------+--------------------------------------------------+
+|             | PowerShell | ``documentation/.venv\\Scripts\\Activate.ps1``   |
++-------------+------------+--------------------------------------------------+
+```
+
+Inside your Python virtual environment,
+install the Python dependencies like so:
+
+```bash
+pip install ./documentation
+```
+
+:::{important}
+Make sure you install Python dependencies inside a Python virtual environment,
+**not** in the global environment.
+:::
+
+## Build the documentation
+
+To build the documentation,
+run:
+
+```bash
+make inc
+make -C documentation sphinx
+```

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -37,3 +37,9 @@ EPICS Base Documentation
    database-api
    record-api
    menu-api
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Contributing
+
+   build-docs

--- a/documentation/pyproject.toml
+++ b/documentation/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "documentation"
+version = "0.1.0"
+description = "Build environment for the epics-base documentation"
+requires-python = ">=3.10"
+dependencies = [
+    "breathe>=5.0.0a5,<6.0.0",
+    "myst-parser>=4.0.0,<6.0.0",
+    "sphinx>=8.1.0,<9.0.0",
+    "sphinx-copybutton>=0.5.2,<0.6.0",
+    "sphinx-rtd-theme>=3.1.0,<4.0.0",
+]
+
+[tool.setuptools]
+# For pip / setuptools, don't assume we're producing a Python package
+packages = []

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,5 +1,0 @@
-sphinx==7.2.6
-myst-parser==2.0.0
-breathe==4.35.0
-sphinx_copybutton==0.5.2
-sphinx-rtd-theme==2.0.0


### PR DESCRIPTION
This should fix the Doxygen + Breathe issue mentioned in #783, by upgrading to the alpha release of Breathe `5.0.0a5`.

As requested by @anjohnson, I've added a small guide on how to build the documentation. The file is not exactly in the place I would want, but I think with the way things are set up currently, we're not allowed to have subfolders.

I've also switched the `requirements.txt` to be a `pyproject.toml`, so that anyone can use their favorite Python tool. I'm tagging @simon-ess as the setuptools/pip fan, to see if it's okay with him.