### PR TITLE
Configure Static IP with RTEMS libbsd

### DIFF
--- a/documentation/new-notes/PR-853.md
+++ b/documentation/new-notes/PR-853.md
@@ -1,0 +1,17 @@
+### Static network configuration for RTEMS targets using libBSD
+
+GitHub [PR #853](https://github.com/epics-base/epics-base/pull/853)
+
+RTEMS targets built against the libBSD network stack can now use a static
+network configuration in addition to DHCP.
+
+When a static IP address and netmask can be read from the board's boot
+configuration, the first non-loopback interface is configured with that static
+address; otherwise the target falls back to DHCP as before.
+
+The boot configuration is read using the mechanism appropriate to the board:
+
+ * MOTLOAD boards read the NVRAM Global Environment Variables (GEV), falling
+   back to the parameters in the `mot-script-boot` boot script.
+ * PPCBUG boards read their PPCBUG NVRAM.
+ * ColdFire (`mcf528x`) boards read their bootloader environment variables.

--- a/modules/libcom/RTEMS/posix/rtems_config.c
+++ b/modules/libcom/RTEMS/posix/rtems_config.c
@@ -64,7 +64,6 @@ extern void *POSIX_Init(void *argument);
 #define CONFIGURE_APPLICATION_NEEDS_CONSOLE_DRIVER
 #define CONFIGURE_APPLICATION_NEEDS_STUB_DRIVER
 #define CONFIGURE_APPLICATION_NEEDS_ZERO_DRIVER
-#define CONFIGURE_APPLICATION_NEEDS_LIBI2C_DRIVER
 
 /* Note: The select() system call can only be used with the first FD_SETSIZE
  *       File Descriptors (newlib default is 64).  Beginning RTEMS 5.1, FDs are

--- a/modules/libcom/RTEMS/posix/rtems_config.c
+++ b/modules/libcom/RTEMS/posix/rtems_config.c
@@ -47,13 +47,7 @@ extern void *POSIX_Init(void *argument);
 
 #ifndef RTEMS_LEGACY_STACK
 #define CONFIGURE_USE_IMFS_AS_BASE_FILESYSTEM
-/*
- * Configure LibBSD.
- * Note: bsp.h must be included before rtems-bsd-config.h so that
- * BSP-specific macros (e.g., LIBBSP_POWERPC_MVME3100_BSP_H) are
- * defined when nexus-devices.h selects the appropriate drivers.
- */
-#include <bsp.h>
+
 //#define RTEMS_BSD_CONFIG_NET_PF_UNIX
 //#define RTEMS_BSD_CONFIG_NET_IF_BRIDGE
 //#define RTEMS_BSD_CONFIG_NET_IF_LAGG

--- a/modules/libcom/RTEMS/posix/rtems_config.c
+++ b/modules/libcom/RTEMS/posix/rtems_config.c
@@ -49,7 +49,11 @@ extern void *POSIX_Init(void *argument);
 #define CONFIGURE_USE_IMFS_AS_BASE_FILESYSTEM
 /*
  * Configure LibBSD.
+ * Note: bsp.h must be included before rtems-bsd-config.h so that
+ * BSP-specific macros (e.g., LIBBSP_POWERPC_MVME3100_BSP_H) are
+ * defined when nexus-devices.h selects the appropriate drivers.
  */
+#include <bsp.h>
 //#define RTEMS_BSD_CONFIG_NET_PF_UNIX
 //#define RTEMS_BSD_CONFIG_NET_IF_BRIDGE
 //#define RTEMS_BSD_CONFIG_NET_IF_LAGG
@@ -66,6 +70,7 @@ extern void *POSIX_Init(void *argument);
 #define CONFIGURE_APPLICATION_NEEDS_CONSOLE_DRIVER
 #define CONFIGURE_APPLICATION_NEEDS_STUB_DRIVER
 #define CONFIGURE_APPLICATION_NEEDS_ZERO_DRIVER
+#define CONFIGURE_APPLICATION_NEEDS_LIBI2C_DRIVER
 
 /* Note: The select() system call can only be used with the first FD_SETSIZE
  *       File Descriptors (newlib default is 64).  Beginning RTEMS 5.1, FDs are

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -990,8 +990,8 @@ POSIX_Init ( void *argument __attribute__((unused)))
     if (epicsRtemsInitPreSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPreSetBootConfigFromNVRAM");
     if (rtems_bsdnet_config.bootp == NULL) {
-        extern void setBootConfigFromNVRAM(void);
-        setBootConfigFromNVRAM();
+        extern int setBootConfigFromNVRAM(char *, size_t);
+        setBootConfigFromNVRAM(NULL, 0);
     }
     if (epicsRtemsInitPostSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPostSetBootConfigFromNVRAM");
@@ -1047,14 +1047,23 @@ POSIX_Init ( void *argument __attribute__((unused)))
     printf("\n***** ifconfig lo0 *****\n");
     rtems_bsd_ifconfig_lo0();
 
-    printf("\n***** add dhcpcd hook *****\n");
-    dhcpDone = epicsEventMustCreate(epicsEventEmpty);
-    rtems_dhcpcd_add_hook(&dhcpcd_hook);
+    /* Check whether global environment static network config exists.
+     * If so, use that, else, fall back to DHCP. */
+    extern int setBootConfigFromNVRAM(char *, size_t);
+    int status = setBootConfigFromNVRAM(rtemsInit_NTP_server_ip,
+                                             sizeof(rtemsInit_NTP_server_ip));
+    bool try_dhcp = status != 0;
 
-    printf("\n***** Start default network dhcpcd *****\n");
-    // if MY_BOOTP???
-    default_network_dhcpcd();
+    if (try_dhcp) {
+        printf("\n***** add dhcpcd hook *****\n");
+        dhcpDone = epicsEventMustCreate(epicsEventEmpty);
+        rtems_dhcpcd_add_hook(&dhcpcd_hook);
 
+        printf("\n***** Start default network dhcpcd *****\n");
+        // if MY_BOOTP???
+        default_network_dhcpcd();
+    }
+    
     /* this seems to be hard coded in the BSP -> Sebastian Huber ? */
     printf("\n--Info (hpj)-- bsd task prio IRQS: %d  -----\n", rtems_bsd_get_task_priority("IRQS"));
     printf("\n--Info (hpj)-- bsd task prio TIME: %d  -----\n", rtems_bsd_get_task_priority("TIME"));

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -34,6 +34,9 @@
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/syslog.h>
+#include <net/route.h>
+#include <net/if_dl.h>
+#include <rtems/bsd/iface.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <assert.h>
@@ -65,6 +68,8 @@
 #include <rtems/bsd/modules.h>
 #include <rtems/dhcpcd.h>
 #include <machine/rtems-bsd-commands.h>
+#include <bsp.h>
+#include <bsp/nexus-devices.h>
 #endif
 
 #include <rtems/telnetd.h>
@@ -873,6 +878,50 @@ default_network_dhcpcd(void)
     sc = rtems_dhcpcd_start(NULL);
     assert(sc == RTEMS_SUCCESSFUL);
 }
