### PR TITLE
asDump* quote UAG and HAG entries

### DIFF
--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -20,6 +20,7 @@
 #include "epicsStdio.h"
 #include "dbDefs.h"
 #include "epicsThread.h"
+#include "epicsString.h"
 #include "cantProceed.h"
 #include "epicsMutex.h"
 #include "errlog.h"
@@ -656,6 +657,14 @@ next_rule:
     }
     return(0);
 }
+
+static
+void asDumpQuoted(FILE *fp, const char *s)
+{
+    fprintf(fp, "\"");
+    (void)epicsStrPrintEscaped(fp, s, strlen(s));
+    fprintf(fp, "\"");
+}
 
 int epicsStdCall asDumpUag(const char *uagname)
 {
@@ -679,7 +688,7 @@ int epicsStdCall asDumpUagFP(FILE *fp,const char *uagname)
         puagname = (UAGNAME *)ellFirst(&puag->list);
         if(puagname) fprintf(fp," {"); else fprintf(fp,"\n");
         while(puagname) {
-            fprintf(fp,"%s",puagname->user);
+            asDumpQuoted(fp, puagname->user);
             puagname = (UAGNAME *)ellNext(&puagname->node);
             if(puagname) fprintf(fp,","); else fprintf(fp,"}\n");
         }
@@ -710,7 +719,7 @@ int epicsStdCall asDumpHagFP(FILE *fp,const char *hagname)
         phagname = (HAGNAME *)ellFirst(&phag->list);
         if(phagname) fprintf(fp," {"); else fprintf(fp,"\n");
         while(phagname) {
-            fprintf(fp,"%s",phagname->host);
+            asDumpQuoted(fp, phagname->host);
             phagname = (HAGNAME *)ellNext(&phagname->node);
             if(phagname) fprintf(fp,","); else fprintf(fp,"}\n");
         }


### PR DESCRIPTION
UAG entries at least may contain characters outside the set `a-zA-Z0-9_\-+:.\[\]<>;` (https://github.com/slac-epics/pvxs-cms/issues/8#issuecomment-4435999344), and since at least 9f01c475421ccfcad25607773e2d9b72a002bce3 can contain escape sequences.  I think that quoted string were always accepted, so unconditionally escape in `asDump*` functions.