### PR TITLE
Add a job to build with INSTALL_LOCATION set in CONFIG_SITE

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -237,6 +237,45 @@ jobs:
       if: ${{ always() }}
       run: python .ci/cue.py -T 5M test-results
 
+  install_location:
+    name: "Ub-24 gcc install location"
+    runs-on: ubuntu-24.04
+    env:
+      CMP: gcc
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Automatic core dumper analysis
+        uses: mdavidsaver/ci-core-dumper@master
+      - name: "apt-get install"
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install qemu-system-x86 g++-mingw-w64-x86-64 gdb
+        if: runner.os == 'Linux'
+      - name: Prepare and compile dependencies
+        run: python .ci/cue.py prepare
+      - name: Update CONFIG_SITE.local to set INSTALL_LOCATION
+        run: |
+          cat <<EOF > configure/CONFIG_SITE.local
+          INSTALL_LOCATION=/tmp/epics
+          EOF
+      - name: Build main module
+        run: python .ci/cue.py build
+      - name: Run main module tests
+        run: python .ci/cue.py -T 60M test
+      - name: Upload tapfiles Artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: tapfiles ${{ matrix.name }}
+          path: "**/O.*/*.tap"
+          if-no-files-found: ignore
+      - name: Collect and show test results
+        if: ${{ always() }}
+        run: python .ci/cue.py -T 5M test-results
+
   docker:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have noticed that the behaviour of INSTALL_LOCATION depends on where it is set; it works differently if it is set as an environment or command-line variable than if set in CONFIG_SITE(.local), despite this being explicitly what is recommended in that file.

This may not be the best approach. One could also update cue.py. This would be necessary as at the moment cue.py only sets environment/commandline variables, so would have to be modified to allow writing to a file.

I have opted for a very not DRY-friendly approach instead of that for the time being since while _in theory_ updating cue.py is nicer, it's not clear that any other feature other than INSTALL_LOCATION really cares about where it is defined.