+
+/*
+ * Block until the named interface reports link up via an RTM_IFINFO routing
+ * message, or until timeout_secs elapses.
+ *
+ * route_sock must already be open (opened before the interface was configured
+ * so that no RTM_IFINFO event can be missed).
+ *
+ * This function was modeled after the RTM_IFINFO handling in
+ * rtems-libbsd/dhcpcd/if-bsd.c (manage_link).  There's a
+ * simpler implementation in a test that uses a sleep loop in
+ * rtems-libbsd/testsuite/include/rtems/bsd/test/default-init.h, but
+ * we chose this more responsive event based implementation.
+ * 
+ * Returns 0 if link came up, -1 on timeout or error.
+ */
+static int
+wait_for_link_up(int route_sock, const char *ifname, int timeout_secs)
+{
+    printf("Waiting for link on %s (timeout %ds)...\n", ifname, timeout_secs);
+    
+    struct timeval tv = { .tv_sec = timeout_secs, .tv_usec = 0 };
+    setsockopt(route_sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    char buf[sizeof(struct if_msghdr) + sizeof(struct sockaddr_dl)];
+    ssize_t n;
+    while ((n = recv(route_sock, buf, sizeof(buf), 0)) > 0) {
+        struct rt_msghdr *rtm = (struct rt_msghdr *)(void *)buf;
+        if (rtm->rtm_type == RTM_IFINFO) {
+            struct if_msghdr *ifm = (struct if_msghdr *)(void *)buf;
+            char name[IFNAMSIZ];
+            if (if_indextoname(ifm->ifm_index, name) != NULL &&
+                strcmp(name, ifname) == 0 &&
+                ifm->ifm_data.ifi_link_state == LINK_STATE_UP) {
+                return 0;
+            }
+        }
+    }
+    
+    /* recv returned <= 0: SO_RCVTIMEO expired (EAGAIN) or socket error */
+    printf("Warning: link did not come up on %s within %ds\n",
+           ifname, timeout_secs);
+    return -1;
+}
 #endif // not RTEMS_LEGACY_STACK
 
 #if __RTEMS_MAJOR__>4
@@ -951,7 +1000,9 @@ POSIX_Init ( void *argument __attribute__((unused)))
     char timeBuff[100];
 
     initConsole ();
-
+    
+    printf("epics-base build date %s, %s\n", __DATE__, __TIME__);
+    
     /*
      * Use BSP-supplied time of day if available otherwise supply default time.
      * It is very likely that other time synchronization facilities in EPICS
@@ -1050,11 +1101,25 @@ POSIX_Init ( void *argument __attribute__((unused)))
     /* Check whether global environment static network config exists.
      * If so, use that, else, fall back to DHCP. */
     extern int setBootConfigFromNVRAM(char *, size_t);
+
+    /* Open route socket before configuring the interface so that no
+     * events are missed. */
+    int route_sock = socket(PF_ROUTE, SOCK_RAW, 0);
+    if (route_sock < 0)
+        printf("Warning: could not open PF_ROUTE socket: %s\n", strerror(errno));
+
+    printf("\n***** checking for static network configuration *****\n");
     int status = setBootConfigFromNVRAM(rtemsInit_NTP_server_ip,
                                              sizeof(rtemsInit_NTP_server_ip));
     bool try_dhcp = status != 0;
 
     if (try_dhcp) {
+        /* Route socket not needed — DHCP path has its own event mechanism */
+        if (route_sock >= 0) {
+            close(route_sock);
+            route_sock = -1;
+        }
+
         printf("\n***** add dhcpcd hook *****\n");
         dhcpDone = epicsEventMustCreate(epicsEventEmpty);
         rtems_dhcpcd_add_hook(&dhcpcd_hook);
@@ -1062,36 +1127,49 @@ POSIX_Init ( void *argument __attribute__((unused)))
         printf("\n***** Start default network dhcpcd *****\n");
         // if MY_BOOTP???
         default_network_dhcpcd();
+
+
+        /* this seems to be hard coded in the BSP -> Sebastian Huber ? */
+        printf("\n--Info (hpj)-- bsd task prio IRQS: %d  -----\n", rtems_bsd_get_task_priority("IRQS"));
+        printf("\n--Info (hpj)-- bsd task prio TIME: %d  -----\n", rtems_bsd_get_task_priority("TIME"));
+
+
+        // wait for dhcp done ... should be if SYNCDHCP is used
+        epicsEventWaitStatus stat;
+        printf("\n ---- Waiting for DHCP ...\n");
+        stat = epicsEventWaitWithTimeout(dhcpDone, 600);
+        if (stat == epicsEventOK)
+            epicsEventDestroy(dhcpDone);
+        else if (stat == epicsEventWaitTimeout)
+            printf("\n ---- DHCP timed out!\n");
+        else
+            printf("\n ---- dhcpDone Event Unknown state %d\n", stat);
+    } else {
+        /* Static IP: block until the physical link comes up before
+         * proceeding to NTP and NFS, analogous to the DHCP event wait. */
+        if (route_sock >= 0) {
+            char ifnamebuf[IF_NAMESIZE];
+            char *ifname = if_indextoname(1, ifnamebuf);
+            if (ifname != NULL)
+                wait_for_link_up(route_sock, ifname, 30);
+            close(route_sock);
+        }
+    }
+
+    { // Dump ifconfig and netstat info to stdout
+        const char* ifconfg_args[] = {
+            "ifconfig", NULL
+        };
+        const char* netstat_args[] = {
+            "netstat", "-rn", NULL
+        };
+
+        printf("-------------- IFCONFIG -----------------\n");
+        rtems_bsd_command_ifconfig(1, (char**) ifconfg_args);
+        printf("-------------- NETSTAT ------------------\n");
+        rtems_bsd_command_netstat(2, (char**) netstat_args);
     }
     
-    /* this seems to be hard coded in the BSP -> Sebastian Huber ? */
-    printf("\n--Info (hpj)-- bsd task prio IRQS: %d  -----\n", rtems_bsd_get_task_priority("IRQS"));
-    printf("\n--Info (hpj)-- bsd task prio TIME: %d  -----\n", rtems_bsd_get_task_priority("TIME"));
-
-
-    // wait for dhcp done ... should be if SYNCDHCP is used
-    epicsEventWaitStatus stat;
-    printf("\n ---- Waiting for DHCP ...\n");
-    stat = epicsEventWaitWithTimeout(dhcpDone, 600);
-    if (stat == epicsEventOK)
-        epicsEventDestroy(dhcpDone);
-    else if (stat == epicsEventWaitTimeout)
-        printf("\n ---- DHCP timed out!\n");
-    else
-        printf("\n ---- dhcpDone Event Unknown state %d\n", stat);
-
-    const char* ifconfg_args[] = {
-        "ifconfig", NULL
-    };
-    const char* netstat_args[] = {
-        "netstat", "-rn", NULL
-    };
-
-    printf("-------------- IFCONFIG -----------------\n");
-    rtems_bsd_command_ifconfig(1, (char**) ifconfg_args);
-    printf("-------------- NETSTAT ------------------\n");
-    rtems_bsd_command_netstat(2, (char**) netstat_args);
-
     /* until now there is no NTP support in libbsd -> Sebastian Huber ... */
     printf("\n***** Until now no NTP support in RTEMS 5 with rtems-libbsd *****\n");
     printf("\n***** Ask ntp server once... *****\n");
@@ -1168,6 +1246,15 @@ POSIX_Init ( void *argument __attribute__((unused)))
    // printf (" telnetd initialized with result %d\n", result);
 #endif
 
+#if 1
+// Start an rtems shell before main, for debugging RTEMS system issues
+    rtems_shell_init("SHLL", RTEMS_MINIMUM_STACK_SIZE * 4,
+                     100, "/dev/console",
+                     false, true,
+                     NULL);
+#endif
+
+    
     printf ("***** Preparing EPICS application *****\n");
     iocshRegisterRTEMS ();
     set_directory (argv[1]);

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -1122,9 +1122,7 @@ POSIX_Init ( void *argument __attribute__((unused)))
         rtems_dhcpcd_add_hook(&dhcpcd_hook);
 
         printf("\n***** Start default network dhcpcd *****\n");
-        // if MY_BOOTP???
         default_network_dhcpcd();
-
 
         /* this seems to be hard coded in the BSP -> Sebastian Huber ? */
         printf("\n--Info (hpj)-- bsd task prio IRQS: %d  -----\n", rtems_bsd_get_task_priority("IRQS"));

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -890,14 +890,14 @@ default_network_dhcpcd(void)
  * simpler implementation in a test that uses a sleep loop in
  * rtems-libbsd/testsuite/include/rtems/bsd/test/default-init.h, but
  * we chose this more responsive event based implementation.
- * 
+ *
  * Returns 0 if link came up, -1 on timeout or error.
  */
 static int
 wait_for_link_up(int route_sock, const char *ifname, int timeout_secs)
 {
     printf("Waiting for link on %s (timeout %ds)...\n", ifname, timeout_secs);
-    
+
     struct timeval tv = { .tv_sec = timeout_secs, .tv_usec = 0 };
     setsockopt(route_sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 
@@ -915,7 +915,7 @@ wait_for_link_up(int route_sock, const char *ifname, int timeout_secs)
             }
         }
     }
