### PR TITLE
Fix #859 in template CONFIG file

### DIFF
--- a/configure/RULES_MODULES
+++ b/configure/RULES_MODULES
@@ -25,10 +25,19 @@
 # Add checked-out submodules to DIRS, unless INSTALL_LOCATION is empty
 LIVE_SUBMODULES = $(subst /Makefile,, \
     $(wildcard $(addsuffix /Makefile, $(SUBMODULES))))
-live = $(if $(wildcard $(INSTALL_CONFIG)/RULES_TOP),LIVE,DEAD)
+live := $(if $(wildcard $(INSTALL_CONFIG)/RULES_TOP),LIVE,DEAD)
 DIRS += $($(live)_SUBMODULES)
 
 include $(CONFIG)/RULES_DIRS
+
+ifeq ($(live),DEAD)
+ifneq ($(filter $(ACTIONS),$(MAKECMDGOALS)),)
+  $(info *** WARNING: The install directory $(INSTALL_LOCATION))
+  $(info ***   is absent or empty. The "make $(MAKECMDGOALS)" rule)
+  $(info ***   cannot recurse into these external modules as a result:)
+  $(info ***     $(LIVE_SUBMODULES))
+endif
+endif
 
 RELEASE_LOCAL := RELEASE.$(EPICS_HOST_ARCH).local
 

--- a/documentation/new-notes/PR-880.md
+++ b/documentation/new-notes/PR-880.md
@@ -1,0 +1,21 @@
+### Template fix for modules with `cfg/RULES*` files
+
+EPICS modules that installed custom build `RULES*` files into
+`$(INSTALL_CFG)` weren't loading them properly when the module
+was built with `INSTALL_LOCATION` set in `configure/CONFIG_SITE`
+or `configure/CONFIG_SITE.local`.
+This release provides a fix in the template `configure/CONFIG`
+file to solve the issue for new modules created from the
+`makeBaseApp` template.
+
+Maintainers of old modules that provide special build rules for
+IOC applications should check their `configure` directory.
+Assuming a `configure/CONFIG` file is present, replace it with
+the `templates/makeBaseApp/top/configure/CONFIG` file from this
+release. If any changes were made to the old file they would
+need to be merged into the new file.
+
+If the module's `configure` directory contains a file named
+`CONFIG_APP` and no `CONFIG_SITE` file, the application must
+date back to before March 2006; the files in the `configure`
+directory should all be replaced in this case.

--- a/src/template/base/top/configure/CONFIG
+++ b/src/template/base/top/configure/CONFIG
@@ -47,3 +47,11 @@ ifdef T_A
  -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
 endif
 
+# Load our cfg/CONFIG* files if installing elsewhere
+ifneq ($(INSTALL_LOCATION),$(TOP))
+  TOP_CFG_CONFIGS := $(wildcard $(INSTALL_CFG)/CONFIG*)
+  ifneq ($(TOP_CFG_CONFIGS),)
+    include $(TOP_CFG_CONFIGS)
+  endif
+endif
+


### PR DESCRIPTION
Fixes #859, build breakage when INSTALL_LOCATION is set.

Instructions on updating existing modules in Notes entries.

Also prints warning messages from the modules/Makefile if $(INSTALL_LOCATION) is empty.