### PR TITLE
fix: add llround() to RTEMS-score

### DIFF
--- a/modules/libcom/src/osi/os/RTEMS-score/epicsMath.h
+++ b/modules/libcom/src/osi/os/RTEMS-score/epicsMath.h
@@ -26,4 +26,16 @@ LIBCOM_API extern const float epicsINF;
 }
 #endif
 
+static inline long long epicsLlround(double x)
+{
+    if(!isfinite(x)) return 0;
+    return (x >= 0.0)
+        ? (long long)floor(x + 0.5)
+        : -(long long)floor(-x + 0.5);
+}
+
+#ifndef __cplusplus
+#  define llround(x) epicsLlround((double)(x))
+#endif
+
 #endif /* epicsMathh */

--- a/modules/libcom/test/epicsMathTest.c
+++ b/modules/libcom/test/epicsMathTest.c
@@ -22,7 +22,7 @@ MAIN(epicsMathTest)
     double tiny = 1e-300;
     double c;
 
-    testPlan(35);
+    testPlan(44);
 
     testOk1(!isnan(0.0));
     testOk1(!isinf(0.0));
@@ -91,6 +91,17 @@ MAIN(epicsMathTest)
     testOk(!isnan(c), "!isnan(1e-300 / 1e-300)");
     testOk(!isinf(c), "!isinf(1e-300 / 1e-300)");
     testOk(c == 1.0, "1e300 / 1e-300 == 1.0");
+
+    /* llround() test */
+    testOk(llround(0.0)  == 0LL,  "llround(0.0) == 0");
+    testOk(llround(0.5)  == 1LL,  "llround(0.5) == 1");
+    testOk(llround(1.5)  == 2LL,  "llround(1.5) == 2");
+    testOk(llround(2.3)  == 2LL,  "llround(2.3) == 2");
+    testOk(llround(2.7)  == 3LL,  "llround(2.7) == 3");
+    testOk(llround(-0.5) == -1LL, "llround(-0.5) == -1");
+    testOk(llround(-1.5) == -2LL, "llround(-1.5) == -2");
+    testOk(llround(-2.3) == -2LL, "llround(-2.3) == -2");
+    testOk(llround(-2.7) == -3LL, "llround(-2.7) == -3");
 
     return testDone();
 }


### PR DESCRIPTION
I realised that `RT-4.9` is still supported ([llround issue](https://github.com/jerzyjamroz/epics-base/actions/runs/22481169454/job/65119452818#step:6:13408)), so I added the `llround` support.

If you have another preference, let me know.