-    
+
     /* recv returned <= 0: SO_RCVTIMEO expired (EAGAIN) or socket error */
     printf("Warning: link did not come up on %s within %ds\n",
            ifname, timeout_secs);
@@ -999,7 +999,7 @@ POSIX_Init ( void *argument __attribute__((unused)))
     char timeBuff[100];
 
     initConsole ();
-    
+
     /*
      * Use BSP-supplied time of day if available otherwise supply default time.
      * It is very likely that other time synchronization facilities in EPICS
@@ -1166,7 +1166,7 @@ POSIX_Init ( void *argument __attribute__((unused)))
         printf("-------------- NETSTAT ------------------\n");
         rtems_bsd_command_netstat(2, (char**) netstat_args);
     }
-    
+
     /* until now there is no NTP support in libbsd -> Sebastian Huber ... */
     printf("\n***** Until now no NTP support in RTEMS 5 with rtems-libbsd *****\n");
     printf("\n***** Ask ntp server once... *****\n");
@@ -1251,7 +1251,6 @@ POSIX_Init ( void *argument __attribute__((unused)))
                      NULL);
 #endif
 
-    
     printf ("***** Preparing EPICS application *****\n");
     iocshRegisterRTEMS ();
     set_directory (argv[1]);

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -36,7 +36,6 @@
 #include <sys/syslog.h>
 #include <net/route.h>
 #include <net/if_dl.h>
-#include <rtems/bsd/iface.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <assert.h>
@@ -1001,8 +1000,6 @@ POSIX_Init ( void *argument __attribute__((unused)))
 
     initConsole ();
     
-    printf("epics-base build date %s, %s\n", __DATE__, __TIME__);
-    
     /*
      * Use BSP-supplied time of day if available otherwise supply default time.
      * It is very likely that other time synchronization facilities in EPICS
@@ -1246,7 +1243,7 @@ POSIX_Init ( void *argument __attribute__((unused)))
    // printf (" telnetd initialized with result %d\n", result);
 #endif
 
-#if 1
+#if 0
 // Start an rtems shell before main, for debugging RTEMS system issues
     rtems_shell_init("SHLL", RTEMS_MINIMUM_STACK_SIZE * 4,
                      100, "/dev/console",

--- a/modules/libcom/RTEMS/score/rtems_init.c
+++ b/modules/libcom/RTEMS/score/rtems_init.c
@@ -591,8 +591,8 @@ Init (rtems_task_argument ignored)
     if (epicsRtemsInitPreSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPreSetBootConfigFromNVRAM");
     if (rtems_bsdnet_config.bootp == NULL) {
-        extern void setBootConfigFromNVRAM(void);
-        setBootConfigFromNVRAM();
+        extern int setBootConfigFromNVRAM(char *, size_t);
+        setBootConfigFromNVRAM(NULL, 0);
     }
     if (epicsRtemsInitPostSetBootConfigFromNVRAM(&rtems_bsdnet_config) != 0)
         delayedPanic("epicsRtemsInitPostSetBootConfigFromNVRAM");

--- a/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
+++ b/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
@@ -102,23 +102,27 @@ splitNfsMountPath(char *nfsString)
 #endif /* HAVE_MOTLOAD || __mcf528x__ */
 
 struct boot_net_config {
-    char *ip_address;
-    char *netmask;
-    char *gateway;
-    char *server;        /* boot server; used as NTP/DNS fallback */
-    char *ntp_server;
-    char *hostname;
-    char *dns_server;
-    char *domainname;
-    char *bootp_boot_file;
+    char *ip_address;           /* static IP address of this device */
+    char *netmask;              /* subnet mask */
+    char *gateway;              /* default gateway */
+    char *server;               /* boot server; used as NTP/DNS fallback if not overridden */
+    char *ntp_server;           /* NTP server (falls back to server if NULL) */
+    char *hostname;             /* this device's hostname */
+    char *dns_server;           /* DNS resolver (falls back to server if NULL) */
+    char *domainname;           /* DNS domain name */
+    char *bootp_boot_file;      /* boot filename reported via BOOTP */
     uint32_t bootp_server_addr; /* server IPv4 address as stored in PPCBUG NVRAM */
 };
 
