### PR TITLE
as/ca: keep HAG and CA hostname state current by DNS TTL

### DIFF
--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -127,7 +127,8 @@ EXPAND_VARS = INSTALL_BIN=$(FINAL_LOCATION)/bin/$(T_A)
 
 SRC_DIRS += $(CURDIR)/test
 TESTPROD_HOST += caStatefulAddrTest
-caStatefulAddrTest_SRCS = caStatefulAddrTest.cpp
+caStatefulAddrTest_SRCS = caStatefulAddrTest.cpp caStatefulAddr.cpp
+caStatefulAddrTest_LIBS = Com
 TESTSCRIPTS_HOST += caStatefulAddrTest.t
 
 PROD_HOST += ca_test

--- a/modules/ca/src/client/Makefile
+++ b/modules/ca/src/client/Makefile
@@ -48,6 +48,7 @@ LIBSRCS += cacWriteNotify.cpp
 LIBSRCS += cacStateNotify.cpp
 LIBSRCS += access.cpp
 LIBSRCS += iocinf.cpp
+LIBSRCS += caStatefulAddr.cpp
 LIBSRCS += convert.cpp
 LIBSRCS += test_event.cpp
 LIBSRCS += repeater.cpp
@@ -94,6 +95,10 @@ ca_RCS = ca.rc
 ca_LIBS = Com
 
 ca_SYS_LIBS_WIN32 = ws2_32 advapi32 user32
+ca_SYS_LIBS_Darwin += resolv
+ca_SYS_LIBS_Linux += resolv
+ca_SYS_LIBS_freebsd += resolv
+ca_SYS_LIBS_solaris += resolv
 
 #   libs needed for PROD and TESTPRODUCT
 PROD_LIBS = ca Com
@@ -121,6 +126,10 @@ EXPAND += caRepeater.service@
 EXPAND_VARS = INSTALL_BIN=$(FINAL_LOCATION)/bin/$(T_A)
 
 SRC_DIRS += $(CURDIR)/test
+TESTPROD_HOST += caStatefulAddrTest
+caStatefulAddrTest_SRCS = caStatefulAddrTest.cpp
+TESTSCRIPTS_HOST += caStatefulAddrTest.t
+
 PROD_HOST += ca_test
 ca_test_SRCS = ca_test_main.c ca_test.c
 ca_test_SYS_LIBS_WIN32 = ws2_32 advapi32 user32

