### PR TITLE
Add run-time debug switch to caRepeater

### DIFF
--- a/modules/ca/src/client/caRepeater.cpp
+++ b/modules/ca/src/client/caRepeater.cpp
@@ -47,19 +47,21 @@
 
 static void usage(char* argv[])
 {
-    fprintf(stderr, "Usage: %s -hv\n"
+    fprintf(stderr, "Usage: %s -hdv\n"
             "\n"
             " -h - Print this message\n"
-            " -v - Do not replace stdin/out/err with /dev/null\n",
+            " -d - Increment debug level and set verbose\n"
+            " -v - Verbose, don't suppress messages\n",
             argv[0]);
 }
 
 int main(int argc, char* argv[])
 {
+    int debug = 0;
     bool detachinout = true;
 
     int opt;
-    while ((opt = getopt(argc, argv, "hv")) != -1) {
+    while ((opt = getopt(argc, argv, "dhv")) != -1) {
         switch (opt) {
         default:
             usage(argv);
@@ -68,6 +70,9 @@ int main(int argc, char* argv[])
         case 'h':
             usage(argv);
             return 0;
+        case 'd':
+            debug++;
+            // Fall through
         case 'v':
             detachinout = false;
             break;
@@ -91,7 +96,7 @@ int main(int argc, char* argv[])
 #endif
 
     (void)! chdir ( "/" );
-    ca_repeater ();
+    ca_repeater ( debug );
     return ( 0 );
 }
 

--- a/modules/ca/src/client/repeater.cpp
+++ b/modules/ca/src/client/repeater.cpp
@@ -70,6 +70,7 @@
 #include "taskwd.h"
 #include "errlog.h"
 
+#define DEBUG // Tell iocinf.h to define debugPrint
 #include "iocinf.h"
 #include "caProto.h"
 #include "udpiiu.h"
@@ -84,6 +85,8 @@
 static tsDLList < repeaterClient > client_list;
 
 static const unsigned short PORT_ANY = 0u;
+
+static int debug = 0;
 
 /*
  * makeSocket()
@@ -128,10 +131,10 @@ static int makeSocket ( unsigned short port, bool reuseAddr, SOCKET * pSock )
 repeaterClient::repeaterClient ( const osiSockAddr &fromIn ) :
     from ( fromIn ), sock ( INVALID_SOCKET )
 {
-#ifdef DEBUG
-    unsigned port = ntohs ( from.ia.sin_port );
-    debugPrintf ( ( "new client %u\n", port ) );
-#endif
+    if ( debug ) {
+        unsigned port = ntohs ( from.ia.sin_port );
+        debugPrintf ( ( "New client on port %u\n", port ) );
+    }
 }
 
 bool repeaterClient::connect ()
@@ -193,19 +196,19 @@ bool repeaterClient::sendMessage ( const void *pBuf, unsigned bufSize )
     status = send ( this->sock, (char *) pBuf, bufSize, 0 );
     if ( status >= 0 ) {
         assert ( static_cast <unsigned> ( status ) == bufSize );
-#ifdef DEBUG
-        epicsUInt16 port = ntohs ( this->from.ia.sin_port );
-        debugPrintf ( ("Sent to %u\n", port ) );
-#endif
+        if ( debug > 1 ) {
+            epicsUInt16 port = ntohs ( this->from.ia.sin_port );
+            debugPrintf ( ("Sent to port %u\n", port ) );
+        }
         return true;
     }
     else {
         int errnoCpy = SOCKERRNO;
         if ( errnoCpy == SOCK_ECONNREFUSED ) {
-#ifdef DEBUG
-            epicsUInt16 port = ntohs ( this->from.ia.sin_port );
-            debugPrintf ( ("Client refused message %u\n", port ) );
-#endif
+            if ( debug ) {
+                epicsUInt16 port = ntohs ( this->from.ia.sin_port );
+                debugPrintf ( ("Client on port %u refused message\n", port ) );
+            }
         }
         else {
             char sockErrBuf[64];
@@ -221,10 +224,10 @@ repeaterClient::~repeaterClient ()
     if ( this->sock != INVALID_SOCKET ) {
         epicsSocketDestroy ( this->sock );
     }
-#ifdef DEBUG
-    epicsUInt16 port = ntohs ( this->from.ia.sin_port );
-    debugPrintf ( ( "Deleted client %u\n", port ) );
-#endif
+    if ( debug ) {
+        epicsUInt16 port = ntohs ( this->from.ia.sin_port );
+        debugPrintf ( ( "Deleted client on port %u\n", port ) );
+    }
 }
 
 void repeaterClient::operator delete ( void * )
@@ -286,6 +289,10 @@ bool repeaterClient::verify ()
 
     if ( sockerrno == SOCK_EADDRINUSE ) {
         // Normal result, client using port
+        if ( debug > 1 ) {
+            epicsUInt16 port = ntohs ( this->from.ia.sin_port );
+            debugPrintf ( ("Client on port %u is alive\n", port ) );
+        }
         return true;
     }
 
@@ -320,6 +327,9 @@ static void verifyClients ( tsFreeList < repeaterClient, 0x20 > & freeList )
             pclient->~repeaterClient ();
             freeList.release ( pclient );
         }
+    }
+    if ( debug ) {
+        debugPrintf ( ( "Verified %u active clients\n", theClients.count() ) );
     }
     client_list.add ( theClients );
 }
@@ -444,11 +454,11 @@ static void register_new_client ( osiSockAddr & from,
         client_list.remove ( *pNewClient );
         pNewClient->~repeaterClient ();
         freeList.release ( pNewClient );
-#       ifdef DEBUG
+        if ( debug ) {
             epicsUInt16 port = ntohs ( from.ia.sin_port );
-            debugPrintf ( ( "Deleted repeater client=%u (error while sending ack)\n",
+            debugPrintf ( ( "Deleted repeater client on port %u, error sending ack\n",
                         port ) );
-#       endif
+        }
     }
 
     /*
@@ -480,7 +490,7 @@ static void register_new_client ( osiSockAddr & from,
 /*
  *  ca_repeater ()
  */
-void ca_repeater ()
+void ca_repeater ( int setDebug )
 {
     tsFreeList < repeaterClient, 0x20 > freeList;
     int size;
@@ -488,6 +498,8 @@ void ca_repeater ()
     osiSockAddr from;
     unsigned short port;
     char * pBuf;
+
+    debug = setDebug;
 
     pBuf = new char [MAX_UDP_RECV];
 
@@ -504,7 +516,7 @@ void ca_repeater ()
          */
         if ( sockerrno == SOCK_EADDRINUSE ) {
             osiSockRelease ();
-            debugPrintf ( ( "CA Repeater: exiting because a repeater is already running\n" ) );
+            debugPrintf ( ( "CA Repeater: Exiting, a repeater is already running\n" ) );
             delete [] pBuf;
             return;
         }

--- a/modules/ca/src/client/udpiiu.h
+++ b/modules/ca/src/client/udpiiu.h
@@ -59,7 +59,7 @@ LIBCA_API void epicsStdCall caRepeaterRegistrationMessage (
     SOCKET sock, unsigned repeaterPort, unsigned attemptNumber );
 extern "C" LIBCA_API void caRepeaterThread (
     void * pDummy );
-LIBCA_API void ca_repeater ( void );
+LIBCA_API void ca_repeater ( int setDebug = 0 );
 
 class cac;
 class cacContextNotify;

--- a/modules/database/src/ioc/misc/iocInit.h
+++ b/modules/database/src/ioc/misc/iocInit.h
@@ -7,7 +7,7 @@
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution.
 \*************************************************************************/
-/** @file iocInit.h   
+/** @file iocInit.h
  * @brief ioc initialization */
 
 #ifndef INCiocInith
@@ -34,7 +34,7 @@ DBCORE_API int iocInit(void);
 
 /** @brief Puts the IOC into a quiescent state without allowing the various internal threads it starts to actually run */
 DBCORE_API int iocBuild(void);
-/** @brief Allows to start an IOC without its Channel Access parts. It can then be shutdown cleanly using iocShutdown. 
+/** @brief Allows to start an IOC without its Channel Access parts. It can then be shutdown cleanly using iocShutdown.
  * Feature only intended to be used for test programs, not production IOCs. */
 DBCORE_API int iocBuildIsolated(void);
 /** @brief Brings the IOC online after iocBuild or iocPause*/


### PR DESCRIPTION
Convert the compile-time repeater `DEBUG` macro into a command-line flag `-d`.
Only works for the stand-alone `caRepeater` program.
Added extra debug messages for active client verification.

This is to help with the review of PR #802.

With -d the repeater now shows client events, e.g.

```
  $ caRepeater -d
  CA Repeater: Attached and initialized
  New client on port 60307
  Verified 1 active clients
  New client on port 52541
  Verified 2 active clients
  Client on port 60307 refused message
  Deleted client on port 60307
  Client on port 52541 refused message
  Deleted client on port 52541
  ^C
```

Running "caRepeater -dd" also shows beacon forwarding and individual client verification:

```
  $ caRepeater -dd
  CA Repeater: Attached and initialized
  New client on port 49968
  Client on port 49968 is alive
  Verified 1 active clients
  Sent to port 49968
  Sent to port 49968
  Sent to port 49968
  New client on port 65377
  Sent to port 49968
  Client on port 49968 is alive
  Client on port 65377 is alive
  Verified 2 active clients
  Sent to port 49968
  Sent to port 65377
  Sent to port 49968
  Sent to port 65377
  Client on port 49968 refused message
  Deleted client on port 49968
  Sent to port 65377
  Sent to port 65377
  Client on port 65377 refused message
  Deleted client on port 65377
  ^C
```