-#ifdef RTEMS_LEGACY_STACK
+/* Configure network from boot_net_config.
+ * RTEMS_LEGACY_STACK: populate rtems_bsdnet_config fields.
+ * libbsd: configure the first hardware interface (index 1) with a static IP.
+ * Returns 0 on success, -1 on failure. */
 static int
 applyNetConfig(const struct boot_net_config *cfg,
                char *ntp_server_ip, size_t ntp_server_ip_size)
 {
+#ifdef RTEMS_LEGACY_STACK
     (void)ntp_server_ip;
     (void)ntp_server_ip_size;
     rtems_bsdnet_bootp_server_name           = cfg->server;
@@ -134,16 +138,7 @@ applyNetConfig(const struct boot_net_config *cfg,
         rtems_bsdnet_bootp_boot_file_name = cfg->bootp_boot_file;
     if (cfg->bootp_server_addr)
         rtems_bsdnet_bootp_server_address.s_addr = cfg->bootp_server_addr;
-    return 0;
-}
 #else
-/* Configure the first hardware network interface with a static IP.
- * Assumes loopback is at index 0 and the first hardware device at index 1.
- * Returns 0 on success, -1 on failure. */
-static int
-applyNetConfig(const struct boot_net_config *cfg,
-               char *ntp_server_ip, size_t ntp_server_ip_size)
-{
     char ifnamebuf[IF_NAMESIZE];
     char *ifname = if_indextoname(1, ifnamebuf);
     if (ifname == NULL) {
@@ -156,7 +151,7 @@ applyNetConfig(const struct boot_net_config *cfg,
            cfg->gateway    ? cfg->gateway    : "NULL");
     if (cfg->ip_address && cfg->netmask) {
         int exit_code = rtems_bsd_ifconfig(ifname, cfg->ip_address,
-                                            cfg->netmask, cfg->gateway);
+                                           cfg->netmask, cfg->gateway);
         if (exit_code != EX_OK) {
             printf("rtems_bsd_ifconfig failed (exit code %d)\n", exit_code);
             return -1;
@@ -167,9 +162,9 @@ applyNetConfig(const struct boot_net_config *cfg,
     }
     if (ntp_server_ip != NULL && ntp_server_ip_size > 0 && cfg->ntp_server != NULL)
         snprintf(ntp_server_ip, ntp_server_ip_size, "%s", cfg->ntp_server);
+#endif
     return 0;
 }
-#endif
 
 #endif /* HAVE_MOTLOAD || HAVE_PPCBUG || __mcf528x__ */
 
@@ -275,14 +270,14 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
     if ((cfg.ip_address = gev("mot-/dev/enet0-cipa", nvp)) == NULL) {
         cfg.ip_address = motScriptParm(mot_script_boot, 'c');
     }
-    
+
     if ((cfg.netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL) {
         cfg.netmask = motScriptParm(mot_script_boot, 'm');
     }
     if ((cfg.gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL) {
         cfg.gateway = motScriptParm(mot_script_boot, 'g');
     }
-    
+
     if ((cfg.server = gev("mot-/dev/enet0-sipa", nvp)) == NULL) {
         cfg.server = motScriptParm(mot_script_boot, 's');
     }

--- a/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
+++ b/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
@@ -101,30 +101,44 @@ struct boot_net_config {
     char *ip_address;
     char *netmask;
     char *gateway;
-    char *server;      /* boot server; used as NTP/DNS fallback */
+    char *server;        /* boot server; used as NTP/DNS fallback */
     char *ntp_server;
+    char *hostname;
+    char *dns_server;
+    char *domainname;
+    char *bootp_boot_file;
+    uint32_t bootp_server_addr; /* server IPv4 address as stored in PPCBUG NVRAM */
 };
 
 #ifdef RTEMS_LEGACY_STACK
-/* Apply the six core bsdnet config assignments common to all BSPs.
- * Each BSP supplements with its own hostname/dns/boot-file overrides. */
-static void
-applyNetConfig(const struct boot_net_config *cfg)
+static int
+applyNetConfig(const struct boot_net_config *cfg,
+               char *ntp_server_ip, size_t ntp_server_ip_size)
 {
+    (void)ntp_server_ip;
+    (void)ntp_server_ip_size;
     rtems_bsdnet_bootp_server_name           = cfg->server;
-    rtems_bsdnet_config.name_server[0]       = cfg->server;
+    rtems_bsdnet_config.name_server[0]       = cfg->dns_server ? cfg->dns_server : cfg->server;
     rtems_bsdnet_config.ntp_server[0]        = cfg->ntp_server ? cfg->ntp_server : cfg->server;
     rtems_bsdnet_config.gateway              = cfg->gateway;
     rtems_bsdnet_config.ifconfig->ip_netmask = cfg->netmask;
     rtems_bsdnet_config.ifconfig->ip_address = cfg->ip_address;
-    rtems_bsdnet_config.hostname             = cfg->ip_address;
+    rtems_bsdnet_config.hostname             = cfg->hostname ? cfg->hostname : cfg->ip_address;
+    if (cfg->domainname)
+        rtems_bsdnet_config.domainname = cfg->domainname;
+    if (cfg->bootp_boot_file)
+        rtems_bsdnet_bootp_boot_file_name = cfg->bootp_boot_file;
+    if (cfg->bootp_server_addr)
+        rtems_bsdnet_bootp_server_address.s_addr = cfg->bootp_server_addr;
+    return 0;
 }
 #else
 /* Configure the first hardware network interface with a static IP.
  * Assumes loopback is at index 0 and the first hardware device at index 1.
  * Returns 0 on success, -1 on failure. */
 static int
-applyNetConfig(const struct boot_net_config *cfg)
+applyNetConfig(const struct boot_net_config *cfg,
+               char *ntp_server_ip, size_t ntp_server_ip_size)
 {
     char ifnamebuf[IF_NAMESIZE];
     char *ifname = if_indextoname(1, ifnamebuf);
@@ -147,6 +161,8 @@ applyNetConfig(const struct boot_net_config *cfg)
         printf("Skipping static IP address and netmask from NVRAM\n");
         return -1;
     }
+    if (ntp_server_ip != NULL && ntp_server_ip_size > 0 && cfg->ntp_server != NULL)
+        snprintf(ntp_server_ip, ntp_server_ip_size, "%s", cfg->ntp_server);
     return 0;
 }
 #endif
@@ -222,7 +238,6 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
     const char *mot_script_boot;
     volatile char *nvp;
-    char *cp;
     struct boot_net_config cfg = {0};
 
 # if defined(BSP_NVRAM_BASE_ADDR)
@@ -271,6 +286,12 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
         char *ntp_gev = gev("epics-ntpserver", nvp);
         cfg.ntp_server = ntp_gev ? ntp_gev : cfg.server;
     }
+    cfg.hostname   = gev("rtems-client-name", nvp);
+    cfg.dns_server = gev("rtems-dns-server", nvp);
+    cfg.domainname = gev("rtems-dns-domainname", nvp);
+    cfg.bootp_boot_file  = gev("mot-/dev/enet0-file", nvp);
+    if (cfg.bootp_boot_file == NULL)
+        cfg.bootp_boot_file = motScriptParm(mot_script_boot, 'f');
 
     /*
      * Apply network configuration
@@ -278,28 +299,18 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 #ifdef RTEMS_LEGACY_STACK
     if (rtems_bsdnet_config.bootp != NULL)
         return 0;
-    applyNetConfig(&cfg);
-    /* BSP-specific overrides from NVRAM: */
-    if ((cp = gev("rtems-dns-server", nvp)) != NULL)
-        rtems_bsdnet_config.name_server[0] = cp;
-    if ((cp = gev("rtems-dns-domainname", nvp)) != NULL)
-        rtems_bsdnet_config.domainname = cp;
-    if ((cp = gev("rtems-client-name", nvp)) != NULL)
-        rtems_bsdnet_config.hostname = cp;
-    if ((rtems_bsdnet_bootp_boot_file_name = gev("mot-/dev/enet0-file", nvp)) == NULL)
-        rtems_bsdnet_bootp_boot_file_name = motScriptParm(mot_script_boot, 'f');
-#else
-    if (applyNetConfig(&cfg) != 0)
-        return -1;
-    if (ntp_server_ip != NULL && ntp_server_ip_size > 0 && cfg.ntp_server != NULL)
-        snprintf(ntp_server_ip, ntp_server_ip_size, "%s", cfg.ntp_server);
 #endif
+    if (applyNetConfig(&cfg, ntp_server_ip, ntp_server_ip_size) != 0)
+        return -1;
 
     rtems_bsdnet_bootp_cmdline = gev("epics-script", nvp);
     splitRtemsBsdnetBootpCmdline();
     splitNfsMountPath(gev("epics-nfsmount", nvp));
-    if ((cp = gev("epics-tz", nvp)) != NULL)
-        epicsEnvSet("TZ", cp);
+    {
+        char *tz = gev("epics-tz", nvp);
+        if (tz != NULL)
+            epicsEnvSet("TZ", tz);
+    }
     return 0;
 }
 
@@ -386,21 +397,20 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
         addr(ip_netmask, nvram.SubnetIPAddressMask),
         addr(gateway,    nvram.GatewayIPAddress),
         serverp,
-        serverp,  /* ntp_server defaults to server */
+        serverp,               /* ntp_server defaults to server */
+        NULL,                  /* hostname */
+        NULL,                  /* dns_server */
+        NULL,                  /* domainname */
+        nvram.BootFilenameString, /* bootp_boot_file */
+        nvram.ServerIPAddress,    /* bootp_server_addr */
     };
 
 #ifdef RTEMS_LEGACY_STACK
     if (rtems_bsdnet_config.bootp != NULL)
         return 0;
-    applyNetConfig(&cfg);
-    rtems_bsdnet_bootp_server_address.s_addr = nvram.ServerIPAddress;  /* binary addr */
-    rtems_bsdnet_bootp_boot_file_name        = nvram.BootFilenameString;
-#else
-    if (applyNetConfig(&cfg) != 0)
-        return -1;
-    if (ntp_server_ip != NULL && ntp_server_ip_size > 0 && cfg.ntp_server != NULL)
-        snprintf(ntp_server_ip, ntp_server_ip_size, "%s", cfg.ntp_server);
 #endif
+    if (applyNetConfig(&cfg, ntp_server_ip, ntp_server_ip_size) != 0)
+        return -1;
     rtems_bsdnet_bootp_cmdline = nvram.ArgumentFilenameString;
     splitRtemsBsdnetBootpCmdline();
     return 0;
@@ -427,36 +437,32 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
     char *server_str = env("SERVER", "192.168.0.1");
     struct boot_net_config cfg = {
-        env("IPADDR0",  "192.168.0.2"),
-        env("NETMASK",  "255.255.252.0"),
-        env("GATEWAY",  NULL),
+        env("IPADDR0",   "192.168.0.2"),
+        env("NETMASK",   "255.255.252.0"),
+        env("GATEWAY",   NULL),
         server_str,
         env("NTPSERVER", server_str),
+        env("HOSTNAME",  "iocNobody"),
+        env("NAMESERVER", server_str),
+        env("DOMAIN",    NULL),
+        env("BOOTFILE",  "uC5282App.boot"),
+        0,  /* bootp_server_addr */
     };
-    const char *cp1;
 
 #ifdef RTEMS_LEGACY_STACK
     if (rtems_bsdnet_config.bootp != NULL)
         return 0;
-    applyNetConfig(&cfg);
-    /* BSP-specific overrides from env: */
-    rtems_bsdnet_config.name_server[0] = env("NAMESERVER", cfg.server);
-    rtems_bsdnet_config.hostname       = env("HOSTNAME", "iocNobody");
-    rtems_bsdnet_bootp_boot_file_name  = env("BOOTFILE", "uC5282App.boot");
-    cp1 = env("DOMAIN", NULL);
-    if (cp1 != NULL)
-        rtems_bsdnet_config.domainname = cp1;
-#else
-    if (applyNetConfig(&cfg) != 0)
-        return -1;
-    if (ntp_server_ip != NULL && ntp_server_ip_size > 0 && cfg.ntp_server != NULL)
-        snprintf(ntp_server_ip, ntp_server_ip_size, "%s", cfg.ntp_server);
 #endif
+    if (applyNetConfig(&cfg, ntp_server_ip, ntp_server_ip_size) != 0)
+        return -1;
     rtems_bsdnet_bootp_cmdline = env("CMDLINE", "epics/iocBoot/iocNobody/st.cmd");
     splitRtemsBsdnetBootpCmdline();
     splitNfsMountPath(env("NFSMOUNT", NULL));
-    if ((cp1 = env("TZ", NULL)) != NULL)
-        epicsEnvSet("TZ", cp1);
+    {
+        char *tz = env("TZ", NULL);
+        if (tz != NULL)
+            epicsEnvSet("TZ", tz);
+    }
     return 0;
 }
 