--- a/modules/ca/src/client/caStatefulAddr.cpp
+++ b/modules/ca/src/client/caStatefulAddr.cpp
@@ -1,0 +1,329 @@
+/*************************************************************************\
+* Copyright (c) 2026 UChicago Argonne LLC, as Operator of Argonne
+*     National Laboratory.
+* SPDX-License-Identifier: EPICS
+\*************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <exception>
+#include <vector>
+
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun)
+#  include <arpa/nameser.h>
+#  include <resolv.h>
+#  define CA_USE_DNS_TTL 1
+#endif
+
+#include "dbDefs.h"
+#include "epicsStdio.h"
+#include "epicsString.h"
+#include "errlog.h"
+#include "osiSock.h"
+
+#include "caStatefulAddr.h"
+
+#define CA_DNS_TTL_FALLBACK 300u
+#define CA_DNS_RETRY 60u
+
+static caStatefulAddr::Resolver caResolverForTest = NULL;
+
+static int caSetIPAddr(epicsUInt32 rawAddr, unsigned short port,
+    struct sockaddr_in *pIP)
+{
+    static const struct sockaddr_in emptyAddr = {0};
+
+    *pIP = emptyAddr;
+    pIP->sin_family = AF_INET;
+    pIP->sin_port = htons(port);
+    pIP->sin_addr.s_addr = htonl(rawAddr);
+    return 0;
+}
+
+static int caParseNumericIPAddr(const char *host, unsigned short defaultPort,
+    struct sockaddr_in *pIP)
+{
+    int status;
+    unsigned addr[4];
+    unsigned long rawAddr;
+    unsigned port;
+    char dummy[8];
+
+    status = sscanf(host, " %u . %u . %u . %u %7s ",
+        addr, addr+1u, addr+2u, addr+3u, dummy);
+    if(status == 4) {
+        if(addr[0] <= 0xff && addr[1] <= 0xff &&
+           addr[2] <= 0xff && addr[3] <= 0xff) {
+            return caSetIPAddr(((epicsUInt32)addr[0] << 24) |
+                               ((epicsUInt32)addr[1] << 16) |
+                               ((epicsUInt32)addr[2] << 8) |
+                               (epicsUInt32)addr[3], defaultPort, pIP);
+        }
+        return -1;
+    }
+
+    status = sscanf(host, " %u . %u . %u . %u : %u %7s ",
+        addr, addr+1u, addr+2u, addr+3u, &port, dummy);
+    if(status == 5 && port <= 0xffff) {
+        if(addr[0] <= 0xff && addr[1] <= 0xff &&
+           addr[2] <= 0xff && addr[3] <= 0xff) {
+            return caSetIPAddr(((epicsUInt32)addr[0] << 24) |
+                               ((epicsUInt32)addr[1] << 16) |
+                               ((epicsUInt32)addr[2] << 8) |
+                               (epicsUInt32)addr[3], (unsigned short)port, pIP);
+        }
+        return -1;
+    }
+
+    status = sscanf(host, " %lu %7s ", &rawAddr, dummy);
+    if(status == 1 && rawAddr <= 0xfffffffful) {
+        return caSetIPAddr((epicsUInt32)rawAddr, defaultPort, pIP);
+    }
+
+    status = sscanf(host, " %lu : %u %7s ", &rawAddr, &port, dummy);
+    if(status == 2 && rawAddr <= 0xfffffffful && port <= 0xffff) {
+        return caSetIPAddr((epicsUInt32)rawAddr, (unsigned short)port, pIP);
+    }
+
+    return -1;
+}
+
+static std::string caHostPart(const char *token)
+{
+    const char *colon = strchr(token, ':');
+
+    if(colon)
+        return std::string(token, colon-token);
+    return std::string(token);
+}
+
+#ifdef CA_USE_DNS_TTL
+static int caDnsTTL(const char *host, const struct in_addr *addr,
+    unsigned *ttl)
+{
+    unsigned char answer[4096];
+    ns_msg handle;
+    int len;
+    int count;
+    int i;
+    int found = 0;
+    unsigned best = 0;
+
+    len = res_query(host, ns_c_in, ns_t_a, answer, sizeof(answer));
+    if(len < 0 || len > (int)sizeof(answer) || ns_initparse(answer, len, &handle))
+        return -1;
+
+    count = ns_msg_count(handle, ns_s_an);
+    for(i = 0; i < count; i++) {
+        ns_rr rr;
+
+        if(ns_parserr(&handle, ns_s_an, i, &rr))
+            continue;
+        if(ns_rr_type(rr) != ns_t_a || ns_rr_class(rr) != ns_c_in)
+            continue;
+        if(ns_rr_rdlen(rr) != sizeof(addr->s_addr))
+            continue;
+        if(memcmp(ns_rr_rdata(rr), &addr->s_addr, sizeof(addr->s_addr)) != 0)
+            continue;
+
+        if(!found || ns_rr_ttl(rr) < best)
+            best = ns_rr_ttl(rr);
+        found = 1;
+    }
+    if(found) {
+        *ttl = best;
+        return 0;
+    }
+    return -1;
+}
+#endif
+
+static int caResolveDefault(const char *token, unsigned short defaultPort,
+    int ignoreNonDefaultPort, caStatefulAddr::ResolveResult *result)
+{
+    struct sockaddr_in addr;
+
+    result->ttl = CA_DNS_TTL_FALLBACK;
+    result->isStatic = 0;
+    if(caParseNumericIPAddr(token, defaultPort, &addr)==0) {
+        if(ignoreNonDefaultPort && ntohs(addr.sin_port) != defaultPort)
+            return 1;
+        result->addr.ia = addr;
+        result->isStatic = 1;
+        return 0;
+    }
+
+    if(aToIPAddr(token, defaultPort, &addr)) {
+        errlogPrintf("CAC: Unable to resolve address list host '%s'\n", token);
+        return -1;
+    }
+    if(ignoreNonDefaultPort && ntohs(addr.sin_port) != defaultPort)
+        return 1;
+
+#ifdef CA_USE_DNS_TTL
+    {
+        std::string host(caHostPart(token));
+
+        if(caDnsTTL(host.c_str(), &addr.sin_addr, &result->ttl))
+            result->ttl = CA_DNS_TTL_FALLBACK;
+    }
+#endif
+    result->addr.ia = addr;
+    return 0;
+}
+
+caStatefulAddr::caStatefulAddr() :
+    _defaultPort(0u),
+    _ignoreNonDefaultPort(0),
+    _resolved(false),
+    _ignored(false),
+    _staticAddr(false),
+    _expires(0)
+{
+    memset(&_addr, 0, sizeof(_addr));
+}
+
+caStatefulAddr::caStatefulAddr(const std::string &token,
+    unsigned short defaultPort, int ignoreNonDefaultPort) :
+    _token(token),
+    _defaultPort(defaultPort),
+    _ignoreNonDefaultPort(ignoreNonDefaultPort),
+    _resolved(false),
+    _ignored(false),
+    _staticAddr(false),
+    _expires(0)
+{
+    memset(&_addr, 0, sizeof(_addr));
+    refreshIfDue();
+}
+
+bool caStatefulAddr::refreshIfDue()
+{
+    time_t now = time(NULL);
+
+    if(now == (time_t)-1)
+        now = 0;
+    return refresh(now);
+}
+
+bool caStatefulAddr::refresh(time_t now)
+{
+    caStatefulAddr::ResolveResult result;
+    caStatefulAddr::Resolver resolver = caResolverForTest;
+    bool oldResolved;
+    osiSockAddr oldAddr;
+    int status;
+
+    if(_ignored || _staticAddr)
+        return false;
+    if(_expires && difftime(now, _expires) < 0.0)
+        return false;
+
+    memset(&result, 0, sizeof(result));
+    oldResolved = _resolved;
+    oldAddr = _addr;
+    if(!resolver)
+        resolver = caResolveDefault;
+
+    status = (*resolver)(_token.c_str(), _defaultPort, _ignoreNonDefaultPort,
+        &result);
+    if(status == 1) {
+        _ignored = true;
+        _resolved = false;
+        return oldResolved;
+    }
+    if(status) {
+        _resolved = false;
+        _staticAddr = false;
+        _expires = now + CA_DNS_RETRY;
+        return oldResolved;
+    }
+
+    _addr = result.addr;
+    _resolved = true;
+    _staticAddr = !!result.isStatic;
+    _expires = _staticAddr ? 0 : now + result.ttl;
+    if(!oldResolved)
+        return true;
+    return !caSockAddrEqual(oldAddr, _addr);
+}
+
+bool caStatefulAddr::resolved() const
+{
+    return _resolved;
+}
+
+bool caStatefulAddr::ignored() const
+{
+    return _ignored;
+}
+
+bool caStatefulAddr::isStatic() const
+{
+    return _staticAddr;
+}
+
+const osiSockAddr &caStatefulAddr::addr() const
+{
+    return _addr;
+}
+
+const std::string &caStatefulAddr::token() const
+{
+    return _token;
+}
+
+void caStatefulAddr::setResolverForTest(Resolver resolver)
+{
+    caResolverForTest = resolver;
+}
+
+void caParseStatefulAddrList(std::vector<caStatefulAddr> &out,
+    const ENV_PARAM *pEnv, unsigned short defaultPort,
+    int ignoreNonDefaultPort)
+{
+    const char *pStr = envGetConfigParamPtr(pEnv);
+
+    if(!pStr)
+        return;
+
+    try {
+        std::vector<char> scratch(pStr, pStr+strlen(pStr)+1);
+        char *save = NULL;
+        const char *pToken;
+
+        for(pToken = epicsStrtok_r(&scratch[0], " \t\n\r", &save);
+            pToken;
+            pToken = epicsStrtok_r(NULL, " \t\n\r", &save)) {
+            caStatefulAddr addr(pToken, defaultPort, ignoreNonDefaultPort);
+
+            if(!addr.ignored())
+                out.push_back(addr);
+        }
+    } catch(std::exception &) {
+    }
+}
+
+bool caSockAddrEqual(const osiSockAddr &lhs, const osiSockAddr &rhs)
+{
+    if(lhs.sa.sa_family != rhs.sa.sa_family)
+        return false;
+    if(lhs.sa.sa_family != AF_INET)
+        return false;
+    return lhs.ia.sin_addr.s_addr == rhs.ia.sin_addr.s_addr &&
+           lhs.ia.sin_port == rhs.ia.sin_port;
+}
+
+bool caSockAddrSeen(std::vector<osiSockAddr> &seen, const osiSockAddr &addr)
+{
+    std::vector<osiSockAddr>::const_iterator it;
+
+    for(it = seen.begin(); it != seen.end(); ++it) {
+        if(caSockAddrEqual(*it, addr))
+            return true;
+    }
+    seen.push_back(addr);
+    return false;
+}

--- a/modules/ca/src/client/caStatefulAddr.cpp
+++ b/modules/ca/src/client/caStatefulAddr.cpp
@@ -27,6 +27,7 @@
 
 #define CA_DNS_TTL_FALLBACK 300u
 #define CA_DNS_RETRY 60u
+#define CA_ADDR_LIST_ENV_MAX 65536u
 
 static caStatefulAddr::Resolver caResolverForTest = NULL;
 
@@ -180,9 +181,9 @@ caStatefulAddr::caStatefulAddr() :
     _resolved(false),
     _ignored(false),
     _staticAddr(false),
-    _expires(0)
+    _expires(0),
+    _addr()
 {
-    memset(&_addr, 0, sizeof(_addr));
 }
 
 caStatefulAddr::caStatefulAddr(const std::string &token,
@@ -193,9 +194,9 @@ caStatefulAddr::caStatefulAddr(const std::string &token,
     _resolved(false),
     _ignored(false),
     _staticAddr(false),
-    _expires(0)
+    _expires(0),
+    _addr()
 {
-    memset(&_addr, 0, sizeof(_addr));
     refreshIfDue();
 }
 
@@ -210,7 +211,7 @@ bool caStatefulAddr::refreshIfDue()
 
 bool caStatefulAddr::refresh(time_t now)
 {
-    caStatefulAddr::ResolveResult result;
+    caStatefulAddr::ResolveResult result = {};
     caStatefulAddr::Resolver resolver = caResolverForTest;
     bool oldResolved;
     osiSockAddr oldAddr;
@@ -221,7 +222,6 @@ bool caStatefulAddr::refresh(time_t now)
     if(_expires && difftime(now, _expires) < 0.0)
         return false;
 
-    memset(&result, 0, sizeof(result));
     oldResolved = _resolved;
     oldAddr = _addr;
     if(!resolver)
@@ -290,9 +290,19 @@ void caParseStatefulAddrList(std::vector<caStatefulAddr> &out,
         return;
 
     try {
-        std::vector<char> scratch(pStr, pStr+strlen(pStr)+1);
+        size_t len = epicsStrnLen(pStr, CA_ADDR_LIST_ENV_MAX);
+        std::vector<char> scratch;
         char *save = NULL;
         const char *pToken;
+
+        if(len == CA_ADDR_LIST_ENV_MAX) {
+            errlogPrintf("CAC: address list '%s' exceeds %u bytes\n",
+                pEnv->name, (unsigned)CA_ADDR_LIST_ENV_MAX);
+            return;
+        }
+
+        scratch.resize(len + 1u, '\0');
+        memcpy(&scratch[0], pStr, len);
 
         for(pToken = epicsStrtok_r(&scratch[0], " \t\n\r", &save);
             pToken;

--- a/modules/ca/src/client/caStatefulAddr.h
+++ b/modules/ca/src/client/caStatefulAddr.h
@@ -1,0 +1,64 @@
+/*************************************************************************\
+* Copyright (c) 2026 UChicago Argonne LLC, as Operator of Argonne
+*     National Laboratory.
+* SPDX-License-Identifier: EPICS
+\*************************************************************************/
+
+#ifndef INC_caStatefulAddr_H
+#define INC_caStatefulAddr_H
+
+#include <string>
+#include <vector>
+#include <time.h>
+
+#include "envDefs.h"
+#include "ellLib.h"
+#include "osiSock.h"
+
+class caStatefulAddr {
+public:
+    struct ResolveResult {
+        osiSockAddr addr;
+        unsigned ttl;
+        int isStatic;
+    };
+
+    typedef int (*Resolver)(const char *token, unsigned short defaultPort,
+        int ignoreNonDefaultPort, ResolveResult *result);
+
+    caStatefulAddr();
+    caStatefulAddr(const std::string &token, unsigned short defaultPort,
+        int ignoreNonDefaultPort);
+
+    bool refreshIfDue();
+    bool refresh(time_t now);
+
+    bool resolved() const;
+    bool ignored() const;
+    bool isStatic() const;
+    const osiSockAddr &addr() const;
+    const std::string &token() const;
+
+    static void setResolverForTest(Resolver resolver);
+
+private:
+    std::string _token;
+    unsigned short _defaultPort;
+    int _ignoreNonDefaultPort;
+    bool _resolved;
+    bool _ignored;
+    bool _staticAddr;
+    time_t _expires;
+    osiSockAddr _addr;
+};
+
+void caParseStatefulAddrList(std::vector<caStatefulAddr> &out,
+    const ENV_PARAM *pEnv, unsigned short defaultPort,
+    int ignoreNonDefaultPort);
+
+bool caSockAddrEqual(const osiSockAddr &lhs, const osiSockAddr &rhs);
+bool caSockAddrSeen(std::vector<osiSockAddr> &seen, const osiSockAddr &addr);
+void caConfigureChannelAccessAutoAddressList(ELLLIST *pList, SOCKET sock,
+    unsigned short port);
+
+#endif /* INC_caStatefulAddr_H */

--- a/modules/ca/src/client/cac.cpp
+++ b/modules/ca/src/client/cac.cpp
@@ -24,6 +24,7 @@
 #include <new>
 #include <stdexcept>
 #include <string> // vxWorks 6.0 requires this include
+#include <vector>
 
 #include "epicsStdio.h"
 #include "dbDefs.h"
@@ -37,6 +38,7 @@
 #include "epicsExport.h"
 
 #include "addrList.h"
+#include "caStatefulAddr.h"
 #include "iocinf.h"
 #include "cac.h"
 #include "inetAddrID.h"
