### PR TITLE
Slow search_reply_udp in RTEMS IOCs (#836)

### DIFF
--- a/modules/libcom/src/osi/os/RTEMS-posix/osdPoolStatus.c
+++ b/modules/libcom/src/osi/os/RTEMS-posix/osdPoolStatus.c
@@ -33,11 +33,7 @@ LIBCOM_API int epicsStdCall osiSufficentSpaceInPool ( size_t contiguousBlockSize
  */
 LIBCOM_API int epicsStdCall osiSufficentSpaceInPool ( size_t contiguousBlockSize )
 {
-    unsigned long n;
-    Heap_Information_block info;
-
-    malloc_info( &info );
-    n = info.Stats.size - (unsigned long)(info.Stats.lifetime_allocated - info.Stats.lifetime_freed);
+    size_t n = malloc_free_space();
     return (n > (50000 + contiguousBlockSize));
 }
 #endif


### PR DESCRIPTION
malloc_info( &info )  takes a long time to get the memory statistics. This is called each time before establishing CA link, which slows down the clients when they try to connect many PVs.
Use malloc_free_space() instead of malloc_info( &info ) in osiSufficentSpaceInPool