--- a/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
+++ b/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
@@ -97,6 +97,60 @@ splitNfsMountPath(char *nfsString)
     }
 }
 
+struct boot_net_config {
+    char *ip_address;
+    char *netmask;
+    char *gateway;
+    char *server;      /* boot server; used as NTP/DNS fallback */
+    char *ntp_server;
+};
+
+#ifdef RTEMS_LEGACY_STACK
+/* Apply the six core bsdnet config assignments common to all BSPs.
+ * Each BSP supplements with its own hostname/dns/boot-file overrides. */
+static void
+applyNetConfig(const struct boot_net_config *cfg)
+{
+    rtems_bsdnet_bootp_server_name           = cfg->server;
+    rtems_bsdnet_config.name_server[0]       = cfg->server;
+    rtems_bsdnet_config.ntp_server[0]        = cfg->ntp_server ? cfg->ntp_server : cfg->server;
+    rtems_bsdnet_config.gateway              = cfg->gateway;
+    rtems_bsdnet_config.ifconfig->ip_netmask = cfg->netmask;
+    rtems_bsdnet_config.ifconfig->ip_address = cfg->ip_address;
+    rtems_bsdnet_config.hostname             = cfg->ip_address;
+}
+#else
+/* Configure the first hardware network interface with a static IP.
+ * Assumes loopback is at index 0 and the first hardware device at index 1.
+ * Returns 0 on success, -1 on failure. */
+static int
+applyNetConfig(const struct boot_net_config *cfg)
+{
+    char ifnamebuf[IF_NAMESIZE];
+    char *ifname = if_indextoname(1, ifnamebuf);
+    if (ifname == NULL) {
+        printf("No network interface found\n");
+        return -1;
+    }
+    printf("Configuring ifconfig with ip=%s, netmask=%s, gateway=%s\n",
+           cfg->ip_address ? cfg->ip_address : "NULL",
+           cfg->netmask    ? cfg->netmask    : "NULL",
+           cfg->gateway    ? cfg->gateway    : "NULL");
+    if (cfg->ip_address && cfg->netmask) {
+        int exit_code = rtems_bsd_ifconfig(ifname, cfg->ip_address,
+                                            cfg->netmask, cfg->gateway);
+        if (exit_code != EX_OK) {
+            printf("rtems_bsd_ifconfig failed (exit code %d)\n", exit_code);
+            return -1;
+        }
+    } else {
+        printf("Skipping static IP address and netmask from NVRAM\n");
+        return -1;
+    }
+    return 0;
+}
+#endif
+
 #if defined(HAVE_MOTLOAD)
 
 /*
@@ -169,10 +223,7 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
     const char *mot_script_boot;
     volatile char *nvp;
     char *cp;
-    char *ip_address;
-    char *netmask;
-    char *gateway;
-    char *server_name;  /* TFTP/boot server IP, also used as DNS/NTP fallback */
+    struct boot_net_config cfg = {0};
 
 # if defined(BSP_NVRAM_BASE_ADDR)
     nvp = (volatile char *)(BSP_NVRAM_BASE_ADDR+0x70f8);
@@ -200,20 +251,25 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
     /*
      * Read network parameters from NVRAM
      */