@@ -251,30 +253,37 @@ cac::cac (
      * load user configured tcp name server address list,
      * create virtual circuits, and add them to server table
      */
-    ELLLIST dest, tmpList;
+    std::vector < caStatefulAddr > nameServers;
+    std::vector < caStatefulAddr > :: const_iterator nameServerIter;
+    std::vector < osiSockAddr > seenNameServers;
 
-    ellInit ( & dest );
-    ellInit ( & tmpList );
-
-    addAddrToChannelAccessAddressList ( &tmpList, &EPICS_CA_NAME_SERVERS, this->_serverPort, false );
-    removeDuplicateAddresses ( &dest, &tmpList, 0 );
+    caParseStatefulAddrList ( nameServers, &EPICS_CA_NAME_SERVERS,
+        this->_serverPort, false );
 
     epicsGuard < epicsMutex > guard ( this->mutex );
 
-    while ( osiSockAddrNode *
-        pNode = reinterpret_cast < osiSockAddrNode * > ( ellGet ( & dest ) ) ) {
+    for ( nameServerIter = nameServers.begin ();
+          nameServerIter != nameServers.end (); ++nameServerIter ) {
         tcpiiu * piiu = NULL;
-        SearchDestTCP * pdst = new SearchDestTCP ( *this, pNode->addr );
+        SearchDestTCP * pdst;
+
+        if ( nameServerIter->resolved () &&
+             caSockAddrSeen ( seenNameServers, nameServerIter->addr () ) ) {
+            continue;
+        }
+        pdst = new SearchDestTCP ( *this, *nameServerIter );
         this->registerSearchDest ( guard, * pdst );
+        if ( ! nameServerIter->resolved () ) {
+            continue;
+        }
         /* Initially assume that servers listed in EPICS_CA_NAME_SERVERS support at least minor
          * version 11.  This causes tcpiiu to send the user and host name authentication
          * messages.  When the actual Version message is received from the server it will
          * be overwrite this assumption.
          */
         bool newIIU = findOrCreateVirtCircuit (
-            guard, pNode->addr, cacChannel::priorityDefault,
+            guard, nameServerIter->addr (), cacChannel::priorityDefault,
             piiu, 11, pdst );
-        free ( pNode );
         if ( newIIU ) {
             piiu->start ( guard );
         }

--- a/modules/ca/src/client/iocinf.cpp
+++ b/modules/ca/src/client/iocinf.cpp
@@ -37,6 +37,7 @@
 #include "osiWireFormat.h"
 
 #include "addrList.h"
+#include "caStatefulAddr.h"
 #include "iocinf.h"
 
 /*
@@ -160,23 +161,12 @@ static void  forcePort ( ELLLIST *pList, unsigned short port )
 }
 
 
-/*
- * configureChannelAccessAddressList ()
- */
-extern "C" void epicsStdCall configureChannelAccessAddressList
+void caConfigureChannelAccessAutoAddressList
         ( ELLLIST *pList, SOCKET sock, unsigned short port )
 {
-    ELLLIST         tmpList;
     char            *pstr;
     char            yesno[32u];
     int             yes;
-
-    /*
-     * don't load the list twice
-     */
-    assert ( ellCount (pList) == 0 );
-
-    ellInit ( &tmpList );
 
     /*
      * Check to see if the user has disabled
@@ -203,8 +193,8 @@ extern "C" void epicsStdCall configureChannelAccessAddressList
         addr.ia.sin_family = AF_UNSPEC;
         osiSockDiscoverBroadcastAddresses ( &bcastList, sock, &addr );
         forcePort ( &bcastList, port );
-        removeDuplicateAddresses ( &tmpList, &bcastList, 1 );
-        if ( ellCount ( &tmpList ) == 0 ) {
+        removeDuplicateAddresses ( pList, &bcastList, 1 );
+        if ( ellCount ( pList ) == 0 ) {
             osiSockAddrNode *pNewNode;
             pNewNode = (osiSockAddrNode *) calloc ( 1, sizeof (*pNewNode) );
             if ( pNewNode ) {
@@ -215,13 +205,31 @@ extern "C" void epicsStdCall configureChannelAccessAddressList
                 pNewNode->addr.ia.sin_family = AF_INET;
                 pNewNode->addr.ia.sin_addr.s_addr = htonl ( INADDR_LOOPBACK );
                 pNewNode->addr.ia.sin_port = htons ( port );
-                ellAdd ( &tmpList, &pNewNode->node );
+                ellAdd ( pList, &pNewNode->node );
             }
             else {
                 errlogPrintf ( "configureChannelAccessAddressList(): no memory available for configuration\n" );
             }
         }
     }
+}
+
+
+/*
+ * configureChannelAccessAddressList ()
+ */
+extern "C" void epicsStdCall configureChannelAccessAddressList
+        ( ELLLIST *pList, SOCKET sock, unsigned short port )
+{
+    ELLLIST         tmpList;
+
+    /*
+     * don't load the list twice
+     */
+    assert ( ellCount (pList) == 0 );
+
+    ellInit ( &tmpList );
+    caConfigureChannelAccessAutoAddressList ( &tmpList, sock, port );
     addAddrToChannelAccessAddressList ( &tmpList, &EPICS_CA_ADDR_LIST, port, false );
 
     removeDuplicateAddresses ( pList, &tmpList, 0 );

--- a/modules/ca/src/client/tcpiiu.cpp
+++ b/modules/ca/src/client/tcpiiu.cpp
@@ -2145,6 +2145,18 @@ SearchDestTCP :: SearchDestTCP (
     _ptcpiiu ( NULL ),
     _cac ( cacIn ),
     _addr ( addrIn ),
+    _stateful ( false ),
+    _active ( false )
+{
+}
+
+SearchDestTCP :: SearchDestTCP (
+    cac & cacIn, const caStatefulAddr & addrIn ) :
+    _statefulAddr ( addrIn ),
+    _ptcpiiu ( NULL ),
+    _cac ( cacIn ),
+    _addr ( addrIn.resolved () ? addrIn.addr () : osiSockAddr () ),
+    _stateful ( true ),
     _active ( false )
 {
 }
@@ -2164,6 +2176,22 @@ void SearchDestTCP :: searchRequest (
     epicsGuard < epicsMutex > & guard,
         const char * pBuf, size_t len  )
 {
+    if ( _stateful ) {
+        bool changed = _statefulAddr.refreshIfDue ();
+
+        if ( changed && _ptcpiiu ) {
+            _ptcpiiu->initiateAbortShutdown ( guard );
+            _ptcpiiu = NULL;
+            _active = false;
+        }
+        if ( ! _statefulAddr.resolved () ) {
+            return;
+        }
+        if ( changed || _addr.sa.sa_family == AF_UNSPEC ) {
+            _addr = _statefulAddr.addr ();
+        }
+    }
+
     // restart circuit if it was shut down
     if ( ! _ptcpiiu ) {
         tcpiiu * piiu = NULL;

--- a/modules/ca/src/client/test/caStatefulAddrTest.cpp
+++ b/modules/ca/src/client/test/caStatefulAddrTest.cpp
@@ -1,0 +1,116 @@
+/*************************************************************************\
+* Copyright (c) 2026 UChicago Argonne LLC, as Operator of Argonne
+*     National Laboratory.
+* SPDX-License-Identifier: EPICS
+\*************************************************************************/
+
+#include <string.h>
+#include <time.h>
+#include <vector>
+
+#include <testMain.h>
+#include <epicsUnitTest.h>
+
+#include "osiSock.h"
+#include "caStatefulAddr.h"
+
+static int resolverPhase;
+static int badNowResolves;
+
+static void setAddr(osiSockAddr *addr, unsigned a, unsigned b,
+    unsigned c, unsigned d, unsigned short port)
+{
+    memset(addr, 0, sizeof(*addr));
+    addr->ia.sin_family = AF_INET;
+    addr->ia.sin_port = htons(port);
+    addr->ia.sin_addr.s_addr =
+        htonl((a << 24) | (b << 16) | (c << 8) | d);
+}
+
+static int fakeResolver(const char *token, unsigned short defaultPort,
+    int ignoreNonDefaultPort, caStatefulAddr::ResolveResult *result)
+{
+    unsigned short port = defaultPort;
+
+    memset(result, 0, sizeof(*result));
+    result->ttl = 10u;
+    if(strcmp(token, "dyn:6000")==0)
+        port = 6000u;
+    if(ignoreNonDefaultPort && port != defaultPort)
+        return 1;
+    if(strcmp(token, "bad")==0 && !badNowResolves)
+        return -1;
+    if(strcmp(token, "dyn")==0 || strcmp(token, "dyn:6000")==0) {
+        setAddr(&result->addr, 10, 0, 0, resolverPhase ? 2u : 1u, port);
+        return 0;
+    }
+    if(strcmp(token, "bad")==0) {
+        setAddr(&result->addr, 10, 0, 0, 3, port);
+        return 0;
+    }
+    return -1;
+}
+
+MAIN(caStatefulAddrTest)
+{
+    testPlan(16);
+
+    caStatefulAddr::setResolverForTest(NULL);
+    {
+        caStatefulAddr addr("127.0.0.1", 5064u, 0);
+
+        testOk(addr.resolved(), "numeric address resolves immediately");
+        testOk(addr.isStatic(), "numeric address is static");
+        testOk(ntohs(addr.addr().ia.sin_port)==5064u,
+            "numeric address uses default port");
+    }
+    {
+        caStatefulAddr addr("127.0.0.1:6000", 5064u, 1);
+
+        testOk(addr.ignored(), "non-default numeric port is ignored when requested");
+    }
+
+    caStatefulAddr::setResolverForTest(fakeResolver);
+    resolverPhase = 0;
+    badNowResolves = 0;
+    {
+        time_t start = time(NULL);
+        caStatefulAddr addr("dyn", 5064u, 0);
+
+        if(start == (time_t)-1)
+            start = 0;
+        testOk(addr.resolved(), "hostname resolves initially");
+        testOk(!addr.isStatic(), "hostname is refreshable");
+        testOk(ntohl(addr.addr().ia.sin_addr.s_addr)==0x0a000001u,
+            "hostname uses initial resolved address");
+        resolverPhase = 1;
+        testOk(!addr.refresh(start + 5), "hostname does not refresh before TTL");
+        testOk(ntohl(addr.addr().ia.sin_addr.s_addr)==0x0a000001u,
+            "hostname keeps cached address before TTL");
+        testOk(addr.refresh(start + 20), "hostname refreshes after TTL");
+        testOk(ntohl(addr.addr().ia.sin_addr.s_addr)==0x0a000002u,
+            "hostname uses refreshed address after TTL");
+    }
+    {
+        time_t start = time(NULL);
+        caStatefulAddr addr("bad", 5064u, 0);
+
+        if(start == (time_t)-1)
+            start = 0;
+        testOk(!addr.resolved(), "unresolved hostname fails closed");
+        badNowResolves = 1;
+        testOk(addr.refresh(start + 120), "unresolved hostname retries later");
+        testOk(addr.resolved(), "retried hostname can become resolved");
+    }
+    {
+        std::vector<osiSockAddr> seen;
+        osiSockAddr addr;
+
+        setAddr(&addr, 10, 0, 0, 4, 5064u);
+        testOk(!caSockAddrSeen(seen, addr), "first address is not duplicate");
+        testOk(caSockAddrSeen(seen, addr), "second address is duplicate");
+    }
+
+    caStatefulAddr::setResolverForTest(NULL);
+    return testDone();
+}

--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -23,6 +23,8 @@
 #   pragma warning(disable:4355)
 #endif
 
+#include <vector>
+
 #define epicsAssertAuthor "Jeff Hill johill@lanl.gov"
 
 #include "envDefs.h"
@@ -282,14 +284,30 @@ udpiiu::udpiiu (
      * broadcast address list
      */
     ELLLIST dest;
+    std::vector < osiSockAddr > seen;
+    std::vector < caStatefulAddr > statefulDest;
+    std::vector < caStatefulAddr > :: const_iterator statefulIter;
     ellInit ( & dest );
-    configureChannelAccessAddressList ( & dest, this->sock, this->serverPort );
+    caConfigureChannelAccessAutoAddressList ( & dest, this->sock, this->serverPort );
     while ( osiSockAddrNode *
         pNode = reinterpret_cast < osiSockAddrNode * > ( ellGet ( & dest ) ) ) {
         SearchDestUDP & searchDest = *
             new SearchDestUDP ( pNode->addr, *this );
         _searchDestList.add ( searchDest );
+        caSockAddrSeen ( seen, pNode->addr );
         free ( pNode );
+    }
+    caParseStatefulAddrList ( statefulDest, & EPICS_CA_ADDR_LIST,
+        this->serverPort, false );
+    for ( statefulIter = statefulDest.begin ();
+          statefulIter != statefulDest.end (); ++statefulIter ) {
+        if ( statefulIter->resolved () &&
+             caSockAddrSeen ( seen, statefulIter->addr () ) ) {
+            continue;
+        }
+        SearchDestUDP & searchDest = *
+            new SearchDestUDP ( *statefulIter, *this );
+        _searchDestList.add ( searchDest );
     }
 
     /* add list of tcp name service addresses */
@@ -958,7 +976,17 @@ bool udpiiu::pushDatagramMsg ( epicsGuard < epicsMutex > & guard,
 
 udpiiu :: SearchDestUDP :: SearchDestUDP (
     const osiSockAddr & destAddr, udpiiu & udpiiuIn ) :
-    _lastError (0u), _destAddr ( destAddr ), _udpiiu ( udpiiuIn )
+    _lastError (0u), _stateful ( false ),
+    _destAddr ( destAddr ), _udpiiu ( udpiiuIn )
+{
+}
+
+udpiiu :: SearchDestUDP :: SearchDestUDP (
+    const caStatefulAddr & destAddr, udpiiu & udpiiuIn ) :
+    _statefulAddr ( destAddr ),
+    _lastError (0u), _stateful ( true ),
+    _destAddr ( destAddr.resolved () ? destAddr.addr () : osiSockAddr () ),
+    _udpiiu ( udpiiuIn )
 {
 }
 
@@ -966,6 +994,13 @@ void udpiiu :: SearchDestUDP :: searchRequest (
             epicsGuard < epicsMutex > & guard, const char * pBuf, size_t bufSize )
 {
     guard.assertIdenticalMutex ( _udpiiu.cacMutex );
+    if ( _stateful ) {
+        _statefulAddr.refreshIfDue ();
+        if ( ! _statefulAddr.resolved () ) {
+            return;
+        }
+        _destAddr = _statefulAddr.addr ();
+    }
     assert ( bufSize <= INT_MAX );
     int bufSizeAsInt = static_cast < int > ( bufSize );
     while ( true ) {
@@ -1453,4 +1488,3 @@ ca_uint32_t udpiiu::datagramSeqNumber (
 {
     return this->sequenceNumber;
 }
-

--- a/modules/ca/src/client/udpiiu.h
+++ b/modules/ca/src/client/udpiiu.h
@@ -39,6 +39,7 @@
 #include "disconnectGovernorTimer.h"
 #include "repeaterSubscribeTimer.h"
 #include "SearchDest.h"
+#include "caStatefulAddr.h"
 
 namespace ca {
 #if __cplusplus>=201103L
@@ -121,12 +122,15 @@ private:
         public SearchDest {
     public:
         SearchDestUDP ( const osiSockAddr &, udpiiu & );
+        SearchDestUDP ( const caStatefulAddr &, udpiiu & );
         void searchRequest (
             epicsGuard < epicsMutex > &, const char * pBuf, size_t bufLen );
         void show (
             epicsGuard < epicsMutex > &, unsigned level ) const;
     private:
+        caStatefulAddr _statefulAddr;
         int _lastError;
+        bool _stateful;
         osiSockAddr _destAddr;
         udpiiu & _udpiiu;
     };

--- a/modules/ca/src/client/virtualCircuit.h
+++ b/modules/ca/src/client/virtualCircuit.h
@@ -37,6 +37,7 @@
 #include "tcpSendWatchdog.h"
 #include "hostNameCache.h"
 #include "SearchDest.h"
+#include "caStatefulAddr.h"
 #include "compilerDependencies.h"
 
 class callbackManager;
@@ -96,6 +97,7 @@ private:
 class SearchDestTCP : public SearchDest {
 public:
     SearchDestTCP ( cac &, const osiSockAddr & );
+    SearchDestTCP ( cac &, const caStatefulAddr & );
     void searchRequest ( epicsGuard < epicsMutex > & guard,
          const char * pbuf, size_t len );
     void show ( epicsGuard < epicsMutex > & guard, unsigned level ) const;
@@ -103,9 +105,11 @@ public:
     void disable ();
     void enable ();
 private:
+    caStatefulAddr _statefulAddr;
     tcpiiu * _ptcpiiu;
     cac & _cac;
-    const osiSockAddr _addr;
+    osiSockAddr _addr;
+    bool _stateful;
     bool _active;
 };
 

--- a/modules/libcom/src/Makefile
+++ b/modules/libcom/src/Makefile
@@ -61,6 +61,10 @@ API_HEADER += dbCoreAPI.h
 LIBRARY=Com
 
 Com_SYS_LIBS_WIN32 = ws2_32 advapi32 user32 dbghelp
+Com_SYS_LIBS_Darwin += resolv
+Com_SYS_LIBS_Linux += resolv
+Com_SYS_LIBS_freebsd += resolv
+Com_SYS_LIBS_solaris += resolv
 
 Com_RCS = Com.rc
 

--- a/modules/libcom/src/as/asLib.h
+++ b/modules/libcom/src/as/asLib.h
@@ -176,10 +176,16 @@ typedef struct uag{
 /*Defs for Host Access Groups*/
 typedef struct{
     ELLNODE         node;
+    /* Private cache state used from asLibRoutines.c; Codacy checks this header alone. */
+    /* cppcheck-suppress unusedStructMember */
     char            *host;      /* Current host name or resolved IP string */
+    /* cppcheck-suppress unusedStructMember */
     char            *source;    /* Original HAG host name for refresh, or NULL */
+    /* cppcheck-suppress unusedStructMember */
     time_t          expires;    /* DNS cache expiry for source */
+    /* cppcheck-suppress unusedStructMember */
     unsigned char   resolved;
+    /* cppcheck-suppress unusedStructMember */
     unsigned char   hashAdded;
 } HAGNAME;
 typedef struct hag{

--- a/modules/libcom/src/as/asLib.h
+++ b/modules/libcom/src/as/asLib.h
@@ -38,6 +38,7 @@ typedef enum{
     asClientCOAR        /*Change of access rights*/
     /*For now this is all*/
 } asClientStatus;
+typedef enum{asNOACCESS,asREAD,asWRITE} asAccessRights;
 
 typedef void (*ASCLIENTCALLBACK) (ASCLIENTPVT,asClientStatus);
 
@@ -46,9 +47,9 @@ long asCheckGet(ASCLIENTPVT asClientPvt);
 long asCheckPut(ASCLIENTPVT asClientPvt);
 */
 #define asCheckGet(asClientPvt) \
-    (!asActive || ((asClientPvt)->access >= asREAD))
+    asCheckClientAccess((asClientPvt), asREAD)
 #define asCheckPut(asClientPvt) \
-    (!asActive || ((asClientPvt)->access >= asWRITE))
+    asCheckClientAccess((asClientPvt), asWRITE)
 
 /* More convenience macros
 void *asTrapWriteWithData(ASCLIENTPVT asClientPvt,
@@ -105,6 +106,8 @@ LIBCOM_API long epicsStdCall asComputeAllAsg(void);
 LIBCOM_API long epicsStdCall asComputeAsg(ASG *pasg);
 */
 LIBCOM_API long epicsStdCall asCompute(ASCLIENTPVT asClientPvt);
+LIBCOM_API long epicsStdCall asCheckClientAccess(
+    ASCLIENTPVT asClientPvt, asAccessRights access);
 LIBCOM_API int epicsStdCall asDump(
     void (*memcallback)(ASMEMBERPVT,FILE *),
     void (*clientcallback)(ASCLIENTPVT,FILE *),int verbose);
@@ -148,9 +151,6 @@ LIBCOM_API void epicsStdCall asTrapWriteAfterWrite(void *pvt);
 /*Private declarations */
 LIBCOM_API extern int asActive;
 
-/* definition of access rights*/
-typedef enum{asNOACCESS,asREAD,asWRITE} asAccessRights;
-
 struct gphPvt;
 
 /*Base pointers for access security*/
@@ -159,6 +159,7 @@ typedef struct asBase{
     ELLLIST         hagList;
     ELLLIST         asgList;
     struct gphPvt   *phash;
+    time_t          hagExpires; /* Earliest refreshable HAG DNS expiry, or 0 */
 } ASBASE;
 
 LIBCOM_API extern volatile ASBASE *pasbase;

--- a/modules/libcom/src/as/asLib.h
+++ b/modules/libcom/src/as/asLib.h
@@ -13,6 +13,8 @@
 #ifndef INCasLibh
 #define INCasLibh
 
+#include <time.h>
+
 #include "libComAPI.h"
 #include "ellLib.h"
 #include "errMdef.h"
@@ -25,7 +27,7 @@ extern "C" {
 struct dbChannel;
 
 /* 0 - Use (unverified) client provided host name string.
- * 1 - Use actual client IP address.  HAG() are resolved to IPs at ACF load time.
+ * 1 - Use actual client IP address.  HAG() host names are resolved to IPs.
  */
 LIBCOM_API extern int asCheckClientIP;
 
@@ -174,7 +176,11 @@ typedef struct uag{
 /*Defs for Host Access Groups*/
 typedef struct{
     ELLNODE         node;
-    char            host[1];
+    char            *host;      /* Current host name or resolved IP string */
+    char            *source;    /* Original HAG host name for refresh, or NULL */
+    time_t          expires;    /* DNS cache expiry for source */
+    unsigned char   resolved;
+    unsigned char   hashAdded;
 } HAGNAME;
 typedef struct hag{
     ELLNODE         node;

--- a/modules/libcom/src/as/asLib.h
+++ b/modules/libcom/src/as/asLib.h
@@ -159,6 +159,8 @@ typedef struct asBase{
     ELLLIST         hagList;
     ELLLIST         asgList;
     struct gphPvt   *phash;
+    /* Private cache state used from asLibRoutines.c; Codacy checks this header alone. */
+    /* cppcheck-suppress unusedStructMember */
     time_t          hagExpires; /* Earliest refreshable HAG DNS expiry, or 0 */
 } ASBASE;
 

--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -51,6 +51,8 @@ static ASBASE *pasbasenew=NULL;
 int   asActive = FALSE;
 
 static void         *freeListPvt = NULL;
+static unsigned     asHagRefreshActive = 0;
+static unsigned     asComputeActive = 0;
 
 
 #define DEFAULT "DEFAULT"
@@ -66,12 +68,14 @@ static long asAddMemberPvt(ASMEMBERPVT *pasMemberPvt,const char *asgName);
 static long asComputeAllAsgPvt(void);
 static long asComputeAsgPvt(ASG *pasg);
 static long asComputePvt(ASCLIENTPVT asClientPvt);
+static long asComputePvtNoRefresh(ASCLIENTPVT asClientPvt);
 static UAG *asUagAdd(const char *uagName);
 static long asUagAddUser(UAG *puag,const char *user);
 static HAG *asHagAdd(const char *hagName);
 static long asHagAddHost(HAG *phag,const char *host);
 static void asHagAddHashEntries(ASBASE *pasbase);
-static void asHagRefreshExpired(ASBASE *pasbase);
+static int asHagRefreshExpired(ASBASE *pasbase);
+static int asHagRefreshAndComputeAll(ASBASE *pasbase);
 static ASG *asAsgAdd(const char *asgName);
 static long asAsgAddInp(ASG *pasg,const char *inp,int inpIndex);
 static ASGRULE *asAsgAddRule(ASG *pasg,asAccessRights access,int level);
@@ -302,19 +306,50 @@ static void asHagAddHashEntries(ASBASE *pasbase)
     }
 }
 
-static void asHagRefreshExpired(ASBASE *pasbase)
+static void asHagScheduleNextExpiry(ASBASE *pasbase)
+{
+    HAG *phag;
+    time_t next = 0;
+    int found = 0;
+
+    if(!pasbase) return;
+    phag = (HAG *)ellFirst(&pasbase->hagList);
+    while(phag) {
+        HAGNAME *phagname = (HAGNAME *)ellFirst(&phag->list);
+
+        while(phagname) {
+            if(phagname->source) {
+                time_t expires = phagname->expires;
+
+                if(expires <= 0)
+                    expires = 1;
+                if(!found || difftime(expires, next) < 0.0) {
+                    next = expires;
+                    found = 1;
+                }
+            }
+            phagname = (HAGNAME *)ellNext(&phagname->node);
+        }
+        phag = (HAG *)ellNext(&phag->node);
+    }
+    pasbase->hagExpires = found ? next : 0;
+}
+
+static int asHagRefreshExpired(ASBASE *pasbase)
 {
     HAG *phag;
     HAGNAME *phagname;
     time_t now;
     int expired = 0;
 
-    if(!asCheckClientIP || !pasbase)
-        return;
+    if(!asCheckClientIP || !pasbase || !pasbase->hagExpires)
+        return 0;
 
     now = time(NULL);
     if(now == (time_t)-1)
-        return;
+        return 0;
+    if(difftime(now, pasbase->hagExpires) < 0.0)
+        return 0;
 
     phag = (HAG *)ellFirst(&pasbase->hagList);
     while(phag && !expired) {
@@ -328,8 +363,10 @@ static void asHagRefreshExpired(ASBASE *pasbase)
         }
         phag = (HAG *)ellNext(&phag->node);
     }
-    if(!expired)
-        return;
+    if(!expired) {
+        asHagScheduleNextExpiry(pasbase);
+        return 0;
+    }
 
     asHagDeleteHashEntries(pasbase);
     phag = (HAG *)ellFirst(&pasbase->hagList);
@@ -343,6 +380,22 @@ static void asHagRefreshExpired(ASBASE *pasbase)
         phag = (HAG *)ellNext(&phag->node);
     }
     asHagAddHashEntries(pasbase);
+    asHagScheduleNextExpiry(pasbase);
+    return 1;
+}
+
+static int asHagRefreshAndComputeAll(ASBASE *pasbase)
+{
+    int refreshed;
+
+    if(asHagRefreshActive || asComputeActive)
+        return 0;
+    asHagRefreshActive = 1;
+    refreshed = asHagRefreshExpired(pasbase);
+    if(refreshed)
+        asComputeAllAsgPvt();
+    asHagRefreshActive = 0;
+    return refreshed;
 }
 
 long epicsStdCall asInitialize(ASINPUTFUNCPTR inputfunction)
@@ -391,6 +444,7 @@ long epicsStdCall asInitialize(ASINPUTFUNCPTR inputfunction)
         puag = (UAG *)ellNext(&puag->node);
     }
     asHagAddHashEntries(pasbasenew);
+    asHagScheduleNextExpiry(pasbasenew);
     pasbaseold = (ASBASE *)pasbase;
     pasbase = (ASBASE volatile *)pasbasenew;
     if(pasbaseold) {
@@ -718,6 +772,7 @@ long epicsStdCall asComputeAllAsg(void)
 
     if(!asActive) return(S_asLib_asNotActive);
     LOCK;
+    asHagRefreshAndComputeAll((ASBASE *)pasbase);
     status = asComputeAllAsgPvt();
     UNLOCK;
     return(status);
@@ -729,6 +784,7 @@ long epicsStdCall asComputeAsg(ASG *pasg)
 
     if(!asActive) return(S_asLib_asNotActive);
     LOCK;
+    asHagRefreshAndComputeAll((ASBASE *)pasbase);
     status = asComputeAsgPvt(pasg);
     UNLOCK;
     return(status);
@@ -743,6 +799,21 @@ long epicsStdCall asCompute(ASCLIENTPVT asClientPvt)
     status = asComputePvt(asClientPvt);
     UNLOCK;
     return(status);
+}
+
+long epicsStdCall asCheckClientAccess(
+    ASCLIENTPVT asClientPvt, asAccessRights access)
+{
+    ASGCLIENT *pasgclient = asClientPvt;
+    long result;
+
+    if(!asActive) return(TRUE);
+    if(!pasgclient) return(FALSE);
+    LOCK;
+    asHagRefreshAndComputeAll((ASBASE *)pasbase);
+    result = (pasgclient->access >= access);
+    UNLOCK;
+    return(result);
 }
 
 /*The dump routines do not lock. Thus they may get inconsistent data.*/
@@ -1168,7 +1239,7 @@ got_it:
     ellAdd(&pgroup->memberList,&pasgmember->node);
     pasgclient = (ASGCLIENT *)ellFirst(&pasgmember->clientList);
     while(pasgclient) {
-        asComputePvt((ASCLIENTPVT)pasgclient);
+        asComputePvtNoRefresh((ASCLIENTPVT)pasgclient);
         pasgclient = (ASGCLIENT *)ellNext(&pasgclient->node);
     }
     return(0);
@@ -1218,7 +1289,7 @@ next_rule:
     while(pasgmember) {
         pasgclient = (ASGCLIENT *)ellFirst(&pasgmember->clientList);
         while(pasgclient) {
-            asComputePvt((ASCLIENTPVT)pasgclient);
+            asComputePvtNoRefresh((ASCLIENTPVT)pasgclient);
             pasgclient = (ASGCLIENT *)ellNext(&pasgclient->node);
         }
         pasgmember = (ASGMEMBER *)ellNext(&pasgmember->node);
@@ -1227,6 +1298,12 @@ next_rule:
 }
 
 static long asComputePvt(ASCLIENTPVT asClientPvt)
+{
+    asHagRefreshAndComputeAll((ASBASE *)pasbase);
+    return asComputePvtNoRefresh(asClientPvt);
+}
+
+static long asComputePvtNoRefresh(ASCLIENTPVT asClientPvt)
 {
     asAccessRights      access=asNOACCESS;
     int                 trapMask=0;
@@ -1243,7 +1320,7 @@ static long asComputePvt(ASCLIENTPVT asClientPvt)
     if(!pasgMember) return(S_asLib_badMember);
     pasg = pasgMember->pasg;
     if(!pasg) return(S_asLib_badAsg);
-    asHagRefreshExpired((ASBASE *)pasbase);
+    asComputeActive++;
     oldaccess=pasgclient->access;
     pasgrule = (ASGRULE *)ellFirst(&pasg->ruleList);
     while(pasgrule) {
@@ -1296,6 +1373,7 @@ next_rule:
     if(pasgclient->pcallback && oldaccess!=access) {
         (*pasgclient->pcallback)(pasgclient,asClientCOAR);
     }
+    asComputeActive--;
     return(0);
 }
 

--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -29,6 +29,7 @@
 #include "epicsThread.h"
 #include "cantProceed.h"
 #include "epicsMutex.h"
+#include "epicsString.h"
 #include "errlog.h"
 #include "gpHash.h"
 #include "freeList.h"
@@ -53,6 +54,7 @@ static void         *freeListPvt = NULL;
 
 
 #define DEFAULT "DEFAULT"
+#define AS_HAG_HOST_MAX 512u
 #define AS_HAG_DNS_TTL_FALLBACK 300u
 #define AS_HAG_DNS_RETRY 60u
 
@@ -99,10 +101,10 @@ static void asInitializeOnce(void *arg)
 
 static char *asStrdupConst(const char *str)
 {
-    size_t len = strlen(str);
+    size_t len = epicsStrnLen(str, AS_HAG_HOST_MAX);
     char *buf = asCalloc(1, len + 1);
 
-    strcpy(buf, str);
+    memcpy(buf, str, len);
     return buf;
 }
 
@@ -123,16 +125,20 @@ static char *asIPAddrString(const struct sockaddr_in *addr)
 static char *asUnresolvedHostString(const char *host)
 {
     static const char unresolved[] = "unresolved:";
-    char *buf = asCalloc(1, sizeof(unresolved) + strlen(host));
+    size_t prefixLen = sizeof(unresolved) - 1;
+    size_t hostLen = epicsStrnLen(host, AS_HAG_HOST_MAX);
+    char *buf = asCalloc(1, prefixLen + hostLen + 1);
 
-    strcpy(buf, unresolved);
-    strcat(buf, host);
+    memcpy(buf, unresolved, prefixLen);
+    memcpy(buf + prefixLen, host, hostLen);
     return buf;
 }
 
 static int asSetIPAddr(epicsUInt32 rawAddr, struct sockaddr_in *pIP)
 {
-    memset(pIP, 0, sizeof(*pIP));
+    static const struct sockaddr_in emptyAddr;
+
+    *pIP = emptyAddr;
     pIP->sin_family = AF_INET;
     pIP->sin_addr.s_addr = htonl(rawAddr);
     return 0;
@@ -192,10 +198,10 @@ static void asHagSetHost(HAGNAME *phagname, char *host, int resolved)
     phagname->resolved = !!resolved;
 }
 
+#ifdef AS_USE_DNS_TTL
 static int asHagDnsTTL(const char *host, const struct in_addr *addr,
     unsigned *ttl)
 {
-#ifdef AS_USE_DNS_TTL
     unsigned char answer[4096];
     ns_msg handle;
     int len;
@@ -229,9 +235,9 @@ static int asHagDnsTTL(const char *host, const struct in_addr *addr,
         *ttl = best;
         return 0;
     }
-#endif
     return -1;
 }
+#endif
 
 static void asHagResolveHost(HAGNAME *phagname, const char *host, time_t now)
 {
@@ -245,8 +251,10 @@ static void asHagResolveHost(HAGNAME *phagname, const char *host, time_t now)
         return;
     }
 
+#ifdef AS_USE_DNS_TTL
     if(asHagDnsTTL(host, &addr.sin_addr, &ttl))
         ttl = AS_HAG_DNS_TTL_FALLBACK;
+#endif
 
     asHagSetHost(phagname, asIPAddrString(&addr), 1);
     phagname->expires = now + ttl;

--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -136,7 +136,7 @@ static char *asUnresolvedHostString(const char *host)
 
 static int asSetIPAddr(epicsUInt32 rawAddr, struct sockaddr_in *pIP)
 {
-    static const struct sockaddr_in emptyAddr;
+    static const struct sockaddr_in emptyAddr = {0};
 
     *pIP = emptyAddr;
     pIP->sin_family = AF_INET;

--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -14,6 +14,13 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <time.h>
+
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__sun)
+#  include <arpa/nameser.h>
+#  include <resolv.h>
+#  define AS_USE_DNS_TTL 1
+#endif
 
 #include "osiSock.h"
 #include "epicsTypes.h"
@@ -46,6 +53,8 @@ static void         *freeListPvt = NULL;
 
 
 #define DEFAULT "DEFAULT"
+#define AS_HAG_DNS_TTL_FALLBACK 300u
+#define AS_HAG_DNS_RETRY 60u
 
 /* Defined in asLib.y */
 static int myParse(ASINPUTFUNCPTR inputfunction);
@@ -59,6 +68,8 @@ static UAG *asUagAdd(const char *uagName);
 static long asUagAddUser(UAG *puag,const char *user);
 static HAG *asHagAdd(const char *hagName);
 static long asHagAddHost(HAG *phag,const char *host);
+static void asHagAddHashEntries(ASBASE *pasbase);
+static void asHagRefreshExpired(ASBASE *pasbase);
 static ASG *asAsgAdd(const char *asgName);
 static long asAsgAddInp(ASG *pasg,const char *inp,int inpIndex);
 static ASGRULE *asAsgAddRule(ASG *pasg,asAccessRights access,int level);
@@ -85,6 +96,247 @@ static void asInitializeOnce(void *arg)
     osiSockAttach();
     asLock  = epicsMutexMustCreate();
 }
+
+static char *asStrdupConst(const char *str)
+{
+    size_t len = strlen(str);
+    char *buf = asCalloc(1, len + 1);
+
+    strcpy(buf, str);
+    return buf;
+}
+
+static char *asIPAddrString(const struct sockaddr_in *addr)
+{
+    char buf[24];
+    epicsUInt32 ip = ntohl(addr->sin_addr.s_addr);
+
+    epicsSnprintf(buf, sizeof(buf),
+                  "%u.%u.%u.%u",
+                  (ip>>24)&0xff,
+                  (ip>>16)&0xff,
+                  (ip>>8)&0xff,
+                  (ip>>0)&0xff);
+    return asStrdupConst(buf);
+}
+
+static char *asUnresolvedHostString(const char *host)
+{
+    static const char unresolved[] = "unresolved:";
+    char *buf = asCalloc(1, sizeof(unresolved) + strlen(host));
+
+    strcpy(buf, unresolved);
+    strcat(buf, host);
+    return buf;
+}
+
+static int asSetIPAddr(epicsUInt32 rawAddr, struct sockaddr_in *pIP)
+{
+    memset(pIP, 0, sizeof(*pIP));
+    pIP->sin_family = AF_INET;
+    pIP->sin_addr.s_addr = htonl(rawAddr);
+    return 0;
+}
+
+static int asParseNumericIPAddr(const char *host, struct sockaddr_in *pIP)
+{
+    int status;
+    unsigned addr[4];
+    unsigned long rawAddr;
+    unsigned port;
+    char dummy[8];
+
+    status = sscanf(host, " %u . %u . %u . %u %7s ",
+        addr, addr+1u, addr+2u, addr+3u, dummy);
+    if(status == 4) {
+        if(addr[0] <= 0xff && addr[1] <= 0xff &&
+           addr[2] <= 0xff && addr[3] <= 0xff) {
+            return asSetIPAddr(((epicsUInt32)addr[0] << 24) |
+                               ((epicsUInt32)addr[1] << 16) |
+                               ((epicsUInt32)addr[2] << 8) |
+                               (epicsUInt32)addr[3], pIP);
+        }
+        return -1;
+    }
+
+    status = sscanf(host, " %u . %u . %u . %u : %u %7s ",
+        addr, addr+1u, addr+2u, addr+3u, &port, dummy);
+    if(status == 5 && port <= 0xffff) {
+        if(addr[0] <= 0xff && addr[1] <= 0xff &&
+           addr[2] <= 0xff && addr[3] <= 0xff) {
+            return asSetIPAddr(((epicsUInt32)addr[0] << 24) |
+                               ((epicsUInt32)addr[1] << 16) |
+                               ((epicsUInt32)addr[2] << 8) |
+                               (epicsUInt32)addr[3], pIP);
+        }
+        return -1;
+    }
+
+    status = sscanf(host, " %lu %7s ", &rawAddr, dummy);
+    if(status == 1 && rawAddr <= 0xfffffffful) {
+        return asSetIPAddr((epicsUInt32)rawAddr, pIP);
+    }
+
+    status = sscanf(host, " %lu : %u %7s ", &rawAddr, &port, dummy);
+    if(status == 2 && rawAddr <= 0xfffffffful && port <= 0xffff) {
+        return asSetIPAddr((epicsUInt32)rawAddr, pIP);
+    }
+
+    return -1;
+}
+
+static void asHagSetHost(HAGNAME *phagname, char *host, int resolved)
+{
+    free(phagname->host);
+    phagname->host = host;
+    phagname->resolved = !!resolved;
+}
+
+static int asHagDnsTTL(const char *host, const struct in_addr *addr,
+    unsigned *ttl)
+{
+#ifdef AS_USE_DNS_TTL
+    unsigned char answer[4096];
+    ns_msg handle;
+    int len;
+    int count;
+    int i;
+    int found = 0;
+    unsigned best = 0;
+
+    len = res_query(host, ns_c_in, ns_t_a, answer, sizeof(answer));
+    if(len < 0 || len > (int)sizeof(answer) || ns_initparse(answer, len, &handle))
+        return -1;
+
+    count = ns_msg_count(handle, ns_s_an);
+    for(i = 0; i < count; i++) {
+        ns_rr rr;
+
+        if(ns_parserr(&handle, ns_s_an, i, &rr))
+            continue;
+        if(ns_rr_type(rr) != ns_t_a || ns_rr_class(rr) != ns_c_in)
+            continue;
+        if(ns_rr_rdlen(rr) != sizeof(addr->s_addr))
+            continue;
+        if(memcmp(ns_rr_rdata(rr), &addr->s_addr, sizeof(addr->s_addr)) != 0)
+            continue;
+
+        if(!found || ns_rr_ttl(rr) < best)
+            best = ns_rr_ttl(rr);
+        found = 1;
+    }
+    if(found) {
+        *ttl = best;
+        return 0;
+    }
+#endif
+    return -1;
+}
+
+static void asHagResolveHost(HAGNAME *phagname, const char *host, time_t now)
+{
+    struct sockaddr_in addr;
+    unsigned ttl = AS_HAG_DNS_TTL_FALLBACK;
+
+    if(aToIPAddr(host, 0, &addr)) {
+        errlogPrintf("ACF: Unable to resolve host '%s'\n", host);
+        asHagSetHost(phagname, asUnresolvedHostString(host), 0);
+        phagname->expires = now + AS_HAG_DNS_RETRY;
+        return;
+    }
+
+    if(asHagDnsTTL(host, &addr.sin_addr, &ttl))
+        ttl = AS_HAG_DNS_TTL_FALLBACK;
+
+    asHagSetHost(phagname, asIPAddrString(&addr), 1);
+    phagname->expires = now + ttl;
+}
+
+static void asHagDeleteHashEntries(ASBASE *pasbase)
+{
+    HAG *phag = (HAG *)ellFirst(&pasbase->hagList);
+
+    while(phag) {
+        HAGNAME *phagname = (HAGNAME *)ellFirst(&phag->list);
+
+        while(phagname) {
+            if(phagname->hashAdded) {
+                gphDelete(pasbase->phash, phagname->host, phag);
+                phagname->hashAdded = 0;
+            }
+            phagname = (HAGNAME *)ellNext(&phagname->node);
+        }
+        phag = (HAG *)ellNext(&phag->node);
+    }
+}
+
+static void asHagAddHashEntries(ASBASE *pasbase)
+{
+    HAG *phag = (HAG *)ellFirst(&pasbase->hagList);
+
+    while(phag) {
+        HAGNAME *phagname = (HAGNAME *)ellFirst(&phag->list);
+
+        while(phagname) {
+            if(phagname->resolved && phagname->host) {
+                GPHENTRY *pgphentry = gphAdd(pasbase->phash, phagname->host, phag);
+
+                if(pgphentry) {
+                    phagname->hashAdded = 1;
+                } else {
+                    errlogPrintf("Duplicated host '%s' in HAG '%s'\n",
+                        phagname->host, phag->name);
+                }
+            }
+            phagname = (HAGNAME *)ellNext(&phagname->node);
+        }
+        phag = (HAG *)ellNext(&phag->node);
+    }
+}
+
+static void asHagRefreshExpired(ASBASE *pasbase)
+{
+    HAG *phag;
+    HAGNAME *phagname;
+    time_t now;
+    int expired = 0;
+
+    if(!asCheckClientIP || !pasbase)
+        return;
+
+    now = time(NULL);
+    if(now == (time_t)-1)
+        return;
+
+    phag = (HAG *)ellFirst(&pasbase->hagList);
+    while(phag && !expired) {
+        phagname = (HAGNAME *)ellFirst(&phag->list);
+        while(phagname) {
+            if(phagname->source && difftime(now, phagname->expires) >= 0.0) {
+                expired = 1;
+                break;
+            }
+            phagname = (HAGNAME *)ellNext(&phagname->node);
+        }
+        phag = (HAG *)ellNext(&phag->node);
+    }
+    if(!expired)
+        return;
+
+    asHagDeleteHashEntries(pasbase);
+    phag = (HAG *)ellFirst(&pasbase->hagList);
+    while(phag) {
+        phagname = (HAGNAME *)ellFirst(&phag->list);
+        while(phagname) {
+            if(phagname->source && difftime(now, phagname->expires) >= 0.0)
+                asHagResolveHost(phagname, phagname->source, now);
+            phagname = (HAGNAME *)ellNext(&phagname->node);
+        }
+        phag = (HAG *)ellNext(&phag->node);
+    }
+    asHagAddHashEntries(pasbase);
+}
+
 long epicsStdCall asInitialize(ASINPUTFUNCPTR inputfunction)
 {
     ASG         *pasg;
@@ -93,8 +345,6 @@ long epicsStdCall asInitialize(ASINPUTFUNCPTR inputfunction)
     GPHENTRY    *pgphentry;
     UAG         *puag;
     UAGNAME     *puagname;
-    HAG         *phag;
-    HAGNAME     *phagname;
     static epicsThreadOnceId asInitializeOnceFlag = EPICS_THREAD_ONCE_INIT;
 
     epicsThreadOnce(&asInitializeOnceFlag,asInitializeOnce,NULL);
@@ -132,19 +382,7 @@ long epicsStdCall asInitialize(ASINPUTFUNCPTR inputfunction)
         }
         puag = (UAG *)ellNext(&puag->node);
     }
-    phag = (HAG *)ellFirst(&pasbasenew->hagList);
-    while(phag) {
-        phagname = (HAGNAME *)ellFirst(&phag->list);
-        while(phagname) {
-            pgphentry = gphAdd(pasbasenew->phash,phagname->host,phag);
-            if(!pgphentry) {
-                errlogPrintf("Duplicated host '%s' in HAG '%s'\n",
-                    phagname->host, phag->name);
-            }
-            phagname = (HAGNAME *)ellNext(&phagname->node);
-        }
-        phag = (HAG *)ellNext(&phag->node);
-    }
+    asHagAddHashEntries(pasbasenew);
     pasbaseold = (ASBASE *)pasbase;
     pasbase = (ASBASE volatile *)pasbasenew;
     if(pasbaseold) {
@@ -997,6 +1235,7 @@ static long asComputePvt(ASCLIENTPVT asClientPvt)
     if(!pasgMember) return(S_asLib_badMember);
     pasg = pasgMember->pasg;
     if(!pasg) return(S_asLib_badAsg);
+    asHagRefreshExpired((ASBASE *)pasbase);
     oldaccess=pasgclient->access;
     pasgrule = (ASGRULE *)ellFirst(&pasg->ruleList);
     while(pasgrule) {
@@ -1088,6 +1327,8 @@ void asFreeAll(ASBASE *pasbase)
         while(phagname) {
             pnext = ellNext(&phagname->node);
             ellDelete(&phag->list,&phagname->node);
+            free(phagname->host);
+            free(phagname->source);
             free(phagname);
             phagname = pnext;
         }
@@ -1220,35 +1461,27 @@ static long asHagAddHost(HAG *phag,const char *host)
     HAGNAME *phagname;
 
     if (!phag) return 0;
+    phagname = asCalloc(1, sizeof(*phagname));
     if(!asCheckClientIP) {
         size_t i, len = strlen(host);
-        phagname = asCalloc(1, sizeof(*phagname) + len);
+        phagname->host = asCalloc(1, len + 1);
         for (i = 0; i < len; i++) {
             phagname->host[i] = (char)tolower((int)host[i]);
         }
+        phagname->resolved = 1;
 
     } else {
         struct sockaddr_in addr;
-        epicsUInt32 ip;
+        time_t now = time(NULL);
 
-        if(aToIPAddr(host, 0, &addr)) {
-            static const char unresolved[] = "unresolved:";
-
-            errlogPrintf("ACF: Unable to resolve host '%s'\n", host);
-
-            phagname = asCalloc(1, sizeof(*phagname) + sizeof(unresolved)-1+strlen(host));
-            strcpy(phagname->host, unresolved);
-            strcat(phagname->host, host);
-
+        if(now == (time_t)-1)
+            now = 0;
+        if(asParseNumericIPAddr(host, &addr)==0) {
+            phagname->host = asIPAddrString(&addr);
+            phagname->resolved = 1;
         } else {
-            ip = ntohl(addr.sin_addr.s_addr);
-            phagname = asCalloc(1, sizeof(*phagname) + 24);
-            epicsSnprintf(phagname->host, 24,
-                          "%u.%u.%u.%u",
-                          (ip>>24)&0xff,
-                          (ip>>16)&0xff,
-                          (ip>>8)&0xff,
-                          (ip>>0)&0xff);
+            phagname->source = asStrdupConst(host);
+            asHagResolveHost(phagname, host, now);
         }
     }
     ellAdd(&phag->list, &phagname->node);

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -624,6 +624,23 @@ static HAGNAME *firstHagName(void)
     return (HAGNAME *)ellFirst(&phag->list);
 }
 
+static void forceHagExpiry(HAGNAME *phagname)
+{
+    if(!phagname)
+        return;
+    phagname->expires = 0;
+    ((ASBASE *)pasbase)->hagExpires = 1;
+}
+
+static void countAccessCallback(ASCLIENTPVT client, asClientStatus status)
+{
+    unsigned *count = asGetClientPvt(client);
+
+    if(status==asClientCOAR && count)
+        (*count)++;
+    (void)asCheckGet(client);
+}
+
 static void testSyntaxErrors(void)
 {
     static const char empty[] = "\n#almost empty file\n\n";
@@ -732,8 +749,7 @@ static void testUseIPCache(void)
         "unresolved HAG entries are retained for retry");
     setHost("127.0.0.1");
     testAccess("ro", 0);
-    if(phagname)
-        phagname->expires = 0;
+    forceHagExpiry(phagname);
     eltc(0);
     testAccess("ro", 0);
     eltc(1);
@@ -745,12 +761,75 @@ static void testUseIPCache(void)
     if(phagname && phagname->source) {
         free(phagname->source);
         phagname->source = epicsStrDup("127.0.0.2");
-        phagname->expires = 0;
+        forceHagExpiry(phagname);
     }
     setHost("127.0.0.2");
     testAccess("ro", 1);
     setHost("127.0.0.1");
     testAccess("ro", 0);
+}
+
+static void testUseIPCachePersistentClients(void)
+{
+    ASMEMBERPVT asp = 0;
+    ASCLIENTPVT oldClient = 0;
+    ASCLIENTPVT newClient = 0;
+    HAGNAME *phagname;
+    unsigned oldCallbackCount = 0;
+    unsigned newCallbackCount = 0;
+    char oldHost[] = "127.0.0.1";
+    char newHost[] = "127.0.0.2";
+    long ret;
+
+    testDiag("testUseIPCachePersistentClients()");
+    asCheckClientIP = 1;
+    asAsl = 0;
+
+    testOk1(asInitMem(hostname_config, NULL)==0);
+    phagname = firstHagName();
+    testOk(phagname && phagname->source && phagname->resolved,
+        "resolved HAG hostname is refreshable for persistent clients");
+
+    ret = asAddMember(&asp, "ro");
+    testOk(ret==0, "add persistent member -> %s", errSymMsg(ret));
+    ret = asAddClient(&oldClient, asp, asAsl, "testing", oldHost);
+    testOk(ret==0, "add original-address client -> %s", errSymMsg(ret));
+    ret = asAddClient(&newClient, asp, asAsl, "testing", newHost);
+    testOk(ret==0, "add later-address client -> %s", errSymMsg(ret));
+
+    asPutClientPvt(oldClient, &oldCallbackCount);
+    ret = asRegisterClientCallback(oldClient, countAccessCallback);
+    testOk(ret==0 && oldCallbackCount==1,
+        "original-address callback registered and called once -> %s",
+        errSymMsg(ret));
+    asPutClientPvt(newClient, &newCallbackCount);
+    ret = asRegisterClientCallback(newClient, countAccessCallback);
+    testOk(ret==0 && newCallbackCount==1,
+        "later-address callback registered and called once -> %s",
+        errSymMsg(ret));
+
+    testOk(asCheckGet(oldClient) && !asCheckPut(oldClient),
+        "original-address client initially has read-only access");
+    testOk(!asCheckGet(newClient) && !asCheckPut(newClient),
+        "later-address client initially has no access");
+
+    if(phagname && phagname->source) {
+        free(phagname->source);
+        phagname->source = epicsStrDup("127.0.0.2");
+        forceHagExpiry(phagname);
+    }
+
+    (void)asCheckGet(oldClient);
+    testOk(!asCheckGet(oldClient) && !asCheckPut(oldClient),
+        "original-address client loses access after check-driven HAG refresh");
+    testOk(asCheckGet(newClient) && !asCheckPut(newClient),
+        "later-address client gains read-only access after check-driven HAG refresh");
+    testOk(oldCallbackCount==2 && newCallbackCount==2,
+        "callbacks fire once per persistent client access transition");
+
+    if(oldClient) asRemoveClient(&oldClient);
+    if(newClient) asRemoveClient(&newClient);
+    if(asp) asRemoveMember(&asp);
 }
 
 static void testFutureProofParser(void)
@@ -876,12 +955,13 @@ static void testFutureProofParser(void)
 
 MAIN(aslibtest)
 {
-    testPlan(76);
+    testPlan(88);
     testSyntaxErrors();
     testFutureProofParser();
     testHostNames();
     testUseIP();
     testUseIPCache();
+    testUseIPCachePersistentClients();
     errlogFlush();
     return testDone();
 }

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -7,6 +7,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include <testMain.h>
 #include <epicsUnitTest.h>
@@ -44,6 +45,34 @@ static const char hostname_config[] = ""
 
     "ASG(rw) {\n"
     "    RULE(1, WRITE) {\n"
+    "        HAG(foo)\n"
+    "    }\n"
+    "}\n";
+
+static const char numeric_config[] = ""
+    "HAG(foo) {127.0.0.1}\n"
+
+    "ASG(DEFAULT) {\n"
+    "    RULE(0, NONE)\n"
+    "}\n"
+
+    "ASG(ro) {\n"
+    "    RULE(0, NONE)\n"
+    "    RULE(1, READ) {\n"
+    "        HAG(foo)\n"
+    "    }\n"
+    "}\n";
+
+static const char unresolved_config[] = ""
+    "HAG(foo) {guaranteed.invalid.}\n"
+
+    "ASG(DEFAULT) {\n"
+    "    RULE(0, NONE)\n"
+    "}\n"
+
+    "ASG(ro) {\n"
+    "    RULE(0, NONE)\n"
+    "    RULE(1, READ) {\n"
     "        HAG(foo)\n"
     "    }\n"
     "}\n";
@@ -582,6 +611,19 @@ static void testAccess(const char *asg, unsigned mask)
     if(asp) asRemoveMember(&asp);
 }
 
+static HAGNAME *firstHagName(void)
+{
+    ASBASE *base = (ASBASE *)pasbase;
+    HAG *phag;
+
+    if(!base)
+        return NULL;
+    phag = (HAG *)ellFirst(&base->hagList);
+    if(!phag)
+        return NULL;
+    return (HAGNAME *)ellFirst(&phag->list);
+}
+
 static void testSyntaxErrors(void)
 {
     static const char empty[] = "\n#almost empty file\n\n";
@@ -658,6 +700,57 @@ static void testUseIP(void)
     testAccess("DEFAULT", 0);
     testAccess("ro", 0);
     testAccess("rw", 0);
+}
+
+static void testUseIPCache(void)
+{
+    HAGNAME *phagname;
+    long ret;
+
+    testDiag("testUseIPCache()");
+    asCheckClientIP = 1;
+    asAsl = 0;
+    setUser("testing");
+
+    testOk1(asInitMem(numeric_config, NULL)==0);
+    phagname = firstHagName();
+    testOk(phagname && !phagname->source && phagname->resolved,
+        "numeric HAG entries are static");
+    setHost("127.0.0.1");
+    testAccess("ro", 1);
+    setHost("127.0.0.2");
+    testAccess("ro", 0);
+
+    eltc(0);
+    ret = asInitMem(unresolved_config, NULL);
+    eltc(1);
+    testOk(ret==0, "unresolved HAG host does not fail ACF load -> %s",
+        errSymMsg(ret));
+    phagname = firstHagName();
+    testOk(phagname && phagname->source && !phagname->resolved &&
+        phagname->expires > time(NULL),
+        "unresolved HAG entries are retained for retry");
+    setHost("127.0.0.1");
+    testAccess("ro", 0);
+    if(phagname)
+        phagname->expires = 0;
+    eltc(0);
+    testAccess("ro", 0);
+    eltc(1);
+
+    testOk1(asInitMem(hostname_config, NULL)==0);
+    phagname = firstHagName();
+    testOk(phagname && phagname->source && phagname->resolved,
+        "resolved HAG hostnames keep their source for refresh");
+    if(phagname && phagname->source) {
+        free(phagname->source);
+        phagname->source = epicsStrDup("127.0.0.2");
+        phagname->expires = 0;
+    }
+    setHost("127.0.0.2");
+    testAccess("ro", 1);
+    setHost("127.0.0.1");
+    testAccess("ro", 0);
 }
 
 static void testFutureProofParser(void)
@@ -783,11 +876,12 @@ static void testFutureProofParser(void)
 
 MAIN(aslibtest)
 {
-    testPlan(64);
+    testPlan(76);
     testSyntaxErrors();
     testFutureProofParser();
     testHostNames();
     testUseIP();
+    testUseIPCache();
     errlogFlush();
     return testDone();
 }


### PR DESCRIPTION
## Summary

This PR makes EPICS Base treat hostname-based policy and search destinations as runtime state instead of one-time startup resolution.

It covers two areas:

1. **Access Security HAG hostnames** now refresh lazily by DNS TTL/retry.
2. **CA client `EPICS_CA_ADDR_LIST` / `EPICS_CA_NAME_SERVERS` hostnames** now stay current for the life of a CA client context.

The goal is to avoid stale behavior in long-lived clients after DNS changes, without requiring reconnect, reload, or restart.

## Why

Before this branch:

- HAG hostnames were resolved once at ACF load time.
- Existing `ASCLIENTPVT` clients could keep stale cached access rights even after HAG DNS state changed.
- CA client hostname destinations were resolved once during setup and then fixed for the lifetime of the context.

So DNS changes could update external reality while EPICS Base continued using stale policy or stale search routing.

## Changes

### Access Security / HAG

- Refresh HAG hostnames lazily by DNS TTL or retry interval.
- Preserve existing address selection by resolving through `aToIPAddr()`.
- Use DNS A-record TTLs on supported POSIX resolver platforms when the selected IPv4 address is present in the reply.
- Fall back to `300s` after successful lookups without a usable TTL and `60s` for unresolved retry.
- Track the next HAG expiry/retry time so ordinary checks stay cheap when no refresh is due.
- Add `asCheckClientAccess(ASCLIENTPVT, asAccessRights)` and route `asCheckGet()` / `asCheckPut()` through it as source-compatible macros.
- Treat HAG DNS expiry as an access-security state transition: refresh HAG state, recompute active clients, and fire existing `asClientCOAR` callbacks when permissions change.
- Split recomputation paths and guard against recursive refresh while recomputing clients or running callbacks.
- Preserve current behavior for `asCheckClientIP=0`, numeric HAG entries, no-source HAG entries, and existing IPv4-only HAG matching.

### CA client search / name-server destinations

- Add a private stateful resolver/cache helper for CA hostname destinations.
- Keep source token, resolved address, resolved/unresolved state, and expiry/retry time instead of discarding the hostname after setup.
- Refresh `EPICS_CA_ADDR_LIST` hostname entries before UDP search sends.
- Refresh `EPICS_CA_NAME_SERVERS` hostname entries before TCP name-server use.
- Disconnect and reconnect a CA name-server circuit if the hostname resolves to a different address.
- Keep unresolved hostname entries present but fail closed until retry succeeds.
- Leave numeric and auto-discovered broadcast destinations static.
- Preserve initial duplicate suppression for resolved destinations.

### Static analysis follow-up

- Use bounded local string handling for environment/token parsing.
- Replace analyzer-flagged zero-initialization patterns with analyzer-friendly initialization.
- Compile DNS TTL parsing only on supported platforms.

## PVXS Follow-up

This PR is scoped to EPICS Base.

PVXS already benefits from the HAG-side access propagation through the existing AS client/check path. A similar follow-up PR will address **stateful PVXS client `addressList` / `nameServers` DNS behavior**.

## Testing

- `make -C epics-base/modules/libcom test`
- `make -C epics-base/modules/libcom/test runtests TESTS=aslibtest`
- `epicsSockResolveTest`
- `make -C epics-base/modules/ca/src/client`
- `make -C epics-base/modules/ca/src/client runtests TESTSCRIPTS_HOST=caStatefulAddrTest.t`
- `git -C epics-base diff --check`
