### PR TITLE
epicsStrPrintEscaped() operate on unterminated string

### DIFF
--- a/modules/libcom/src/misc/epicsString.c
+++ b/modules/libcom/src/misc/epicsString.c
@@ -234,7 +234,7 @@ int epicsStrPrintEscaped(FILE *fp, const char *s, size_t len)
    if (fp == NULL)
        return -1;
 
-   if (s == NULL || strlen(s) == 0 || len == 0)
+   if (s == NULL || len == 0)
        return 0; // No work to do
 
    while (len--) {

--- a/modules/libcom/src/misc/epicsString.h
+++ b/modules/libcom/src/misc/epicsString.h
@@ -119,6 +119,9 @@ LIBCOM_API char * epicsStrnDup(const char *s, size_t len);
  * \param fp  File descriptor to print to
  * \param s   String to print
  * \param n   Length of string
+ * \return Number of characters printed, or negative on error.
+ *
+ * \since 7.0.8 until UNRELEASED, @code strlen(s) @endcode must be valid.
  */
 LIBCOM_API int epicsStrPrintEscaped(FILE *fp, const char *s, size_t n);
 

--- a/modules/libcom/test/epicsStringTest.c
+++ b/modules/libcom/test/epicsStringTest.c
@@ -220,6 +220,7 @@ void testEpicsStrPrintEscaped(void)
 
     // Passing cases
     testOk1(epicsStrPrintEscaped(testFile, "1234", 4) == 4);
+    testOk1(epicsStrPrintEscaped(testFile, "1234extra", 4) == 4);
     testOk1(epicsStrPrintEscaped(testFile, "\a\b\f\n\r\t\v\\\'\"", 10) == 20);
 
     // Failing cases
@@ -236,7 +237,6 @@ void testEpicsStrPrintEscaped(void)
         testSkip(1, "fprintf is broken on this system");
     }
     testOk1(epicsStrPrintEscaped(testFile, NULL, 4) == 0);
-    testOk1(epicsStrPrintEscaped(testFile, "", 4) == 0);
     testOk1(epicsStrPrintEscaped(testFile, "1234", 0) == 0);
 
     fclose(testFile);


### PR DESCRIPTION
Until 3a2d225682d79f79c84852dbcb98d54cb250d62f (#310) `epicsStrPrintEscaped()` would operate on an unterminated string.  The added call to `strlen(s)` requires that the input string be null terminated, although `len <= strlen(s)` would work.  
f488765631998c9d0b27a14c13aa412ec81a5fe9 explicitly tests this case.

So far this bug is theoretical in epics-base as all usage pass `len==strlen(s)`.

Which raises a question.  Is this bug worth fixing with this PR?  Or do we instead document that the input string must be null terminated?