-    if ((ip_address = gev("mot-/dev/enet0-cipa", nvp)) == NULL) {
-        ip_address = motScriptParm(mot_script_boot, 'c');
-    }
-
-    if ((netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL) {
-        netmask = motScriptParm(mot_script_boot, 'm');
-    }
-
-    if ((gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL) {
-        gateway = motScriptParm(mot_script_boot, 'g');
+    if ((cfg.ip_address = gev("mot-/dev/enet0-cipa", nvp)) == NULL) {
+        cfg.ip_address = motScriptParm(mot_script_boot, 'c');
     }
     
-    if ((server_name = gev("mot-/dev/enet0-sipa", nvp)) == NULL) {
-        server_name = motScriptParm(mot_script_boot, 's');
+    if ((cfg.netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL) {
+        cfg.netmask = motScriptParm(mot_script_boot, 'm');
+    }
+    if ((cfg.gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL) {
+        cfg.gateway = motScriptParm(mot_script_boot, 'g');
+    }
+    
+    if ((cfg.server = gev("mot-/dev/enet0-sipa", nvp)) == NULL) {
+        cfg.server = motScriptParm(mot_script_boot, 's');
+    }
+
+
+    {
+        char *ntp_gev = gev("epics-ntpserver", nvp);
+        cfg.ntp_server = ntp_gev ? ntp_gev : cfg.server;
     }
 
     /*
@@ -222,70 +278,21 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 #ifdef RTEMS_LEGACY_STACK
     if (rtems_bsdnet_config.bootp != NULL)
         return 0;
-
-    rtems_bsdnet_bootp_server_name = server_name;
-    rtems_bsdnet_config.gateway = gateway;
-    rtems_bsdnet_config.ifconfig->ip_netmask = netmask;
-
-    rtems_bsdnet_config.name_server[0] = gev("rtems-dns-server", nvp);
-    if (rtems_bsdnet_config.name_server[0] == NULL)
-        rtems_bsdnet_config.name_server[0] = server_name;
-    cp = gev("rtems-dns-domainname", nvp);
-    if (cp)
+    applyNetConfig(&cfg);
+    /* BSP-specific overrides from NVRAM: */
+    if ((cp = gev("rtems-dns-server", nvp)) != NULL)
+        rtems_bsdnet_config.name_server[0] = cp;
+    if ((cp = gev("rtems-dns-domainname", nvp)) != NULL)
         rtems_bsdnet_config.domainname = cp;
-
-    rtems_bsdnet_config.ifconfig->ip_address = ip_address;
-    rtems_bsdnet_config.hostname = gev("rtems-client-name", nvp);
-    if (rtems_bsdnet_config.hostname == NULL)
-        rtems_bsdnet_config.hostname = ip_address;
-
+    if ((cp = gev("rtems-client-name", nvp)) != NULL)
+        rtems_bsdnet_config.hostname = cp;
     if ((rtems_bsdnet_bootp_boot_file_name = gev("mot-/dev/enet0-file", nvp)) == NULL)
         rtems_bsdnet_bootp_boot_file_name = motScriptParm(mot_script_boot, 'f');
-
-    rtems_bsdnet_config.ntp_server[0] = gev("epics-ntpserver", nvp);
-    if (rtems_bsdnet_config.ntp_server[0] == NULL)
-        rtems_bsdnet_config.ntp_server[0] = server_name;
 #else
-    /*
-     * Configure interface with static IP and optional gateway using libbsd
-     */
-    {
-        char ifnamebuf[IF_NAMESIZE];
-        /* Assumes loopback interface is already brought up on
-         * index 0, and index 1 is the first hardware device. */
-        char *ifname = if_indextoname(1, ifnamebuf);
-        if (ifname == NULL) {
-            printf("No network interface found\n");
-            return -1;
-        }
-        printf("Configuring ifconfig with ip=%s, netmask=%s, gateway=%s\n",
-               ip_address? ip_address: "NULL",
-               netmask? netmask: "NULL",
-               gateway? gateway: "NULL");
-        
-        if (ip_address && netmask) {
-            int exit_code;
-            exit_code = rtems_bsd_ifconfig(ifname, ip_address, netmask, gateway);
-            if (exit_code != EX_OK) {
-                printf("rtems_bsd_ifconfig failed (exit code %d)\n", exit_code);
-                return -1;
-            }
-        } else {
-            printf("Skipping static IP address and netmask from NVRAM\n");
-            return -1;
-        }
-    }
-
-    /*
-     * Set NTP server for one-shot time sync
-     */
-    if (ntp_server_ip != NULL && ntp_server_ip_size > 0) {
-        char *ntp_gev = gev("epics-ntpserver", nvp);
-        if (ntp_gev == NULL)
-            ntp_gev = server_name;
-        if (ntp_gev != NULL)
-            snprintf(ntp_server_ip, ntp_server_ip_size, "%s", ntp_gev);
-    }
+    if (applyNetConfig(&cfg) != 0)
+        return -1;
+    if (ntp_server_ip != NULL && ntp_server_ip_size > 0 && cfg.ntp_server != NULL)
+        snprintf(ntp_server_ip, ntp_server_ip_size, "%s", cfg.ntp_server);
 #endif
 
     rtems_bsdnet_bootp_cmdline = gev("epics-script", nvp);
@@ -333,15 +340,11 @@ static char *addr(char *cbuf, uint32_t addr)
 int
 setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
-#ifdef RTEMS_LEGACY_STACK
     static struct ppcbug_nvram nvram;
     static char ip_address[INET_ADDRSTRLEN];
     static char ip_netmask[INET_ADDRSTRLEN];
     static char server[INET_ADDRSTRLEN];
     static char gateway[INET_ADDRSTRLEN];
-
-    if (rtems_bsdnet_config.bootp != NULL)
-        return 0;
 
     /*
      * Get network configuration from PPCBUG.
@@ -376,30 +379,31 @@ setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
         *d++ = *s++;
     }
 #endif
-    /*
-     * Assume that the boot server is also the name, log and ntp server!
-     */
-    rtems_bsdnet_config.name_server[0] =
-    rtems_bsdnet_config.ntp_server[0]  =
-      rtems_bsdnet_bootp_server_name   = addr(server, nvram.ServerIPAddress);
-    rtems_bsdnet_bootp_server_address.s_addr = nvram.ServerIPAddress;
-    /*
-     * Nothing better to use as host name!
-     */
-    rtems_bsdnet_config.ifconfig->ip_address =
-      rtems_bsdnet_config.hostname = addr(ip_address, nvram.ClientIPAddress);
 
-    rtems_bsdnet_config.gateway = addr(gateway, nvram.GatewayIPAddress);
-    rtems_bsdnet_config.ifconfig->ip_netmask = addr(ip_netmask, nvram.SubnetIPAddressMask);
+    char * serverp = addr(server, nvram.ServerIPAddress);
+    struct boot_net_config cfg = {
+        addr(ip_address, nvram.ClientIPAddress),
+        addr(ip_netmask, nvram.SubnetIPAddressMask),
+        addr(gateway,    nvram.GatewayIPAddress),
+        serverp,
+        serverp,  /* ntp_server defaults to server */
+    };
 
-    rtems_bsdnet_bootp_boot_file_name = nvram.BootFilenameString;
+#ifdef RTEMS_LEGACY_STACK
+    if (rtems_bsdnet_config.bootp != NULL)
+        return 0;
+    applyNetConfig(&cfg);
+    rtems_bsdnet_bootp_server_address.s_addr = nvram.ServerIPAddress;  /* binary addr */
+    rtems_bsdnet_bootp_boot_file_name        = nvram.BootFilenameString;
+#else
+    if (applyNetConfig(&cfg) != 0)
+        return -1;
+    if (ntp_server_ip != NULL && ntp_server_ip_size > 0 && cfg.ntp_server != NULL)
+        snprintf(ntp_server_ip, ntp_server_ip_size, "%s", cfg.ntp_server);
+#endif
     rtems_bsdnet_bootp_cmdline = nvram.ArgumentFilenameString;
     splitRtemsBsdnetBootpCmdline();
     return 0;
-#else
-    /* TODO: Implement NVRAM boot configuration for libbsd if needed */
-    return -1;
-#endif
 }
 
 #elif defined(__mcf528x__)
@@ -421,32 +425,39 @@ env(const char *parm, const char *defaultValue)
 int
 setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
-#ifdef RTEMS_LEGACY_STACK
+    char *server_str = env("SERVER", "192.168.0.1");
+    struct boot_net_config cfg = {
+        env("IPADDR0",  "192.168.0.2"),
+        env("NETMASK",  "255.255.252.0"),
+        env("GATEWAY",  NULL),
+        server_str,
+        env("NTPSERVER", server_str),
+    };
     const char *cp1;
 
+#ifdef RTEMS_LEGACY_STACK
     if (rtems_bsdnet_config.bootp != NULL)
         return 0;
-    rtems_bsdnet_config.gateway = env("GATEWAY", NULL);
-    rtems_bsdnet_config.ifconfig->ip_netmask = env("NETMASK", "255.255.252.0");
-
-    rtems_bsdnet_bootp_server_name = env("SERVER", "192.168.0.1");
-    rtems_bsdnet_config.name_server[0] = env("NAMESERVER", rtems_bsdnet_bootp_server_name);
-    rtems_bsdnet_config.ntp_server[0] = env("NTPSERVER", rtems_bsdnet_bootp_server_name);
+    applyNetConfig(&cfg);
+    /* BSP-specific overrides from env: */
+    rtems_bsdnet_config.name_server[0] = env("NAMESERVER", cfg.server);
+    rtems_bsdnet_config.hostname       = env("HOSTNAME", "iocNobody");
+    rtems_bsdnet_bootp_boot_file_name  = env("BOOTFILE", "uC5282App.boot");
     cp1 = env("DOMAIN", NULL);
     if (cp1 != NULL)
         rtems_bsdnet_config.domainname = cp1;
-    rtems_bsdnet_config.hostname = env("HOSTNAME", "iocNobody");
-    rtems_bsdnet_config.ifconfig->ip_address = env("IPADDR0", "192.168.0.2");
-    rtems_bsdnet_bootp_boot_file_name = env("BOOTFILE", "uC5282App.boot");
+#else
+    if (applyNetConfig(&cfg) != 0)
+        return -1;
+    if (ntp_server_ip != NULL && ntp_server_ip_size > 0 && cfg.ntp_server != NULL)
+        snprintf(ntp_server_ip, ntp_server_ip_size, "%s", cfg.ntp_server);
+#endif
     rtems_bsdnet_bootp_cmdline = env("CMDLINE", "epics/iocBoot/iocNobody/st.cmd");
+    splitRtemsBsdnetBootpCmdline();
     splitNfsMountPath(env("NFSMOUNT", NULL));
     if ((cp1 = env("TZ", NULL)) != NULL)
         epicsEnvSet("TZ", cp1);
     return 0;
-#else
-    /* TODO: Implement NVRAM boot configuration for libbsd if needed */
-    return -1;
-#endif
 }
 
 #else

--- a/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
+++ b/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
@@ -33,6 +33,8 @@ char *env_nfsServer;
 char *env_nfsPath;
 char *env_nfsMountPoint;
 
+#if defined(HAVE_MOTLOAD) || defined(HAVE_PPCBUG) || defined(__mcf528x__)
+
 extern char* rtems_bsdnet_bootp_cmdline;
 /*
  * Split argument string of form nfs_server:nfs_export:<path>
@@ -71,6 +73,7 @@ splitRtemsBsdnetBootpCmdline(void)
     }
 }
 
+#if defined(HAVE_MOTLOAD) || defined(__mcf528x__)
 /*
  * Split NFS mount information of the form nfs_server:host_path:local_path
  */
@@ -96,6 +99,7 @@ splitNfsMountPath(char *nfsString)
         }
     }
 }
+#endif /* HAVE_MOTLOAD || __mcf528x__ */
 
 struct boot_net_config {
     char *ip_address;
@@ -166,6 +170,8 @@ applyNetConfig(const struct boot_net_config *cfg,
     return 0;
 }
 #endif
+
+#endif /* HAVE_MOTLOAD || HAVE_PPCBUG || __mcf528x__ */
 
 #if defined(HAVE_MOTLOAD)
 

--- a/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
+++ b/modules/libcom/RTEMS/setBootConfigFromNVRAM.c
@@ -14,6 +14,11 @@
 #include <unistd.h>
 #ifdef RTEMS_LEGACY_STACK
 #include <rtems/rtems_bsdnet.h>
+#else
+#include <stdio.h>
+#include <net/if.h>
+#include <sysexits.h>
+#include <rtems/bsd/bsd.h>
 #endif
 #include <bsp.h>
 #include <string.h>
@@ -158,12 +163,16 @@ motScriptParm(const char *mot_script_boot, char parm)
     return NULL;
 }
 
-void
-setBootConfigFromNVRAM(void)
+int
+setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
-    char *cp;
     const char *mot_script_boot;
     volatile char *nvp;
+    char *cp;
+    char *ip_address;
+    char *netmask;
+    char *gateway;
+    char *server_name;  /* TFTP/boot server IP, also used as DNS/NTP fallback */
 
 # if defined(BSP_NVRAM_BASE_ADDR)
     nvp = (volatile char *)(BSP_NVRAM_BASE_ADDR+0x70f8);
@@ -172,12 +181,13 @@ setBootConfigFromNVRAM(void)
     int fd;
     if ((fd = open(BSP_I2C_VPD_EEPROM_DEV_NAME, 0)) < 0) {
         printf("Can't open %s: %s\n", BSP_I2C_VPD_EEPROM_DEV_NAME, strerror(errno));
-        return;
+        return -1;
     }
     lseek(fd, 0x10f8, SEEK_SET);
     if (read(fd, gev_buf, sizeof gev_buf) != sizeof gev_buf) {
         printf("Can't read %s: %s\n", BSP_I2C_VPD_EEPROM_DEV_NAME, strerror(errno));
-        return;
+        close(fd);
+        return -1;
     }
     close(fd);
     nvp = gev_buf;
@@ -185,39 +195,105 @@ setBootConfigFromNVRAM(void)
 #  error "No way to read GEV!"
 # endif
 
-    if (rtems_bsdnet_config.bootp != NULL)
-        return;
     mot_script_boot = gev("mot-script-boot", nvp);
-    if ((rtems_bsdnet_bootp_server_name = gev("mot-/dev/enet0-sipa", nvp)) == NULL)
-        rtems_bsdnet_bootp_server_name = motScriptParm(mot_script_boot, 's');
-    if ((rtems_bsdnet_config.gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL)
-        rtems_bsdnet_config.gateway = motScriptParm(mot_script_boot, 'g');
-    if  ((rtems_bsdnet_config.ifconfig->ip_netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL)
-        rtems_bsdnet_config.ifconfig->ip_netmask = motScriptParm(mot_script_boot, 'm');
+
+    /*
+     * Read network parameters from NVRAM
+     */
+    if ((ip_address = gev("mot-/dev/enet0-cipa", nvp)) == NULL) {
+        ip_address = motScriptParm(mot_script_boot, 'c');
+    }
+
+    if ((netmask = gev("mot-/dev/enet0-snma", nvp)) == NULL) {
+        netmask = motScriptParm(mot_script_boot, 'm');
+    }
+
+    if ((gateway = gev("mot-/dev/enet0-gipa", nvp)) == NULL) {
+        gateway = motScriptParm(mot_script_boot, 'g');
+    }
+    
+    if ((server_name = gev("mot-/dev/enet0-sipa", nvp)) == NULL) {
+        server_name = motScriptParm(mot_script_boot, 's');
+    }
+
+    /*
+     * Apply network configuration
+     */
+#ifdef RTEMS_LEGACY_STACK
+    if (rtems_bsdnet_config.bootp != NULL)
+        return 0;
+
+    rtems_bsdnet_bootp_server_name = server_name;
+    rtems_bsdnet_config.gateway = gateway;
+    rtems_bsdnet_config.ifconfig->ip_netmask = netmask;
 
     rtems_bsdnet_config.name_server[0] = gev("rtems-dns-server", nvp);
     if (rtems_bsdnet_config.name_server[0] == NULL)
-        rtems_bsdnet_config.name_server[0] = rtems_bsdnet_bootp_server_name;
+        rtems_bsdnet_config.name_server[0] = server_name;
     cp = gev("rtems-dns-domainname", nvp);
     if (cp)
         rtems_bsdnet_config.domainname = cp;
 
-    if ((rtems_bsdnet_config.ifconfig->ip_address = gev("mot-/dev/enet0-cipa", nvp)) == NULL)
-        rtems_bsdnet_config.ifconfig->ip_address = motScriptParm(mot_script_boot, 'c');
+    rtems_bsdnet_config.ifconfig->ip_address = ip_address;
     rtems_bsdnet_config.hostname = gev("rtems-client-name", nvp);
     if (rtems_bsdnet_config.hostname == NULL)
-        rtems_bsdnet_config.hostname = rtems_bsdnet_config.ifconfig->ip_address;
+        rtems_bsdnet_config.hostname = ip_address;
 
     if ((rtems_bsdnet_bootp_boot_file_name = gev("mot-/dev/enet0-file", nvp)) == NULL)
         rtems_bsdnet_bootp_boot_file_name = motScriptParm(mot_script_boot, 'f');
+
+    rtems_bsdnet_config.ntp_server[0] = gev("epics-ntpserver", nvp);
+    if (rtems_bsdnet_config.ntp_server[0] == NULL)
+        rtems_bsdnet_config.ntp_server[0] = server_name;
+#else
+    /*
+     * Configure interface with static IP and optional gateway using libbsd
+     */
+    {
+        char ifnamebuf[IF_NAMESIZE];
+        /* Assumes loopback interface is already brought up on
+         * index 0, and index 1 is the first hardware device. */
+        char *ifname = if_indextoname(1, ifnamebuf);
+        if (ifname == NULL) {
+            printf("No network interface found\n");
+            return -1;
+        }
+        printf("Configuring ifconfig with ip=%s, netmask=%s, gateway=%s\n",
+               ip_address? ip_address: "NULL",
+               netmask? netmask: "NULL",
+               gateway? gateway: "NULL");
+        
+        if (ip_address && netmask) {
+            int exit_code;
+            exit_code = rtems_bsd_ifconfig(ifname, ip_address, netmask, gateway);
+            if (exit_code != EX_OK) {
+                printf("rtems_bsd_ifconfig failed (exit code %d)\n", exit_code);
+                return -1;
+            }
+        } else {
+            printf("Skipping static IP address and netmask from NVRAM\n");
+            return -1;
+        }
+    }
+
+    /*
+     * Set NTP server for one-shot time sync
+     */
+    if (ntp_server_ip != NULL && ntp_server_ip_size > 0) {
+        char *ntp_gev = gev("epics-ntpserver", nvp);
+        if (ntp_gev == NULL)
+            ntp_gev = server_name;
+        if (ntp_gev != NULL)
+            snprintf(ntp_server_ip, ntp_server_ip_size, "%s", ntp_gev);
+    }
+#endif
+
     rtems_bsdnet_bootp_cmdline = gev("epics-script", nvp);
     splitRtemsBsdnetBootpCmdline();
     splitNfsMountPath(gev("epics-nfsmount", nvp));
-    rtems_bsdnet_config.ntp_server[0] = gev("epics-ntpserver", nvp);
-    if (rtems_bsdnet_config.ntp_server[0] == NULL)
-        rtems_bsdnet_config.ntp_server[0] = rtems_bsdnet_bootp_server_name;
     if ((cp = gev("epics-tz", nvp)) != NULL)
         epicsEnvSet("TZ", cp);
+    return 0;
 }
 
 #elif defined(HAVE_PPCBUG)
@@ -254,9 +330,10 @@ static char *addr(char *cbuf, uint32_t addr)
     return (char *)inet_ntop(AF_INET, &a, cbuf, INET_ADDRSTRLEN);
 }
 
-void
-setBootConfigFromNVRAM(void)
+int
+setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
+#ifdef RTEMS_LEGACY_STACK
     static struct ppcbug_nvram nvram;
     static char ip_address[INET_ADDRSTRLEN];
     static char ip_netmask[INET_ADDRSTRLEN];
@@ -264,7 +341,7 @@ setBootConfigFromNVRAM(void)
     static char gateway[INET_ADDRSTRLEN];
 
     if (rtems_bsdnet_config.bootp != NULL)
-        return;
+        return 0;
 
     /*
      * Get network configuration from PPCBUG.
@@ -318,6 +395,11 @@ setBootConfigFromNVRAM(void)
     rtems_bsdnet_bootp_boot_file_name = nvram.BootFilenameString;
     rtems_bsdnet_bootp_cmdline = nvram.ArgumentFilenameString;
     splitRtemsBsdnetBootpCmdline();
+    return 0;
+#else
+    /* TODO: Implement NVRAM boot configuration for libbsd if needed */
+    return -1;
+#endif
 }
 
 #elif defined(__mcf528x__)
