### PR TITLE
Fix memory overwrite in macParseDefns

### DIFF
--- a/modules/libcom/src/macLib/macUtil.c
+++ b/modules/libcom/src/macLib/macUtil.c
@@ -17,12 +17,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
 
 #include "dbDefs.h"
 #include "errlog.h"
 #include "macLib.h"
-#include "epicsString.h"
 
 /*
  * Parse macros definitions in "a=xxx,b=yyy" format and convert them to
@@ -68,7 +66,7 @@ epicsStdCall macParseDefns(
        for defns="1,3,5" give 3 pairs so num will be 6 (strlen(defns)+1)
        but as num is used as an index e.g. del[num] we need
        numMax to be strlen(defns) + 2 */
-    numMax = epicsStrnLen( defns, INT_MAX ) + 2;
+    numMax = strlen( defns ) + 2;
     if ( numMax < altNumMax )
         numMax = altNumMax;
     ptr = (const char **) calloc( numMax, sizeof( char * ) );

--- a/modules/libcom/src/macLib/macUtil.c
+++ b/modules/libcom/src/macLib/macUtil.c
@@ -66,7 +66,7 @@ epicsStdCall macParseDefns(
        for defns="1,3,5" give 3 pairs so num will be 6 (strlen(defns)+1)
        but as num is used as an index e.g. del[num] we need
        numMax to be strlen(defns) + 2 */
-    numMax = strlen( defns ) + 2;
+    numMax = strlen( defns ) + 2; /* Flawfinder: ignore */
     if ( numMax < altNumMax )
         numMax = altNumMax;
     ptr = (const char **) calloc( numMax, sizeof( char * ) );

--- a/modules/libcom/src/macLib/macUtil.c
+++ b/modules/libcom/src/macLib/macUtil.c
@@ -17,10 +17,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 
 #include "dbDefs.h"
 #include "errlog.h"
 #include "macLib.h"
+#include "epicsString.h"
 
 /*
  * Parse macros definitions in "a=xxx,b=yyy" format and convert them to
@@ -62,8 +64,11 @@ epicsStdCall macParseDefns(
         printf( "macParseDefns( %s )\n", defns );
 
     /* allocate temporary pointer arrays; in worst case they need to have
-       as many entries as the length of the defns string */
-    numMax = strlen( defns );
+       as many entries as the length of the defns string + 2
+       for defns="1,3,5" give 3 pairs so num will be 6 (strlen(defns)+1)
+       but as num is used as an index e.g. del[num] we need
+       numMax to be strlen(defns) + 2 */
+    numMax = epicsStrnLen( defns, INT_MAX ) + 2;
     if ( numMax < altNumMax )
         numMax = altNumMax;
     ptr = (const char **) calloc( numMax, sizeof( char * ) );

--- a/modules/libcom/test/macDefExpandTest.c
+++ b/modules/libcom/test/macDefExpandTest.c
@@ -62,6 +62,27 @@ static void macEnvScope(void)
     checkMac(handle, "F", NULL);
 
     {
+        /* test worst case for short definitions
+         * https://github.com/epics-base/epics-base/pull/838
+         */
+        macParseDefns(NULL, "1,3,5", &defines); /* smoke */
+
+#define CASE(I,V) \
+        testOk(defines[I] && strcmp(defines[I], V)==0, "defines[%u] \"%s\" == \"" V "\"", I, defines[I])
+        CASE(0,"1");
+        testOk1(defines[1]==NULL);
+        CASE(2,"3");
+        testOk1(defines[3]==NULL);
+        CASE(4,"5");
+        testOk1(defines[5]==NULL);
+        testOk1(defines[6]==NULL);
+#undef CASE
+
+        free(defines);
+        defines = NULL;
+    }
+
+    {
         macPushScope(handle);
 
         macParseDefns(NULL, "A=11,C=13,D=14,G=7", &defines);

--- a/modules/libcom/test/macDefExpandTest.c
+++ b/modules/libcom/test/macDefExpandTest.c
@@ -169,7 +169,7 @@ static void check(const char *str, const char *macros, const char *expect)
 MAIN(macDefExpandTest)
 {
     eltc(0);
-    testPlan(97);
+    testPlan(104);
 
     check("FOO", "", "FOO");
 


### PR DESCRIPTION
With `windows-x64-debug` a corrupted memory block was detected when parsing some substitution files, this fixes the issue that was caused by the writing past end of allocated array