### PR TITLE
Change Win-22 MSC-22 from debug to default configuration

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -179,7 +179,6 @@ jobs:
             os: windows-2022
             cmp: vs2022
             configuration: default
-            extra: "CMD_CXXFLAGS=-analyze"
 
           - name: "Win-22 MSC-22, static"
             os: windows-2022
@@ -191,6 +190,7 @@ jobs:
             os: windows-2022
             cmp: vs2022
             configuration: debug
+            extra: "CMD_CXXFLAGS=-analyze"
 
           - name: "Win-22 MSC-22 c++14, debug"
             os: windows-2022

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -178,7 +178,7 @@ jobs:
           - name: "Win-22 MSC-22"
             os: windows-2022
             cmp: vs2022
-            configuration: debug
+            configuration: default
             extra: "CMD_CXXFLAGS=-analyze"
 
           - name: "Win-22 MSC-22, static"


### PR DESCRIPTION
change `debug` to `default` - guessing typo as job is otherwise a duplicate build 