@@ -336,13 +418,14 @@ env(const char *parm, const char *defaultValue)
     return epicsStrDup(cp);
 }
 
-void
-setBootConfigFromNVRAM(void)
+int
+setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
+#ifdef RTEMS_LEGACY_STACK
     const char *cp1;
 
     if (rtems_bsdnet_config.bootp != NULL)
-        return;
+        return 0;
     rtems_bsdnet_config.gateway = env("GATEWAY", NULL);
     rtems_bsdnet_config.ifconfig->ip_netmask = env("NETMASK", "255.255.252.0");
 
@@ -359,16 +442,22 @@ setBootConfigFromNVRAM(void)
     splitNfsMountPath(env("NFSMOUNT", NULL));
     if ((cp1 = env("TZ", NULL)) != NULL)
         epicsEnvSet("TZ", cp1);
+    return 0;
+#else
+    /* TODO: Implement NVRAM boot configuration for libbsd if needed */
+    return -1;
+#endif
 }
 
 #else
 /*
  * Placeholder for systems without NVRAM
  */
-void
-setBootConfigFromNVRAM(void)
+int
+setBootConfigFromNVRAM(char *ntp_server_ip, size_t ntp_server_ip_size)
 {
     printf("SYSTEM HAS NO NON-VOLATILE RAM!\n");
     printf("YOU MUST USE SOME OTHER METHOD TO OBTAIN NETWORK CONFIGURATION\n");
+    return -1;
 }
 #endif


### PR DESCRIPTION
These changes allow epics to use RTEMS with libbsd to configure a static IP.  If no static IP configuration is in nvram, it falls back to trying DHCP.  

The changes also begin separating the BSP specific querying of network information from the actual initialization/setup of the network, with the hope that we can separate the two completely in the future soon.