### PR TITLE
Add support for METHOD, AUTHORITY, and PROTOCOL in Access Security

### DIFF
--- a/.github/workflows/check-editorconfig.yml
+++ b/.github/workflows/check-editorconfig.yml
@@ -8,6 +8,6 @@ jobs:
   editorconfig:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: EditorConfig-Action
-        uses: greut/eclint-action@v0
+        uses: greut/eclint-action@b9844795dd0b5fb19e3c60bd731fd3e548524b5c # v0

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -210,11 +210,11 @@ jobs:
             configuration: default
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
     - name: Automatic core dumper analysis
-      uses: mdavidsaver/ci-core-dumper@master
+      uses: mdavidsaver/ci-core-dumper@cda67d63a56db36aca1126d8d00aa5f7ff1ee1db # master
     - name: "apt-get install"
       run: |
         sudo apt-get update
@@ -228,7 +228,7 @@ jobs:
       run: python .ci/cue.py -T 60M test
     - name: Upload tapfiles Artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: tapfiles ${{ matrix.name }}
         path: '**/O.*/*.tap'
@@ -286,11 +286,11 @@ jobs:
         dnf -y install python3 gdb make perl gcc-c++ glibc-devel readline-devel ncurses-devel perl-devel perl-Test-Simple
         git --version || dnf -y install git
         python3 --version
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
     - name: Automatic core dumper analysis
-      uses: mdavidsaver/ci-core-dumper@master
+      uses: mdavidsaver/ci-core-dumper@cda67d63a56db36aca1126d8d00aa5f7ff1ee1db # master
     - name: Prepare and compile dependencies
       run: python3 .ci/cue.py prepare
     - name: Build main module
@@ -299,7 +299,7 @@ jobs:
       run: python3 .ci/cue.py -T 20M test
     - name: Upload tapfiles Artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: tapfiles ${{ matrix.name }}
         path: '**/O.*/*.tap'
@@ -316,7 +316,7 @@ jobs:
       BCFG: default
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: true
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Repositories
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: false
 
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get install --yes libreadline-dev
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/config.yml
@@ -59,6 +59,6 @@ jobs:
           make -sj2 || echo '*** Ignoring build failure for CodeQL ***'
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/modules/libcom/src/as/asLib.h
+++ b/modules/libcom/src/as/asLib.h
@@ -18,6 +18,11 @@
 #include "errMdef.h"
 #include "errlog.h"
 
+/** Identifies added API associated with asAddClientIdentity()
+ * @since UNRELEASED
+ */
+#define EPICS_ASLIB_HAS_IDENTITY
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,6 +34,8 @@ struct dbChannel;
  */
 LIBCOM_API extern int asCheckClientIP;
 
+typedef struct asIdentity *ASIDENTITYPVT;
+typedef struct asIdentity ASIDENTITY;
 typedef struct asgMember *ASMEMBERPVT;
 typedef struct asgClient *ASCLIENTPVT;
 typedef int (*ASINPUTFUNCPTR)(char *buf,int max_size);
@@ -47,6 +54,8 @@ long asCheckPut(ASCLIENTPVT asClientPvt);
     (!asActive || ((asClientPvt)->access >= asREAD))
 #define asCheckPut(asClientPvt) \
     (!asActive || ((asClientPvt)->access >= asWRITE))
+#define asCheckRPC(asClientPvt) \
+    (!asActive || ((asClientPvt)->access >= asRPC))
 
 /* More convenience macros
 void *asTrapWriteWithData(ASCLIENTPVT asClientPvt,
@@ -54,9 +63,16 @@ void *asTrapWriteWithData(ASCLIENTPVT asClientPvt,
      int dbrType, int no_elements, void *data);
 void asTrapWriteAfter(ASCLIENTPVT asClientPvt);
 */
+
+/* Adapter function for backward compatibility */
+LIBCOM_API void * epicsStdCall asTrapWriteWithDataCompat(
+    ASCLIENTPVT asClientPvt,
+    const char *user, const char *host, struct dbChannel *addr,
+    int dbrType, int no_elements, void *data);
+
 #define asTrapWriteWithData(asClientPvt, user, host, addr, type, count, data) \
     ((asActive && (asClientPvt)->trapMask) \
-    ? asTrapWriteBeforeWithData((user), (host), (addr), (type), (count), (data)) \
+    ? asTrapWriteWithDataCompat((asClientPvt), (user), (host), (addr), (type), (count), (data)) \
     : 0)
 #define asTrapWriteAfter(pvt) \
     if (pvt) asTrapWriteAfterWrite(pvt)
@@ -89,9 +105,14 @@ LIBCOM_API void epicsStdCall asPutMemberPvt(
 LIBCOM_API long epicsStdCall asAddClient(
     ASCLIENTPVT *asClientPvt,ASMEMBERPVT asMemberPvt,
     int asl,const char *user,char *host);
+LIBCOM_API long epicsStdCall asAddClientIdentity(
+    ASCLIENTPVT *asClientPvt,ASMEMBERPVT asMemberPvt,
+    int asl, ASIDENTITY identity);
 /*client must provide permanent storage for user and host*/
 LIBCOM_API long epicsStdCall asChangeClient(
     ASCLIENTPVT asClientPvt,int asl,const char *user,char *host);
+LIBCOM_API long epicsStdCall asChangeClientIdentity(
+    ASCLIENTPVT asClientPvt,int asl, ASIDENTITY identity);
 LIBCOM_API long epicsStdCall asRemoveClient(ASCLIENTPVT *asClientPvt);
 LIBCOM_API void * epicsStdCall asGetClientPvt(ASCLIENTPVT asClientPvt);
 LIBCOM_API void epicsStdCall asPutClientPvt(
@@ -125,6 +146,9 @@ LIBCOM_API int epicsStdCall asDumpHashFP(FILE *fp);
 LIBCOM_API void * epicsStdCall asTrapWriteBeforeWithData(
     const char *userid, const char *hostid, struct dbChannel *addr,
     int dbrType, int no_elements, void *data);
+LIBCOM_API void * epicsStdCall asTrapWriteBeforeWithIdentityData(
+    ASIDENTITY identity, struct dbChannel *addr,
+    int dbrType, int no_elements, void *data);
 
 LIBCOM_API void epicsStdCall asTrapWriteAfterWrite(void *pvt);
 
@@ -142,12 +166,14 @@ LIBCOM_API void epicsStdCall asTrapWriteAfterWrite(void *pvt);
 #define S_asLib_badClient       (M_asLib|12) /*access security: bad ASCLIENTPVT*/
 #define S_asLib_badAsg          (M_asLib|13) /*access security: bad ASG*/
 #define S_asLib_noMemory        (M_asLib|14) /*access security: no Memory */
-
+#define S_asLib_dupMethod       (M_asLib|15) /* Duplicate method name in rule */
+#define S_asLib_dupAuthority    (M_asLib|16) /* Duplicate authority name in rule */
+
 /*Private declarations */
 LIBCOM_API extern int asActive;
 
 /* definition of access rights*/
-typedef enum{asNOACCESS,asREAD,asWRITE} asAccessRights;
+typedef enum{asNOACCESS,asREAD,asWRITE,asRPC} asAccessRights;
 
 struct gphPvt;
 
@@ -155,6 +181,7 @@ struct gphPvt;
 typedef struct asBase{
     ELLLIST         uagList;
     ELLLIST         hagList;
+    ELLLIST         authList;
     ELLLIST         asgList;
     struct gphPvt   *phash;
 } ASBASE;
@@ -181,6 +208,13 @@ typedef struct hag{
     char            *name;
     ELLLIST         list;   /*list of HAGNAME*/
 } HAG;
+// Defs for Authority Chains
+typedef struct authchain {
+    ELLNODE         node;
+    char *          name;       /* Authority chain ID */
+    char *          chain;      /* Authority Chain: Common Name or newline-separated Chain of Common Names (root to issuer) */
+    ELLLIST         list;       /* List of named Authority definitions (pointer to this list) */
+} AUTHCHAIN;
 /*Defs for Access SecurityGroups*/
 typedef struct {
     ELLNODE         node;
@@ -190,7 +224,23 @@ typedef struct {
     ELLNODE         node;
     HAG             *phag;
 }ASGHAG;
+typedef struct {
+    ELLNODE         node;
+    struct method   *pmethod;
+} ASGMETHOD;
+typedef struct {
+    ELLNODE         node;
+    struct authority *pauthority;
+} ASGAUTHORITY;
+
 #define AS_TRAP_WRITE 1
+
+enum AsProtocol {
+    AS_PROTOCOL_NOT_SET = -1,
+    AS_PROTOCOL_TCP = 0,
+    AS_PROTOCOL_TLS = 1
+};
+
 typedef struct{
     ELLNODE         node;
     asAccessRights  access;
@@ -203,6 +253,9 @@ typedef struct{
     ELLLIST         hagList; /*List of ASGHAG*/
     int             trapMask;
     int             ignore; // 1 if rule to be ignored because of unknown elements
+    enum AsProtocol protocol; /* -1: ignore, AS_PROTOCOL_TCP: not TLS, AS_PROTOCOL_TLS: TLS */
+    ELLLIST         methodList; /*List of ASGMETHOD*/
+    ELLLIST         authList; /*List of ASGAUTHORITY*/
 } ASGRULE;
 typedef struct{
     ELLNODE         node;
@@ -230,11 +283,18 @@ typedef struct asgMember {
     void            *userPvt;
 } ASGMEMBER;
 
+typedef struct asIdentity {
+    const char *user;
+    char *host;
+    const char *method;
+    const char *authority;
+    enum AsProtocol protocol;
+} ASGIDENTITY;
+
 typedef struct asgClient {
     ELLNODE         node;
     ASGMEMBER       *pasgMember;
-    const char      *user;
-    char            *host;
+    ASIDENTITY      identity;
     void            *userPvt;
     ASCLIENTCALLBACK pcallback;
     int             level;
@@ -242,11 +302,25 @@ typedef struct asgClient {
     int             trapMask;
 } ASGCLIENT;
 
+/* Define METHOD and AUTHORITY structures here for use in ASGRULE */
+typedef struct method{
+    char            *name;
+} METHOD;
+
+typedef struct authority{
+    char            *name;
+} AUTHORITY;
+
 LIBCOM_API long epicsStdCall asComputeAsg(ASG *pasg);
 /*following is "friend" function*/
 LIBCOM_API void * epicsStdCall asCalloc(size_t nobj,size_t size);
 LIBCOM_API char * epicsStdCall asStrdup(unsigned char *str);
 LIBCOM_API void asFreeAll(ASBASE *pasbase);
+
+// The maximum length of the Authority string that can be processed
+// by the EPICS Authorization system.  Set as large as you like to handle the longest string you think will be provided.
+// Holds the concatenated common names of the chain of authority all the way back to the root certificate.
+#define MAX_AUTH_CHAIN_STRING 2048
 #ifdef __cplusplus
 }
 #endif

--- a/modules/libcom/src/as/asLib.y
+++ b/modules/libcom/src/as/asLib.y
@@ -19,30 +19,40 @@ static HAG *yyHag=NULL;
 static ASG *yyAsg=NULL;
 static ASGRULE *yyAsgRule=NULL;
 
-static
-char* yystrdup(const char *inp) {
-    char* ret = strdup(inp);
-    if(!ret)
-        yyerror("MALLOC");
-    return ret;
-}
+static ELLLIST yyCertPath;
+typedef struct {
+    ELLNODE node;
+    char *commonName;
+} CertPathNode_t;
 
+static int saveAuthorityEntry(char *name);
+
+static int pushCertPath(char *commonName);
+static void popCertPath();
+
+static char *getCurrentCertPath();
+
+static void initCertPathStack();
+static void freeCertPathStack();
+
+static int _pushCertPath(const char *commonName);
+static char* yystrdup(const char *inp);
 %}
 
 %start asconfig
 
-%token tokenUAG tokenHAG tokenASG tokenRULE tokenCALC
+%token tokenUAG tokenHAG tokenASG tokenRULE tokenCALC tokenMETHOD tokenAUTHORITY tokenPROTOCOL
 %token <Str> tokenSTRING
 %token <Int64> tokenINT64 tokenINP
 %token <Float64> tokenFLOAT64
 
-%union
-{
+%union {
     epicsInt64 Int64;
     epicsFloat64 Float64;
     char *Str;
 }
 
+%type <Str> auth_head
 %type <Str> non_rule_keyword
 %type <Str> generic_block_elem_name
 %type <Str> generic_block_elem
@@ -59,6 +69,7 @@ asconfig_item:  tokenUAG uag_head uag_body
     |   tokenUAG uag_head
     |   tokenHAG hag_head hag_body
     |   tokenHAG hag_head
+    |   tokenAUTHORITY top_auth { popCertPath(); }
     |   tokenASG asg_head asg_body
     |   tokenASG asg_head
     |   generic_item
@@ -71,6 +82,12 @@ keyword: tokenUAG
     { $$ = yystrdup("HAG"); }
     | tokenCALC
     { $$ = yystrdup("CALC"); }
+    | tokenMETHOD
+    { $$ = yystrdup("METHOD"); }
+    | tokenAUTHORITY
+    { $$ = yystrdup("AUTHORITY"); }
+    | tokenPROTOCOL
+    { $$ = yystrdup("PROTOCOL"); }
     | non_rule_keyword
     ;
 
@@ -216,6 +233,54 @@ hag_host_list_name: tokenSTRING
     }
     ;
 
+top_auth: top_auth_head  auth_body
+    | top_auth_head
+    ;
+
+top_auth_head:   '(' tokenSTRING ',' tokenSTRING ')'
+    {
+        pushCertPath($4);         // Add this new Certificate Path component to the Certificate Chain
+        saveAuthorityEntry($2);   // Then create a new EPICS Security AUTHORITY with the given name
+    }
+    | '(' tokenSTRING ')'
+    {
+        pushCertPath($2);         // Add this new Certificate Path component to the Certificate Chain
+    }
+    ;
+
+auth_body: '{' auth_body_item_list '}'
+    ;
+
+auth_body_item_list: auth_body_item auth_body_item_list
+    | auth_body_item
+    ;
+
+auth_body_item: tokenAUTHORITY auth_head
+    {
+        saveAuthorityEntry($2);   // Create a new EPICS Security AUTHORITY with the given name
+    } auth_body
+    {
+        popCertPath();
+    }
+    | tokenAUTHORITY auth_head
+    {
+        saveAuthorityEntry($2);   // Then create a new EPICS Security AUTHORITY with the given name
+        popCertPath();
+    }
+    ;
+
+auth_head: '(' tokenSTRING ',' tokenSTRING ')'
+    {
+        pushCertPath($4);
+        $$ = $2;
+    }
+    | '(' tokenSTRING ')'
+    {
+        pushCertPath($2);
+        $$ = NULL;
+    }
+    ;
+
 asg_head:   '(' tokenSTRING ')'
     {
         yyAsg = asAsgAdd($2);
@@ -262,6 +327,8 @@ rule_head_mandatory:    tokenINT64 ',' tokenSTRING
             yyAsgRule = asAsgAddRule(yyAsg,asREAD,(int)$1);
         } else if((strcmp($3,"WRITE")==0)) {
             yyAsgRule = asAsgAddRule(yyAsg,asWRITE,(int)$1);
+        } else if((strcmp($3,"RPC")==0)) {
+            yyAsgRule = asAsgAddRule(yyAsg,asRPC,(int)$1);
         } else {
             yywarn("Ignoring RULE that contains an unsupported keyword", $3);
         }
@@ -291,6 +358,23 @@ rule_list:  rule_list rule_list_item
 
 rule_list_item: tokenUAG '(' rule_uag_list ')'
     |   tokenHAG  '(' rule_hag_list ')'
+    |   tokenMETHOD '(' rule_method_list ')'
+    |   tokenAUTHORITY '(' rule_authority_list ')'
+    |   tokenPROTOCOL '(' tokenSTRING ')'
+    {
+        if((strcasecmp($3,"TLS")==0)) {
+            if (asAsgAddProtocolAdd(yyAsgRule,AS_PROTOCOL_TLS))
+                yyerror("");
+        } else if((strcasecmp($3,"TCP")==0)) {
+            if (asAsgAddProtocolAdd(yyAsgRule,AS_PROTOCOL_TCP))
+                yyerror("");
+        } else {
+            yywarn("Ignoring RULE containing unsupported PROTOCOL", $3);
+            if (asAsgRuleDisable(yyAsgRule))
+                yyerror("");
+        }
+        free($3);
+    }
     |   tokenCALC '(' tokenSTRING ')'
     {
         if (asAsgRuleCalc(yyAsgRule,$3))
@@ -329,6 +413,31 @@ rule_hag_list_name: tokenSTRING
         free($1);
     }
     ;
+
+rule_method_list: rule_method_list ',' rule_method_list_name
+    |   rule_method_list_name
+    ;
+
+rule_method_list_name: tokenSTRING
+    {
+        if (asAsgRuleMethodAdd(yyAsgRule, $1))
+            yyerror("");
+        free($1);
+    }
+    ;
+
+rule_authority_list: rule_authority_list ',' rule_authority_list_name
+    |   rule_authority_list_name
+    ;
+
+rule_authority_list_name: tokenSTRING
+    {
+        if (asAsgRuleAuthorityAdd(yyAsgRule, $1))
+            yyerror("");
+        free($1);
+    }
+    ;
+
 %%
 
 #include "asLib_lex.c"
@@ -349,6 +458,7 @@ static int yywarn(char *str, char *token)
     yyWarned = TRUE;
     return 0;
 }
+
 static int myParse(ASINPUTFUNCPTR inputfunction)
 {
     static int  FirstFlag = 1;
@@ -363,6 +473,137 @@ static int myParse(ASINPUTFUNCPTR inputfunction)
         yyrestart(NULL);
     }
     FirstFlag = 0;
+    initCertPathStack();    // Initialise the Certificate Chain to store an ongoing stack of certificates as they are parsed
     rtnval = yyparse();
+    freeCertPathStack();    // Free the Certificate Chain
     if(rtnval!=0 || yyFailed) return(-1); else return(0);
 }
+
+/**
+ * Add the given Certificate Authority's Common Name to the Certificate Chain
+ * and signal errors to parser if it fails.
+ * Free up the given Common Name once consumed
+ */
+static int pushCertPath(char *commonName) {
+    if (_pushCertPath(commonName) != 0) {
+        yyerror("Out of memory");
+        free(commonName);
+        return -1;
+    }
+    free(commonName);
+    return 0;
+}
+
+/**
+ * Make an actual entry in EPICS Security in the list of declared named AUTHORITIES keyed on the given AUTHORITY ID.
+ *
+ * This will retrieve the Certificate Chain that has been parsed up till now, including
+ * all parent components that have been seen, and will associate it with the given AUTHORITY ID by
+ * calling `asAddAuthority` to add it to EPICS Security as a named AUTHORITY entry
+ * that can be referenced in an ASG RULE.
+ */
+static int saveAuthorityEntry(char *name) {
+    if (name) {
+        char *auth_chain = getCurrentCertPath();
+        if (!auth_chain) {
+            yyerror("Out of memory");
+            free(name);
+            return -1;
+        }
+
+        if (!asAddAuthority(name, auth_chain)) {
+            char message[100];
+            sprintf(message, "AUTHORITY: %s=%s", name, auth_chain);
+            free(auth_chain);
+            free(name);
+            yyerror(message);
+            return -1;
+        }
+
+        free(auth_chain);
+        free(name);
+    }
+    return 0;
+}
+
+/**
+ * Add the given Certificate Authority's Common Name to the end of the current Certificate Chain
+ */
+static int _pushCertPath(const char *commonName) {
+    CertPathNode_t *node = malloc(sizeof(CertPathNode_t));
+    if (!node) return -1;
+
+    node->commonName = strdup(commonName);
+    if (!node->commonName) {
+        free(node);
+        return -1;
+    }
+
+    ellAdd(&yyCertPath, &node->node);
+    return 0;
+}
+
+/**
+ * Remove the last Common Name that was added to the Certificate Chain
+ */
+static void popCertPath() {
+    CertPathNode_t *node = (CertPathNode_t *)ellLast(&yyCertPath);
+    if (node) {
+        ellDelete(&yyCertPath, &node->node);
+        free(node->commonName);
+        free(node);
+    }
+}
+
+/**
+ * Gets the current Certificate Chain that has been parsed so far.
+ */
+static char *getCurrentCertPath() {
+    size_t total_len = 1;  /* For null terminator */
+    CertPathNode_t *node;
+    char *result;
+
+    /* First pass: calculate required length */
+    for (node = (CertPathNode_t *)ellFirst(&yyCertPath); node;
+         node = (CertPathNode_t *)ellNext(&node->node)) {
+        total_len += strlen(node->commonName) + 1;  /* +1 for newline */
+    }
+
+    result = malloc(total_len);
+    if (!result) return NULL;
+    result[0] = '\0';
+
+    /* Second pass: build string */
+    for (node = (CertPathNode_t *)ellFirst(&yyCertPath); node;
+         node = (CertPathNode_t *)ellNext(&node->node)) {
+        if (result[0]) strcat(result, "\n");
+        strcat(result, node->commonName);
+    }
+
+    return result;
+}
+
+/**
+ * Initialise the Certificate Chain when we start parsing
+ */
+static void initCertPathStack() {
+    ellInit(&yyCertPath);
+}
+
+/**
+ * Free up the Certificate Chain once we're done parsing
+ */
+static void freeCertPathStack() {
+    while (ellFirst(&yyCertPath)) {
+        popCertPath();
+    }
+}
+
+static
+char* yystrdup(const char *inp) {
+    char* ret = strdup(inp);
+    if(!ret)
+        yyerror("MALLOC");
+    return ret;
+}
+

--- a/modules/libcom/src/as/asLib.y
+++ b/modules/libcom/src/as/asLib.y
@@ -11,6 +11,7 @@
 static int yyerror(char *);
 static int yy_start;
 #include "asLibRoutines.c"
+#include "epicsString.h"
 static int yyFailed = FALSE;
 static int yyWarned = FALSE;
 static int line_num=1;
@@ -362,10 +363,10 @@ rule_list_item: tokenUAG '(' rule_uag_list ')'
     |   tokenAUTHORITY '(' rule_authority_list ')'
     |   tokenPROTOCOL '(' tokenSTRING ')'
     {
-        if((strcasecmp($3,"TLS")==0)) {
+        if((epicsStrCaseCmp($3,"TLS")==0)) {
             if (asAsgAddProtocolAdd(yyAsgRule,AS_PROTOCOL_TLS))
                 yyerror("");
-        } else if((strcasecmp($3,"TCP")==0)) {
+        } else if((epicsStrCaseCmp($3,"TCP")==0)) {
             if (asAsgAddProtocolAdd(yyAsgRule,AS_PROTOCOL_TCP))
                 yyerror("");
         } else {

--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -18,6 +18,7 @@
 #include "osiSock.h"
 #include "epicsTypes.h"
 #include "epicsStdio.h"
+#include "epicsString.h"
 #include "dbDefs.h"
 #include "epicsThread.h"
 #include "cantProceed.h"
@@ -59,6 +60,8 @@ static UAG *asUagAdd(const char *uagName);
 static long asUagAddUser(UAG *puag,const char *user);
 static HAG *asHagAdd(const char *hagName);
 static long asHagAddHost(HAG *phag,const char *host);
+static AUTHCHAIN *asAddAuthority(const char *name, const char *chain);
+static const char *asGetAuthority(const char *name);
 static ASG *asAsgAdd(const char *asgName);
 static long asAsgAddInp(ASG *pasg,const char *inp,int inpIndex);
 static ASGRULE *asAsgAddRule(ASG *pasg,asAccessRights access,int level);
@@ -67,19 +70,24 @@ static long asAsgRuleUagAdd(ASGRULE *pasgrule,const char *name);
 static long asAsgRuleHagAdd(ASGRULE *pasgrule,const char *name);
 static long asAsgRuleCalc(ASGRULE *pasgrule,const char *calc);
 static long asAsgRuleDisable(ASGRULE *pasgrule);
+static long asAsgRuleMethodAdd(ASGRULE *pasgrule, const char *name);
+static long asAsgRuleAuthorityAdd(ASGRULE *pasgrule, const char *name);
+static long asAsgAddProtocolAdd(ASGRULE *pasgrule,enum AsProtocol protocol);
 
-/*
-  asInitialize can be called while access security is already active.
-  This is accomplished by doing the following:
-
-  The version pointed to by pasbase is kept as is but locked against changes
-  A new version is created and pointed to by pasbasenew
-  If anything goes wrong. The original version is kept. This results is some
-  wasted space but at least things still work.
-  If the new access security configuration is successfully read then:
-     the old memberList is moved from old to new.
-     the old structures are freed.
-*/
+/**
+ * @brief Initialize the Access Security
+ * This can be called while access security is already active.
+ * This is accomplished by doing the following:
+ *  - The version pointed to by pasbase is kept as is but locked against changes
+ *  - A new version is created and pointed to by pasbasenew
+ *  - If anything goes wrong. The original version is kept. This results is some
+ *    wasted space but at least things still work.
+ *  - If the new access security configuration is successfully read then:
+ *    * the old memberList is moved from old to new.
+ *    * the old structures are freed.
+ *
+ * @param arg Argument (not used)
+ */
 static void asInitializeOnce(void *arg)
 {
     osiSockAttach();
@@ -362,9 +370,49 @@ void epicsStdCall asPutMemberPvt(ASMEMBERPVT asMemberPvt,void *userPvt)
     pasgmember->userPvt = userPvt;
 }
 
+/**
+ * @brief Add a client to an existing ASG
+ * This function adds a client to an existing ASG.
+ * A client is defined by a user, method, authority, and host all of which can
+ * be NULL.
+ * It is the responsibility of the caller to free the client structure when it is no longer needed.
+ *
+ * @param pasClientPvt Pointer to the client structure
+ * @param asMemberPvt Pointer to the member structure
+ * @param asl Access level
+ * @param user User name
+ * @param host Host name
+ * @return Status code
+ *          `S_asLib_asNotActive` if access security is not active,
+ *          `S_asLib_badMember` if the member is not provided,
+ *          `S_asLib_noMemory` if there is not enough memory to allocate the client structure,
+ *          or the status from `asComputePvt` which will be 0 if the client is successfully added
+ */
 long epicsStdCall asAddClient(ASCLIENTPVT *pasClientPvt,ASMEMBERPVT asMemberPvt,
-        int asl,const char *user,char *host)
-{
+        int asl,const char *user,char *host) {
+
+    return asAddClientIdentity(pasClientPvt, asMemberPvt, asl,
+        (ASIDENTITY){ .user = user, .host = host, .method = "ca"  });
+}
+
+/**
+ * @brief Add a client to an existing ASG
+ * This function adds a client to an existing ASG.
+ * A client is defined by a user, method, authority, and host all of which can
+ * be NULL.
+ * It is the responsibility of the caller to free the client structure when it is no longer needed.
+ *
+ * @param pasClientPvt Pointer to the client structure
+ * @param asMemberPvt Pointer to the member structure
+ * @param asl Access level
+ * @param identity identity of the client
+ * @return Status code
+ *          `S_asLib_asNotActive` if access security is not active,
+ *          `S_asLib_badMember` if the member is not provided,
+ *          `S_asLib_noMemory` if there is not enough memory to allocate the client structure,
+ *          or the status from `asComputePvt` which will be 0 if the client is successfully added
+ */
+long epicsStdCall asAddClientIdentity(ASCLIENTPVT *pasClientPvt,ASMEMBERPVT asMemberPvt, int asl, ASIDENTITY identity) {
     ASGMEMBER   *pasgmember = asMemberPvt;
     ASGCLIENT   *pasgclient;
     size_t      len, i;
@@ -374,15 +422,16 @@ long epicsStdCall asAddClient(ASCLIENTPVT *pasClientPvt,ASMEMBERPVT asMemberPvt,
     if(!pasgmember) return(S_asLib_badMember);
     pasgclient = freeListCalloc(freeListPvt);
     if(!pasgclient) return(S_asLib_noMemory);
-    len = strlen(host);
-    for (i = 0; i < len; i++) {
-        host[i] = (char)tolower((int)host[i]);
+    if ( identity.host ) {
+        len = strlen(identity.host);
+        for (i = 0; i < len; i++) {
+            identity.host[i] = (char)tolower((int)identity.host[i]);
+        }
     }
     *pasClientPvt = pasgclient;
     pasgclient->pasgMember = asMemberPvt;
     pasgclient->level = asl;
-    pasgclient->user = user;
-    pasgclient->host = host;
+    pasgclient->identity = identity;
     LOCK;
     ellAdd(&pasgmember->clientList,&pasgclient->node);
     status = asComputePvt(pasgclient);
@@ -390,8 +439,28 @@ long epicsStdCall asAddClient(ASCLIENTPVT *pasClientPvt,ASMEMBERPVT asMemberPvt,
     return(status);
 }
 
+/**
+ * @brief Change a client's attributes
+ * @param asClientPvt Pointer to the client structure
+ * @param asl Access level
+ * @param user User name
+ * @param host Host name
+ * @return Status code
+ */
 long epicsStdCall asChangeClient(
-    ASCLIENTPVT asClientPvt,int asl,const char *user,char *host)
+    ASCLIENTPVT asClientPvt,int asl,const char *user,char *host) {
+    return asChangeClientIdentity(asClientPvt, asl,(ASIDENTITY){ .user = user, .host = host, .method = "ca" });
+}
+
+/**
+ * @brief Change a client's attributes
+ * @param asClientPvt Pointer to the client structure
+ * @param asl Access level
+ * @param identity identity of the client
+ * @return Status code
+ */
+long epicsStdCall asChangeClientIdentity(
+    ASCLIENTPVT asClientPvt,int asl, ASIDENTITY identity)
 {
     ASGCLIENT   *pasgclient = asClientPvt;
     long        status;
@@ -399,14 +468,13 @@ long epicsStdCall asChangeClient(
 
     if(!asActive) return(S_asLib_asNotActive);
     if(!pasgclient) return(S_asLib_badClient);
-    len = strlen(host);
+    len = strlen(identity.host);
     for (i = 0; i < len; i++) {
-        host[i] = (char)tolower((int)host[i]);
+        identity.host[i] = (char)tolower((int)identity.host[i]);
     }
     LOCK;
     pasgclient->level = asl;
-    pasgclient->user = user;
-    pasgclient->host = host;
+    pasgclient->identity = identity;
     status = asComputePvt(pasgclient);
     UNLOCK;
     return(status);
@@ -501,7 +569,7 @@ long epicsStdCall asCompute(ASCLIENTPVT asClientPvt)
 
 /*The dump routines do not lock. Thus they may get inconsistent data.*/
 /*HOWEVER if they did lock and a user interrupts one of then then BAD BAD*/
-static const char *asAccessName[] = {"NONE","READ","WRITE"};
+static const char *asAccessName[] = {"NONE","READ","WRITE","RPC"};
 static const char *asTrapOption[] = {"NOTRAPWRITE","TRAPWRITE"};
 static const char *asLevelName[] = {"ASL0","ASL1"};
 int epicsStdCall asDump(
@@ -512,6 +580,18 @@ int epicsStdCall asDump(
     return asDumpFP(stdout,memcallback,clientcallback,verbose);
 }
 
+/**
+ * @brief Dump the ASG to a file
+ * This function dumps the ASG to a normalized ACF file.
+ * It calls the member callback for each member and
+ * the client callback for each client within each member if they are provided.
+ *
+ * @param fp File pointer
+ * @param memcallback Callback function for members
+ * @param clientcallback Callback function for clients
+ * @param verbose Verbosity level
+ * @return Status code
+ */
 int epicsStdCall asDumpFP(
         FILE *fp,
         void (*memcallback)(struct asgMember *,FILE *),
@@ -522,6 +602,7 @@ int epicsStdCall asDumpFP(
     UAGNAME     *puagname;
     HAG         *phag;
     HAGNAME     *phagname;
+    AUTHCHAIN   *pauthchain;
     ASG         *pasg;
     ASGINP      *pasginp;
     ASGRULE     *pasgrule;
@@ -529,6 +610,8 @@ int epicsStdCall asDumpFP(
     ASGUAG      *pasguag;
     ASGMEMBER   *pasgmember;
     ASGCLIENT   *pasgclient;
+    ASGMETHOD   *pasgmethod;
+    ASGAUTHORITY *pasgauthority;
 
     if(!asActive) return(0);
     puag = (UAG *)ellFirst(&pasbase->uagList);
@@ -545,7 +628,6 @@ int epicsStdCall asDumpFP(
         puag = (UAG *)ellNext(&puag->node);
     }
     phag = (HAG *)ellFirst(&pasbase->hagList);
-    if(!phag) fprintf(fp,"No HAGs\n");
     while(phag) {
         fprintf(fp,"HAG(%s)",phag->name);
         phagname = (HAGNAME *)ellFirst(&phag->list);
@@ -556,6 +638,22 @@ int epicsStdCall asDumpFP(
             if(phagname) fprintf(fp,","); else fprintf(fp,"}\n");
         }
         phag = (HAG *)ellNext(&phag->node);
+    }
+    pauthchain = (AUTHCHAIN *)ellFirst(&pasbase->authList);
+    while(pauthchain) {
+        fprintf(fp,"AUTHORITY(%s: ",pauthchain->name);
+        char token_buf[MAX_AUTH_CHAIN_STRING];
+        strncpy(token_buf, pauthchain->chain, sizeof(token_buf));
+        token_buf[sizeof(token_buf) - 1] = '\0';
+        const char *token = strtok(token_buf, "\n");
+        int first = 1;
+        while (token) {
+            fprintf(fp,"%s%s", (first ? "" : " -> "), token);
+            first = 0;
+            token = strtok(NULL, "\n");
+        }
+        fprintf(fp,")\n");
+        pauthchain = (AUTHCHAIN *)ellNext(&pauthchain->node);
     }
     pasg = (ASG *)ellFirst(&pasbase->asgList);
     if(!pasg) fprintf(fp,"No ASGs\n");
@@ -593,7 +691,9 @@ int epicsStdCall asDumpFP(
                 asTrapOption[pasgrule->trapMask]);
             pasguag = (ASGUAG *)ellFirst(&pasgrule->uagList);
             pasghag = (ASGHAG *)ellFirst(&pasgrule->hagList);
-            if(pasguag || pasghag || pasgrule->calc) {
+            pasgmethod = (ASGMETHOD *)ellFirst(&pasgrule->methodList);
+            pasgauthority = (ASGAUTHORITY *)ellFirst(&pasgrule->authList);
+            if(pasguag || pasghag|| pasgmethod|| pasgauthority || pasgrule->calc) {
                 fprintf(fp," {\n");
                 print_rule_end_brace = TRUE;
             } else {
@@ -612,12 +712,30 @@ int epicsStdCall asDumpFP(
                 pasghag = (ASGHAG *)ellNext(&pasghag->node);
                 if(pasghag) fprintf(fp,","); else fprintf(fp,")\n");
             }
+            if(pasgmethod) fprintf(fp,"\t\tMETHOD(");
+            while(pasgmethod) {
+                fprintf(fp,"\"%s\"",pasgmethod->pmethod->name);
+                pasgmethod = (ASGMETHOD *)ellNext(&pasgmethod->node);
+                if(pasgmethod) fprintf(fp,","); else fprintf(fp,")\n");
+            }
+            if(pasgauthority) fprintf(fp,"\t\tAUTHORITY(");
+            while(pasgauthority) {
+                fprintf(fp,"%s",pasgauthority->pauthority->name);
+                pasgauthority = (ASGAUTHORITY *)ellNext(&pasgauthority->node);
+                if(pasgauthority) fprintf(fp,","); else fprintf(fp,")\n");
+            }
             if(pasgrule->calc) {
                 fprintf(fp,"\t\tCALC(\"%s\")",pasgrule->calc);
                 if(verbose)
                     fprintf(fp," result=%s",(pasgrule->result==1 ? "TRUE" : "FALSE"));
                 fprintf(fp,"\n");
             }
+            if(pasgrule->protocol > 0) {
+                fprintf(fp,"\t\tPROTOCOL(\"tls\")\n");
+            } else if(!pasgrule->protocol) {
+                fprintf(fp,"\t\tPROTOCOL(\"tcp\")\n");
+            }
+
 next_rule:
             if(print_rule_end_brace) fprintf(fp,"\t}\n");
             pasgrule = (ASGRULE *)ellNext(&pasgrule->node);
@@ -634,7 +752,7 @@ next_rule:
             fprintf(fp,"\n");
             pasgclient = (ASGCLIENT *)ellFirst(&pasgmember->clientList);
             while(pasgclient) {
-                fprintf(fp,"\t\t\t %s %s",pasgclient->user,pasgclient->host);
+                fprintf(fp,"\t\t\t %s %s",pasgclient->identity.user,pasgclient->identity.host);
                 if(pasgclient->level>=0 && pasgclient->level<=1)
                         fprintf(fp," %s",asLevelName[pasgclient->level]);
                 else
@@ -700,7 +818,6 @@ int epicsStdCall asDumpHagFP(FILE *fp,const char *hagname)
 
     if(!asActive) return(0);
     phag = (HAG *)ellFirst(&pasbase->hagList);
-    if(!phag) fprintf(fp,"No HAGs\n");
     while(phag) {
         if(hagname && strcmp(hagname,phag->name)!=0) {
             phag = (HAG *)ellNext(&phag->node);
@@ -731,6 +848,8 @@ int epicsStdCall asDumpRulesFP(FILE *fp,const char *asgname)
     ASGRULE     *pasgrule;
     ASGHAG      *pasghag;
     ASGUAG      *pasguag;
+    ASGMETHOD   *pasgmethod;
+    ASGAUTHORITY *pasgauthority;
 
     if(!asActive) return(0);
     pasg = (ASG *)ellFirst(&pasbase->asgList);
@@ -763,13 +882,15 @@ int epicsStdCall asDumpRulesFP(FILE *fp,const char *asgname)
         }
         while(pasgrule) {
             int print_rule_end_brace = FALSE;
-            if ( pasgrule->ignore) goto next_rule;
+            if (pasgrule->ignore) goto next_rule;
             fprintf(fp,"\tRULE(%d,%s,%s)",
                 pasgrule->level,asAccessName[pasgrule->access],
                 asTrapOption[pasgrule->trapMask]);
             pasguag = (ASGUAG *)ellFirst(&pasgrule->uagList);
             pasghag = (ASGHAG *)ellFirst(&pasgrule->hagList);
-            if(pasguag || pasghag || pasgrule->calc) {
+            pasgmethod = (ASGMETHOD *)ellFirst(&pasgrule->methodList);
+            pasgauthority = (ASGAUTHORITY *)ellFirst(&pasgrule->authList);
+            if(pasguag || pasghag || pasgmethod || pasgauthority || pasgrule->calc) {
                 fprintf(fp," {\n");
                 print_rule_end_brace = TRUE;
             } else {
@@ -782,19 +903,43 @@ int epicsStdCall asDumpRulesFP(FILE *fp,const char *asgname)
                 pasguag = (ASGUAG *)ellNext(&pasguag->node);
                 if(pasguag) fprintf(fp,","); else fprintf(fp,")\n");
             }
-            pasghag = (ASGHAG *)ellFirst(&pasgrule->hagList);
             if(pasghag) fprintf(fp,"\t\tHAG(");
             while(pasghag) {
                 fprintf(fp,"%s",pasghag->phag->name);
                 pasghag = (ASGHAG *)ellNext(&pasghag->node);
                 if(pasghag) fprintf(fp,","); else fprintf(fp,")\n");
             }
+            if(pasgmethod) {
+                fprintf(fp,"\t\tMETHOD(");
+                while(pasgmethod) {
+                    fprintf(fp,"\"%s\"",pasgmethod->pmethod->name);
+                    pasgmethod = (ASGMETHOD *)ellNext(&pasgmethod->node);
+                    if(pasgmethod) fprintf(fp,","); else fprintf(fp,")\n");
+                }
+            }
+            if(pasgauthority) {
+                fprintf(fp,"\t\tAUTHORITY(");
+                while(pasgauthority) {
+                    fprintf(fp,"%s",pasgauthority->pauthority->name);
+                    pasgauthority = (ASGAUTHORITY *)ellNext(&pasgauthority->node);
+                    if(pasgauthority) fprintf(fp,","); else fprintf(fp,")\n");
+                }
+            }
             if(pasgrule->calc) {
                 fprintf(fp,"\t\tCALC(\"%s\")",pasgrule->calc);
                 fprintf(fp," result=%s",(pasgrule->result==1 ? "TRUE" : "FALSE"));
                 fprintf(fp,"\n");
             }
-next_rule:
+            switch (pasgrule->protocol) {
+                case AS_PROTOCOL_TCP:
+                    fprintf(fp,"\t\tPROTOCOL(\"tcp\")\n");
+                    break;
+                case AS_PROTOCOL_TLS:
+                    fprintf(fp,"\t\tPROTOCOL(\"tls\")\n");
+                    break;
+                default: ;
+            }
+        next_rule:
             if(print_rule_end_brace) fprintf(fp,"\t}\n");
             pasgrule = (ASGRULE *)ellNext(&pasgrule->node);
         }
@@ -840,7 +985,7 @@ int epicsStdCall asDumpMemFP(FILE *fp,const char *asgname,
             if(!clients) pasgclient = NULL;
             while(pasgclient) {
                 fprintf(fp,"\t\t\t %s %s",
-                    pasgclient->user,pasgclient->host);
+                    pasgclient->identity.user,pasgclient->identity.host);
                 if(pasgclient->level>=0 && pasgclient->level<=1)
                     fprintf(fp," %s",asLevelName[pasgclient->level]);
                 else
@@ -950,7 +1095,7 @@ static long asComputeAsgPvt(ASG *pasg)
     if(!asActive) return(S_asLib_asNotActive);
     pasgrule = (ASGRULE *)ellFirst(&pasg->ruleList);
     while(pasgrule) {
-        if ( pasgrule->ignore) goto next_rule;
+        if (pasgrule->ignore) goto next_rule;
         double  result = pasgrule->result;  /* set for VAL */
         long    status;
 
@@ -979,7 +1124,17 @@ next_rule:
     }
     return(0);
 }
-
+
+/**
+ * @brief Compute the access and trap mask for a client
+ *
+ * The access and trap mask are computed based on the rules for the client's ASG.
+ * They are then stored in the client structure in the access and trapMask fields.
+ * If the access has changed, the client callback is called.
+ *
+ * @param asClientPvt Pointer to the client structure
+ * @return Status code
+ */
 static long asComputePvt(ASCLIENTPVT asClientPvt)
 {
     asAccessRights      access=asNOACCESS;
@@ -1000,10 +1155,11 @@ static long asComputePvt(ASCLIENTPVT asClientPvt)
     oldaccess=pasgclient->access;
     pasgrule = (ASGRULE *)ellFirst(&pasg->ruleList);
     while(pasgrule) {
-        if (pasgrule->ignore) goto next_rule;
-        if(access == asWRITE) break;
-        if(access>=pasgrule->access) goto next_rule;
-        if(pasgclient->level > pasgrule->level) goto next_rule;
+        if(pasgrule->ignore) goto next_rule;
+        if(access >= asWRITE) break; // Already the highest then stop
+        if(access>=pasgrule->access) goto next_rule; // Already higher access than this rule, try next rule
+        if(pasgclient->level > pasgrule->level) goto next_rule; // Skip if the client's security group level is greater than this rule's level
+        if (pasgrule->protocol != AS_PROTOCOL_NOT_SET && pasgrule->protocol != asClientPvt->identity.protocol ) goto next_rule;
         /*if uagList is empty then no need to check uag*/
         if(ellCount(&pasgrule->uagList)>0){
             ASGUAG      *pasguag;
@@ -1012,7 +1168,7 @@ static long asComputePvt(ASCLIENTPVT asClientPvt)
             pasguag = (ASGUAG *)ellFirst(&pasgrule->uagList);
             while(pasguag) {
                 if((puag = pasguag->puag)) {
-                    pgphentry = gphFind(pasbase->phash,pasgclient->user,puag);
+                    pgphentry = gphFind(pasbase->phash,pasgclient->identity.user,puag);
                     if(pgphentry) goto check_hag;
                 }
                 pasguag = (ASGUAG *)ellNext(&pasguag->node);
@@ -1028,13 +1184,54 @@ check_hag:
             pasghag = (ASGHAG *)ellFirst(&pasgrule->hagList);
             while(pasghag) {
                 if((phag = pasghag->phag)) {
-                    pgphentry=gphFind(pasbase->phash,pasgclient->host,phag);
-                    if(pgphentry) goto check_calc;
+                    pgphentry=gphFind(pasbase->phash,pasgclient->identity.host,phag);
+                    if(pgphentry) goto check_method;
                 }
                 pasghag = (ASGHAG *)ellNext(&pasghag->node);
             }
             goto next_rule;
         }
+check_method:
+    if(ellCount(&pasgrule->methodList)>0) {
+        ASGMETHOD *pasgmethod;
+
+        if (!pasgclient->identity.method) {
+            goto next_rule;
+        }
+
+        // Directly check if method matches any in the rule's list
+        pasgmethod = (ASGMETHOD *)ellFirst(&pasgrule->methodList);
+        while(pasgmethod) {
+           if (epicsStrCaseCmp(pasgmethod->pmethod->name, pasgclient->identity.method) == 0) {
+                goto check_authority;
+            }
+            pasgmethod = (ASGMETHOD *)ellNext(&pasgmethod->node);
+        }
+        goto next_rule;
+    }
+
+check_authority:
+    if(ellCount(&pasgrule->authList)>0) {
+        ASGAUTHORITY *pasgauthority;
+
+        if (!pasgclient->identity.authority) {
+            goto next_rule;
+        }
+
+        // Directly check if authority matches any in the rule's list
+        pasgauthority = (ASGAUTHORITY *)ellFirst(&pasgrule->authList);
+        while(pasgauthority) {
+            const char * rule_authority = asGetAuthority(pasgauthority->pauthority->name);
+            if ( !rule_authority ) {
+                goto next_rule;
+            }
+            if(strncmp(rule_authority, pasgclient->identity.authority, strlen(rule_authority)) == 0) {
+                goto check_calc;
+            }
+            pasgauthority = (ASGAUTHORITY *)ellNext(&pasgauthority->node);
+        }
+        goto next_rule;
+    }
 check_calc:
         if(!pasgrule->calc
         || (!(pasg->inpBad & pasgrule->inpUsed) && (pasgrule->result==1))) {
@@ -1051,7 +1248,12 @@ next_rule:
     }
     return(0);
 }
-
+
+/**
+ * @brief Free all the memory allocated for the access security system
+ *
+ * @param pasbase Pointer to the base structure
+ */
 void asFreeAll(ASBASE *pasbase)
 {
     UAG         *puag;
@@ -1063,10 +1265,9 @@ void asFreeAll(ASBASE *pasbase)
     ASGRULE     *pasgrule;
     ASGHAG      *pasghag;
     ASGUAG      *pasguag;
+    ASGMETHOD   *pasgmethod;
+    ASGAUTHORITY *pasgauthority;
     void        *pnext;
-
-    if(!pasbase)
-        return;
 
     puag = (UAG *)ellFirst(&pasbase->uagList);
     while(puag) {
@@ -1123,6 +1324,22 @@ void asFreeAll(ASBASE *pasbase)
                 ellDelete(&pasgrule->hagList,&pasghag->node);
                 free(pasghag);
                 pasghag = pnext;
+            }
+            pasgmethod = (ASGMETHOD *)ellFirst(&pasgrule->methodList);
+            while(pasgmethod) {
+                pnext = ellNext(&pasgmethod->node);
+                ellDelete(&pasgrule->methodList,&pasgmethod->node);
+                free(pasgmethod->pmethod);
+                free(pasgmethod);
+                pasgmethod = pnext;
+            }
+            pasgauthority = (ASGAUTHORITY *)ellFirst(&pasgrule->authList);
+            while(pasgauthority) {
+                pnext = ellNext(&pasgauthority->node);
+                ellDelete(&pasgrule->authList,&pasgauthority->node);
+                free(pasgauthority->pauthority);
+                free(pasgauthority);
+                pasgauthority = pnext;
             }
             pnext = ellNext(&pasgrule->node);
             ellDelete(&pasg->ruleList,&pasgrule->node);
@@ -1254,7 +1471,93 @@ static long asHagAddHost(HAG *phag,const char *host)
     ellAdd(&phag->list, &phagname->node);
     return 0;
 }
-
+
+/**
+ * @brief Adds a new authority chain to the linked list of authority chains.
+ * Inserts the new authority chain in alphabetical order based on its name.
+ *
+ * If a duplicate name is found, the function logs an error message and returns NULL.
+ *
+ * @param name The name of the authority chain to be added.
+ * @param chain The authority chain string (a chain of common names - newline-delimited, ordered from Root to Issuer).
+ * @return A pointer to the newly created AUTHCHAIN structure if successful, or NULL if an error occurs.
+ */
+AUTHCHAIN *asAddAuthority(const char *name, const char *chain) {
+    AUTHCHAIN         *pprev;
+    AUTHCHAIN         *pnext;
+    AUTHCHAIN         *pauth;
+    int         cmpvalue;
+    ASBASE      *pasbase = (ASBASE *)pasbasenew;
+
+    /*Insert in alphabetic order*/
+    pnext = (AUTHCHAIN *)ellFirst(&pasbase->authList);
+    while(pnext) {
+        cmpvalue = strcmp(name,pnext->name);
+        if(cmpvalue<0) break;
+        if(cmpvalue==0) {
+            errlogPrintf("Duplicate Named Certificate Authority '%s'\n", name);
+            return(NULL);
+        }
+        pnext = (AUTHCHAIN *)ellNext(&pnext->node);
+    }
+    const size_t name_len = strlen(name);
+    const size_t chain_len = strlen(chain);
+    pauth = asCalloc(1,sizeof(AUTHCHAIN)+name_len+chain_len+2);
+    ellInit(&pauth->list);
+    pauth->name = (char *)(pauth+1);
+    memcpy(pauth->name, name, name_len+1);
+    pauth->chain = (pauth->name+name_len+1);
+    memcpy(pauth->chain, chain, chain_len+1);
+    if(pnext==NULL) { /*Add to end of list*/
+        ellAdd(&pasbase->authList,&pauth->node);
+    } else {
+        pprev = (AUTHCHAIN *)ellPrevious(&pnext->node);
+        ellInsert(&pasbase->authList,&pprev->node,&pauth->node);
+    }
+    return(pauth);
+}
+
+/**
+ * @brief Retrieves the authority chain associated with a given name.
+ *
+ * This function searches for a specified authority name in an alphabetically
+ * ordered list. If the name is found, the corresponding authority chain is
+ * returned. If the name is not found, an error message is logged, and a
+ * `NULL` value is returned.
+ *
+ * @param name The name of the authority to search for.
+ *             Expected to be unique and match the order in the list.
+ *
+ * @return The corresponding authority chain for the specified name as a
+ *         constant character pointer. If the authority name is not found,
+ *         returns `NULL`.  newline-delimited, ordered from Root to Issuer
+ *
+ * @note The function assumes that the list of authorities in `authList` is
+ *       in alphabetical order for efficient searching.
+ *
+ * @note Logs an error if the specified authority name is not found in the
+ *       list.
+ *
+ * @warning If the global pointer `pasbasenew` is uninitialized or invalid,
+ *          behavior is undefined.
+ */
+const char *asGetAuthority(const char *name) {
+    ASBASE      *pasbase = (ASBASE *)pasbasenew;
+
+    /*Assumes the list is in alphabetic order*/
+    AUTHCHAIN *pnext = (AUTHCHAIN *) ellFirst(&pasbase->authList);
+    while(pnext) {
+        const int comparison = strcmp(name, pnext->name);
+        if(comparison<0) break;
+        if(comparison==0) {
+            return pnext->chain;
+        }
+        pnext = (AUTHCHAIN *)ellNext(&pnext->node);
+    }
+    errlogPrintf("Certificate Authority Not Defined '%s'\n", name);
+    return(NULL);
+}
+
 static ASG *asAsgAdd(const char *asgName)
 {
     ASG         *pprev;
@@ -1308,6 +1611,14 @@ static long asAsgAddInp(ASG *pasg,const char *inp,int inpIndex)
     return(0);
 }
 
+/**
+ * @brief Add a rule to an access security group
+ *
+ * @param pasg Pointer to the access security group
+ * @param access Access rights
+ * @param level Access level
+ * @return Pointer to the rule or NULL if there is no memory to allocate the rule
+ */
 static ASGRULE *asAsgAddRule(ASG *pasg,asAccessRights access,int level)
 {
     ASGRULE     *pasgrule;
@@ -1317,8 +1628,11 @@ static ASGRULE *asAsgAddRule(ASG *pasg,asAccessRights access,int level)
     pasgrule->access = access;
     pasgrule->trapMask = 0;
     pasgrule->level = level;
+    pasgrule->protocol = AS_PROTOCOL_NOT_SET;
     ellInit(&pasgrule->uagList);
     ellInit(&pasgrule->hagList);
+    ellInit(&pasgrule->authList);
+    ellInit(&pasgrule->methodList);
     ellAdd(&pasg->ruleList,&pasgrule->node);
     return(pasgrule);
 }
@@ -1327,6 +1641,13 @@ static long asAsgAddRuleOptions(ASGRULE *pasgrule,int trapMask)
 {
     if(!pasgrule) return(0);
     pasgrule->trapMask = trapMask;
+    return(0);
+}
+
+static long asAsgAddProtocolAdd(ASGRULE *pasgrule,enum AsProtocol protocol)
+{
+    if(!pasgrule) return(0);
+    pasgrule->protocol = protocol;
     return(0);
 }
 
@@ -1382,6 +1703,74 @@ static long asAsgRuleHagAdd(ASGRULE *pasgrule, const char *name)
     return 0;
 }
 
+/**
+ * @brief Add a method to a rule
+ *
+ * @param pasgrule Pointer to the rule
+ * @param name Name of the method
+ * @return 0 if successful, S_asLib_dupMethod if the method is already in the rule
+ */
+static long asAsgRuleMethodAdd(ASGRULE *pasgrule, const char *name)
+{
+    ASGMETHOD *pasgmethod;
+    METHOD    *pmethod;
+
+    if(!pasgrule) return 0;
+
+    pasgmethod = (ASGMETHOD *)ellFirst(&pasgrule->methodList);
+    while(pasgmethod) {
+        if(strcmp(pasgmethod->pmethod->name, name) == 0) {
+            errlogPrintf("Duplicate method '%s' in rule\n", name);
+            return S_asLib_dupMethod;
+        }
+        pasgmethod = (ASGMETHOD *)ellNext(&pasgmethod->node);
+    }
+
+    const size_t method_name_len = strlen(name);
+    pmethod = asCalloc(1, sizeof(METHOD)+method_name_len+1);
+    pmethod->name = (char *)(pmethod+1);
+    memcpy(pmethod->name, name, method_name_len+1);
+
+    pasgmethod = asCalloc(1,sizeof(ASGMETHOD));
+    pasgmethod->pmethod = pmethod;
+    ellAdd(&pasgrule->methodList,&pasgmethod->node);
+    return 0;
+}
+
+/**
+ * @brief Add an authority to a rule
+ *
+ * @param pasgrule Pointer to the rule
+ * @param name Name of the authority
+ * @return 0 if successful, S_asLib_dupAuthority if the authority is already in the rule
+ */
+static long asAsgRuleAuthorityAdd(ASGRULE *pasgrule, const char *name)
+{
+    ASGAUTHORITY *pasgauthority;
+    AUTHORITY    *pauthority;
+
+    if(!pasgrule) return 0;
+
+    pasgauthority = (ASGAUTHORITY *)ellFirst(&pasgrule->authList);
+    while(pasgauthority) {
+        if(strcmp(pasgauthority->pauthority->name, name) == 0) {
+            errlogPrintf("Duplicate authority '%s' in rule\n", name);
+            return S_asLib_dupAuthority;
+        }
+        pasgauthority = (ASGAUTHORITY *)ellNext(&pasgauthority->node);
+    }
+
+    const size_t auth_name_len = strlen(name);
+    pauthority = asCalloc(1, sizeof(AUTHORITY)+auth_name_len+1);
+    pauthority->name = (char *)(pauthority+1);
+    memcpy(pauthority->name, name, auth_name_len+1);
+
+    pasgauthority = asCalloc(1,sizeof(ASGAUTHORITY));
+    pasgauthority->pauthority = pauthority;
+    ellAdd(&pasgrule->authList,&pasgauthority->node);
+    return 0;
+}
+
 static long asAsgRuleCalc(ASGRULE *pasgrule,const char *calc)
 {
     short err;
@@ -1421,7 +1810,7 @@ static long asAsgRuleCalc(ASGRULE *pasgrule,const char *calc)
 /**
  * @brief Disable a rule if it contains unsupported elements
  * @param pasgrule the rule to disable
- * @return Non-zero if rule was not disabled
+ * @return Non-zero if the rule was not disabled
  */
 static long asAsgRuleDisable(ASGRULE *pasgrule) {
     if (!pasgrule) return 1;

--- a/modules/libcom/src/as/asLib_lex.l
+++ b/modules/libcom/src/as/asLib_lex.l
@@ -43,6 +43,9 @@ HAG     { return(tokenHAG);     }
 ASG     { return(tokenASG);     }
 RULE    { return(tokenRULE);    }
 CALC    { return(tokenCALC);    }
+METHOD  { return(tokenMETHOD);  }
+AUTHORITY { return(tokenAUTHORITY); }
+PROTOCOL { return(tokenPROTOCOL);   }
 
 INP{link} {
         yylval.Int64 = (unsigned char)yytext[3];

--- a/modules/libcom/src/as/asTrapWrite.c
+++ b/modules/libcom/src/as/asTrapWrite.c
@@ -58,7 +58,7 @@ typedef struct asTrapWritePvt
 }asTrapWritePvt;
 
 static asTrapWritePvt *pasTrapWritePvt = 0;
-
+
 static void asTrapWriteInit(void)
 {
     pasTrapWritePvt = callocMustSucceed(1,sizeof(asTrapWritePvt),"asTrapWriteInit");
@@ -110,9 +110,16 @@ void epicsStdCall asTrapWriteUnregisterListener(asTrapWriteId id)
     free(plistener);
     epicsMutexUnlock(pasTrapWritePvt->lock);
 }
-
+
 void * epicsStdCall asTrapWriteBeforeWithData(
     const char *userid, const char *hostid, dbChannel *chan,
+    int dbrType, int no_elements, void *data)
+{
+    return asTrapWriteBeforeWithIdentityData((ASIDENTITY){ .user = userid, .host = (char *)hostid, .method = "ca"  }, chan, dbrType, no_elements, data);
+}
+
+void * epicsStdCall asTrapWriteBeforeWithIdentityData(
+    ASIDENTITY identity, dbChannel *chan,
     int dbrType, int no_elements, void *data)
 {
     writeMessage *pwriteMessage;
@@ -124,8 +131,11 @@ void * epicsStdCall asTrapWriteBeforeWithData(
 
     pwriteMessage = (writeMessage *)freeListCalloc(
         pasTrapWritePvt->freeListWriteMessage);
-    pwriteMessage->message.userid = userid;
-    pwriteMessage->message.hostid = hostid;
+    pwriteMessage->message.userid = identity.user;
+    pwriteMessage->message.hostid = identity.host;
+    pwriteMessage->message.method = identity.method;
+    pwriteMessage->message.authority = identity.authority;
+    pwriteMessage->message.protocol = identity.protocol;
     pwriteMessage->message.serverSpecific = chan;
     pwriteMessage->message.dbrType = dbrType;
     pwriteMessage->message.no_elements = no_elements;
@@ -150,6 +160,21 @@ void * epicsStdCall asTrapWriteBeforeWithData(
     }
     epicsMutexUnlock(pasTrapWritePvt->lock);
     return pwriteMessage;
+}
+
+void * epicsStdCall asTrapWriteWithDataCompat(
+    ASCLIENTPVT asClientPvt, const char *user, const char *host, dbChannel *addr,
+    int dbrType, int no_elements, void *data)
+{
+    return asTrapWriteBeforeWithIdentityData(
+        (ASIDENTITY){
+            .user = user,
+            .host = (char *)host,
+            .method = asClientPvt->identity.method,
+            .authority = asClientPvt->identity.authority,
+            .protocol = asClientPvt->identity.protocol
+        },
+        addr, dbrType, no_elements, data);
 }
 
 void epicsStdCall asTrapWriteAfterWrite(void *pvt)

--- a/modules/libcom/src/as/asTrapWrite.h
+++ b/modules/libcom/src/as/asTrapWrite.h
@@ -33,7 +33,10 @@ struct dbChannel;
  */
 typedef struct asTrapWriteMessage {
     const char *userid; /**< \brief Userid of whoever originated the request. */
+    const char *method; /**< \brief Method of the request (ca, anonymous, or x509). */
+    const char *authority; /**< \brief Authority of the request (common name of the root certificate authority). */
     const char *hostid; /**< \brief Hostid of whoever originated the request. */
+    epicsInt8 protocol; /**< \brief the connection is TLS encapsulated, or simple TCP. */
     /** \brief A field for use by the server.
      *
      * Any listener that uses this field must know what type of

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -7,7 +7,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+#include <osiUnistd.h>
 
 #include <testMain.h>
 #include <epicsUnitTest.h>

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -19,6 +19,15 @@
 
 #include <asLib.h>
 
+/* Portable thread-local storage helper for tests */
+#ifdef _MSC_VER
+#  define STORE static __declspec( thread )
+#elif __GNUC__
+#  define STORE static __thread
+#else
+#  define STORE static
+#endif
+
 // The maximum number of links in a chain of authority we will provide in test data.  Increase as needed
 #define MAX_CERT_AUTH_CHAIN_LENGTH 10
 
@@ -1070,7 +1079,7 @@ static void testAccess(const char *asg, unsigned mask)
     ASMEMBERPVT asp = 0; /* aka dbCommon::asp */
     ASCLIENTPVT client = 0;
 
-    static __thread char formattedCertAuthChain[MAX_AUTH_CHAIN_STRING];
+    STORE char formattedCertAuthChain[MAX_AUTH_CHAIN_STRING];
     parseCertAuthChain(&formattedCertAuthChain[0]);
 
     long ret = asAddMember(&asp, asg);
@@ -1078,7 +1087,13 @@ static void testAccess(const char *asg, unsigned mask)
         testFail("testAccess(ASG:%s, ID:%s, METHOD:%s, AUTHORITY:%s, HOST:%s, PROTOCOL:%s, ASL:%d) -> asAddMember error: %s",
                  asg, asUser, asMethod?asMethod:"", asAuthority?formattedCertAuthChain:"", asHost, protocol ? "true":"false", asAsl, errSymMsg(ret));
     } else {
-        ret = asAddClientIdentity(&client, asp, asAsl, (ASIDENTITY){ .user = asUser, .host = asHost, .method = asMethod, .authority = asAuthority, .protocol = protocol });
+        ASIDENTITY id;
+        id.user = asUser;
+        id.host = asHost;
+        id.method = asMethod;
+        id.authority = asAuthority;
+        id.protocol = protocol;
+        ret = asAddClientIdentity(&client, asp, asAsl, id);
     }
     if(ret) {
         testFail("testAccess(ASG:%s, ID:%s, METHOD:%s, AUTHORITY:%s, HOST:%s, PROTOCOL:%s, ASL:%d) -> asAddClient error: %s",

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -7,6 +7,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <testMain.h>
 #include <epicsUnitTest.h>
@@ -18,8 +19,15 @@
 
 #include <asLib.h>
 
+// The maximum number of links in a chain of authority we will provide in test data.  Increase as needed
+#define MAX_CERT_AUTH_CHAIN_LENGTH 10
+
+// For tests these are the values of the client that are being tested against the given Access Security Group
 static char *asUser,
-            *asHost;
+            *asHost,
+            *asMethod,
+            *asAuthority;
+static enum AsProtocol protocol=AS_PROTOCOL_TCP;
 static int asAsl;
 
 /**
@@ -32,20 +40,428 @@ static const char hostname_config[] = ""
     "HAG(foo) {localhost}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n"
 
     "ASG(rw) {\n"
-    "    RULE(1, WRITE) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(1, WRITE) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
+    "}\n";
+
+/**
+ * @brief Test data with METHOD, AUTHORITY, and PROTOCOL Access Security Group configurations
+ *
+ * This is a test case for `METHOD`, `AUTHORITY`, and `PROTOCOL` Access Security Group configurations.
+ * It includes an Access Security Group (ASG) that is configured to allow access
+ * to PV resources controlled by `METHOD` and `AUTHORITY` constraints.
+ * It also showcases the use of `PROTOCOL` to specify constraints based on the transport layer security used.
+ * It also includes an example of the `RPC` permission type for the `rwx` rule.
+ */
+static const char method_auth_config[] = ""
+    "UAG(bar) {boss}\n"
+    "UAG(foo) {testing}\n"
+    "UAG(ops) {geek}\n"
+
+    "AUTHORITY(AUTH_EPICS_ROOT, \"EPICS Org Root CA\") {\n"
+    "	AUTHORITY(AUTH_INTERMEDIATE_CA, \"Intermediate CA\") {\n"
+    "		AUTHORITY(AUTH_ORNL_CA, \"ORNL Org CA\")\n"
+    "	}\n"
+    "	AUTHORITY(AUTH_UNRELATED_CA, \"Unrelated CA\")\n"
+    "}\n"
+
+    "ASG(DEFAULT) {\n"
+    "	RULE(0, NONE)\n"
+    "}\n"
+
+    "ASG(ro) {\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		UAG(foo,ops)\n"
+    "		METHOD(\"ca\")\n"
+    "		PROTOCOL(\"TCP\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(rw) {\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, WRITE, TRAPWRITE) {\n"
+    "		UAG(foo)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_UNRELATED_CA)\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(rwx) {\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, RPC) {\n"
+    "		UAG(bar)\n"
+    "		METHOD(\"x509\",\"ignored\",\"ignored_too\")\n"
+    "		AUTHORITY(AUTH_UNRELATED_CA, AUTH_ORNL_CA)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n";
+
+/**
+ * Defines the expected output of asDumpFP() for the `method_auth_config` test case.
+ *
+ * This should be a direct copy of the `method_auth_config` string except that
+ * all spaces in string lists are removed, and the default RULE flag (`NOTRAPWRITE`) is
+ * added when it is not present in the original string.
+ */
+static const char *expected_method_auth_config =
+    "UAG(bar) {boss}\n"
+    "UAG(foo) {testing}\n"
+    "UAG(ops) {geek}\n"
+
+    "AUTHORITY(AUTH_EPICS_ROOT: EPICS Org Root CA)\n"
+    "AUTHORITY(AUTH_INTERMEDIATE_CA: EPICS Org Root CA -> Intermediate CA)\n"
+    "AUTHORITY(AUTH_ORNL_CA: EPICS Org Root CA -> Intermediate CA -> ORNL Org CA)\n"
+    "AUTHORITY(AUTH_UNRELATED_CA: EPICS Org Root CA -> Unrelated CA)\n"
+
+    "ASG(DEFAULT) {\n"
+    "	RULE(0,NONE,NOTRAPWRITE)\n"
+    "}\n"
+
+    "ASG(ro) {\n"
+    "	RULE(0,NONE,NOTRAPWRITE)\n"
+    "	RULE(1,READ,NOTRAPWRITE) {\n"
+    "		UAG(foo,ops)\n"
+    "		METHOD(\"ca\")\n"
+    "		PROTOCOL(\"tcp\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(rw) {\n"
+    "	RULE(0,NONE,NOTRAPWRITE)\n"
+    "	RULE(1,WRITE,TRAPWRITE) {\n"
+    "		UAG(foo)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_UNRELATED_CA)\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(rwx) {\n"
+    "	RULE(0,NONE,NOTRAPWRITE)\n"
+    "	RULE(1,RPC,NOTRAPWRITE) {\n"
+    "		UAG(bar)\n"
+    "		METHOD(\"x509\",\"ignored\",\"ignored_too\")\n"
+    "		AUTHORITY(AUTH_UNRELATED_CA,AUTH_ORNL_CA)\n"
+    "		PROTOCOL(\"tls\")\n"
+    "	}\n"
+    "}\n";
+
+/**
+ * Defines the expected output of asDumpRulesFP() for the `DEFAULT` Access Security Group.
+ *
+ * This should be a direct copy of the `method_auth_config` DEFAULT ASG string except that
+ * all spaces in string lists are removed, and the default RULE flag (`NOTRAPWRITE`) is
+ * added when it is not present in the original string.
+ */
+static const char *expected_DEFAULT_rules_config =
+    "ASG(DEFAULT) {\n"
+    "	RULE(0,NONE,NOTRAPWRITE)\n"
+    "}\n";
+
+/**
+ * Defines the expected output of asDumpRulesFP() for the `ro` Access Security Group.
+ *
+ * This should be a direct copy of the `method_auth_config` ro ASG string except that
+ * all spaces in string lists are removed, and the default RULE flag (`NOTRAPWRITE`) is
+ * added when it is not present in the original string.
+ */
+static const char *expected_ro_rules_config =
+    "ASG(ro) {\n"
+    "	RULE(0,NONE,NOTRAPWRITE)\n"
+    "	RULE(1,READ,NOTRAPWRITE) {\n"
+    "		UAG(foo,ops)\n"
+    "		METHOD(\"ca\")\n"
+    "		PROTOCOL(\"tcp\")\n"
+    "	}\n"
+    "}\n";
+
+/**
+ * Defines the expected output of asDumpRulesFP() for the `rw` Access Security Group.
+ *
+ * This should be a direct copy of the `method_auth_config` rw ASG string except that
+ * all spaces in string lists are removed, and the default RULE flag (`NOTRAPWRITE`) is
+ * added when it is not present in the original string.
+ */
+static const char *expected_rw_rules_config =
+    "ASG(rw) {\n"
+    "	RULE(0,NONE,NOTRAPWRITE)\n"
+    "	RULE(1,WRITE,TRAPWRITE) {\n"
+    "		UAG(foo)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_UNRELATED_CA)\n"
+    "	}\n"
+    "}\n";
+
+/**
+ * Defines the expected output of asDumpRulesFP() for the `rwx` Access Security Group.
+ *
+ * This should be a direct copy of the `method_auth_config` rwx ASG string except that
+ * all spaces in string lists are removed, and the default RULE flag (`NOTRAPWRITE`) is
+ * added when it is not present in the original string.
+ */
+static const char *expected_rwx_rules_config =
+    "ASG(rwx) {\n"
+    "	RULE(0,NONE,NOTRAPWRITE)\n"
+    "	RULE(1,RPC,NOTRAPWRITE) {\n"
+    "		UAG(bar)\n"
+    "		METHOD(\"x509\",\"ignored\",\"ignored_too\")\n"
+    "		AUTHORITY(AUTH_UNRELATED_CA,AUTH_ORNL_CA)\n"
+    "		PROTOCOL(\"tls\")\n"
+    "	}\n"
+    "}\n";
+
+/**
+ * @brief Test data for validating hierarchical certificate-based access control.
+ *
+ * @details
+ * This test dataset validates the delegation of authority and inheritance in certificate chains by modeling
+ * Oak Ridge National Laboratory's (ORNL) facilities and organizational structure. The test validates:
+ *
+ * 1. Hierarchical Certificate Authority chains:
+ *    - Certificate Authorities can delegate trust by signing intermediate Certificate Authorities
+ *    - Client certificates inherit trust from their entire signing chain
+ *    - Multiple independent Certificate Authority hierarchies can coexist (e.g., ORNL Root vs ORNL IT Root)
+ *
+ * 2. Fine-grained access control:
+ *    - Role-based access through User Access Groups (UAGs)
+ *    - Facility-specific device grouping and permissions
+ *    - Separation of admin, operations and user privileges
+ *
+ * The test extends EPICS Access Control File (ACF) syntax with PKI concepts:
+ *
+ * - @b METHOD: The authentication mechanism (e.g., "x509") required by a RULE
+ * - @b AUTHORITY: The Certificate Authority(s) accepted by a RULE. Matches if client's chain contains any listed Certificate Authority
+ * - @b PROTOCOL: Required transport security (e.g., "TLS") for the RULE
+ *
+ * Organization & Certificate Structure:
+ *
+ * Laboratory Level:
+ *   ORNL Root CA (signs facility CAs)
+ *   ORNL IT Root CA (signs user certificates)
+ *   --> ORNL User CA (issues all user certificates)
+ *
+ * Spallation Neutron Source (SNS):
+ *   SNS Intermediate CA
+ *   --> SNS Control Systems CA (issues controls system device certs)
+ *   --> SNS Beamline Operations CA (issues beamline equipment certs)
+ *   Groups: Controls, Beamline Operations
+ *   Roles per group: Admins, Operators, Users, Devices
+ *
+ * High Flux Isotope Reactor (HFIR):
+ *   HFIR Intermediate CA
+ *   --> HFIR Control Systems CA (issues reactor control system certs)
+ *   --> HFIR Sample Environment CA (issues sample environment equipment certs)
+ *   Groups: Controls, Sample Environment
+ *   Roles per group: Admins, Operators, Users, Devices
+ *
+ * The test data includes:
+ * - Complete Certificate Authority hierarchies for ORNL, SNS and HFIR
+ * - User Access Groups for each facility/group/role combination
+ * - Access Security Groups with rules validating:
+ *   - Role-based access (admin vs operator vs user)
+ *   - Certificate chain validation
+ *   - Transport security requirements
+ *   - Future-proofing support (GROUP keyword ignored)
+ *
+ * All human users have certificates issued by the ORNL User CA, while devices
+ * have certificates from their respective facility CAs. This enforces proper
+ * separation between user authentication and device authorization.
+ */
+static const char chained_auth_config[] = ""
+    // Authority chain containing SNS and HIFR Certificate Authorities
+    "AUTHORITY(AUTH_ORNL_ROOT, \"ORNL Root CA\") {\n"
+    "	AUTHORITY(\"SNS Intermediate CA\") {\n"
+    "		AUTHORITY(AUTH_SNS_CTRL, \"SNS Control Systems CA\")\n"
+    "		AUTHORITY(AUTH_BEAMLINE, \"SNS Beamline Operations CA\")\n"
+    "   }\n"
+    "	AUTHORITY(\"HFIR Intermediate CA\") {\n"
+    "		AUTHORITY(AUTH_HIFR_CTRL, \"HFIR Control Systems CA\")\n"
+    "		AUTHORITY(AUTH_HIFR_SAMPLE, \"HFIR Sample Environment CA\")\n"
+    "   }\n"
+    "}\n"
+
+    // Authority chain containing ORNL IT User Certificate Authorities
+    "AUTHORITY(AUTH_ORNL_IT_ROOT, \"ORNL IT Root CA\") {\n"
+    "	AUTHORITY(AUTH_ORNL_USERS, \"ORNL User Certificate Authority\")\n"
+    "}\n"
+
+    "UAG(ORNL:ADMINS) {s.streiffer}\n"
+
+    "UAG(SNS:ADMINS) {s.streiffer}\n"
+    "UAG(SNS:CTRL:ADMINS) {v.fanelli}\n"
+    "UAG(SNS:CTRL:OPS) {v.fanelli, ann.op}\n"
+    "UAG(SNS:CTRL:USERS) {v.fanelli, w.blower, x.windman, y.gale}\n"
+    "UAG(SNS:CTRL:DEVICES) {SNS:CTRL:IOC:VAC01, SNS:CTRL:IOC:MOT02, SNS:CTRL:IOC:TEMP03, SNS:CTRL:IOC:PWR04}\n"
+    "UAG(SNS:BEAM:ADMINS) {f.pilat}\n"
+    "UAG(SNS:BEAM:OPS) {f.pilat, bee.op}\n"
+    "UAG(SNS:BEAM:USERS) {f.pilat, g.squat, h.lunge, i.press}\n"
+    "UAG(SNS:BEAM:DEVICES) {SNS:BEAM:IOC:DET01, SNS:BEAM:IOC:COLL02, SNS:BEAM:IOC:CHOP03, SNS:BEAM:IOC:MON04}\n"
+
+    "UAG(HFIR:ADMINS) {s.streiffer}\n"
+    "UAG(HFIR:CTRL:ADMINS) {b.weston}\n"
+    "UAG(HFIR:CTRL:OPS) {b.weston, cee.op}\n"
+    "UAG(HFIR:CTRL:USERS) {b.weston, c.north, d.southerly, e.eastman}\n"
+    "UAG(HFIR:CTRL:DEVICES) {HFIR:CTRL:IOC:REACT01, HFIR:CTRL:IOC:COOL02, HFIR:CTRL:IOC:SHLD03}\n"
+    "UAG(HFIR:ENV:ADMINS) {g.lynn}\n"
+    "UAG(HFIR:ENV:OPS) {g.lynn, dee.op}\n"
+    "UAG(HFIR:ENV:USERS) {g.lynn, h.overman, i.bachman}\n"
+    "UAG(HFIR:ENV:DEVICES) {HFIR:ENV:IOC:TEMP01, HFIR:ENV:IOC:MAG02}\n"
+
+    // Try out GROUP syntax: will be ignored by future proofing functionality
+    "GROUP(PHYSICS_GROUP) {physics}\n"
+
+    "ASG(DEFAULT) {\n"
+    "	RULE(0, NONE)\n"
+    "}\n"
+
+    "ASG(PHYSICS) {\n"
+    // ORNL Physics Users: To try out GROUPS syntax: ignored due to future proofing
+    "	RULE(0, WRITE, TRAPWRITE) {\n"
+    "		GROUP(PHYSICS_GROUP)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_IT_ROOT)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(ADMIN) {\n"
+    // ORNL Admin Users
+    "	RULE(0, WRITE, TRAPWRITE) {\n"
+    "		UAG(ORNL:ADMINS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_IT_ROOT)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(SNS:ADMIN) {\n"
+    // SNS Admin Users
+    "	RULE(0, WRITE, TRAPWRITE) {\n"
+    "		UAG(SNS:ADMINS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_IT_ROOT)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(SNS:CTRL:ADMIN) {\n"
+    // SNS Controls Admin Users
+    "	RULE(0, WRITE, TRAPWRITE) {\n"
+    "		UAG(SNS:CTRL:ADMINS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_USERS)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(SNS:CONTROLS) {\n"
+    // SNS Controls Users
+    "	RULE(0, READ) {\n"
+    "		UAG(SNS:CTRL:USERS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_USERS)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    // SNS Controls Operators and Devices
+    "	RULE(1, WRITE, TRAPWRITE) {\n"
+    "		UAG(SNS:CTRL:OPS, SNS:CTRL:DEVICES)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_USERS, AUTH_SNS_CTRL)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(SNS:BEAMLINE) {\n"
+    // SNS Beamline Users
+    "	RULE(0, READ) {\n"
+    "		UAG(SNS:BEAM:USERS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_USERS)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    // SNS Beamline Operators and Devices
+    "	RULE(1, WRITE, TRAPWRITE) {\n"
+    "		UAG(SNS:BEAM:OPS, SNS:BEAM:DEVICES)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_USERS, AUTH_BEAMLINE)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(HFIR:ADMIN) {\n"
+    // HIFR Admin Users
+    "	RULE(0, WRITE, TRAPWRITE) {\n"
+    "		UAG(HFIR:ADMINS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_IT_ROOT)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(HFIR:CTRL:ADMIN) {\n"
+    // HIFR Controls Admin Users
+    "	RULE(0, WRITE, TRAPWRITE) {\n"
+    "		UAG(HFIR:CTRL:ADMINS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_USERS)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(HFIR:CONTROLS) {\n"
+    // HIFR Controls Users
+    "	RULE(0, READ) {\n"
+    "		UAG(HFIR:CTRL:USERS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_USERS)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    // HIFR Controls Operators and Devices
+    "	RULE(1, WRITE, TRAPWRITE) {\n"
+    "		UAG(HFIR:CTRL:OPS, HFIR:CTRL:DEVICES)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_HIFR_CTRL,AUTH_ORNL_USERS)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(HFIR:ENV:ADMIN) {\n"
+    // HIFR Sample Environment Admin Users
+    "	RULE(0, WRITE, TRAPWRITE) {\n"
+    "		UAG(HFIR:ENV:ADMINS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_USERS)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    "}\n"
+
+    "ASG(HFIR:ENVIRONMENT) {\n"
+    "	RULE(0, READ) {\n"
+    // HIFR Sample Environment Users
+    "		UAG(HFIR:ENV:USERS)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_ORNL_USERS)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
+    // HIFR Sample Environment Operators and Devices
+    "	RULE(1, WRITE, TRAPWRITE) {\n"
+    "		UAG(HFIR:ENV:OPS, HFIR:ENV:DEVICES)\n"
+    "		METHOD(\"x509\")\n"
+    "		AUTHORITY(AUTH_HIFR_SAMPLE,AUTH_ORNL_USERS)\n"
+    "		PROTOCOL(\"TLS\")\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -61,14 +477,14 @@ static const char supported_config_1[] = ""
     "GENERIC(WELL, FORMED, ARG, LIST)\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -82,18 +498,18 @@ static const char supported_config_2[] = ""
     "HAG(foo) {localhost}\n"
 
     "SIMPLE(WELL, FORMED, ARG, LIST) {\n"
-    "    WELL, FORMED, LIST\n"
+    "	WELL, FORMED, LIST\n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -108,19 +524,18 @@ static const char supported_config_3[] = ""
     "HAG(foo) {localhost}\n"
 
     "COMPLEX_ARGUMENTS(1, WELL, \"FORMED\", ARG, LIST) {\n"
-    "    ALSO_GENERIC(WELL, FORMED, ARG, LIST, 2.0) \n"
-    "    RULE(WELL, FORMED, ARG, LIST, 2.0) \n"
+    "	ALSO_GENERIC(WELL, FORMED, ARG, LIST, 2.0) \n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -132,27 +547,27 @@ static const char supported_config_3[] = ""
  * - includes floating point numbers, and an empty arg list
  */
 static const char supported_config_4[] = ""
-"HAG(foo) {localhost}\n"
+    "HAG(foo) {localhost}\n"
 
-"SUB_BLOCKS(1.0, ARGS) {\n"
-"    ALSO_GENERIC() {\n"
-"        AND_LIST_BODY\n"
-"    }\n"
-"    RULE() {\n"
-"        BIGGER, LIST, BODY\n"
-"    }\n"
-"}\n"
+    "SUB_BLOCKS(1.0, ARGS) {\n"
+    "	ALSO_GENERIC() {\n"
+    "		AND_LIST_BODY\n"
+    "	}\n"
+    "	ANOTHER_GENERIC() {\n"
+    "		BIGGER, LIST, BODY\n"
+    "	}\n"
+    "}\n"
 
-"ASG(DEFAULT) {\n"
-"    RULE(0, NONE)\n"
-"}\n"
+    "ASG(DEFAULT) {\n"
+    "	RULE(0, NONE)\n"
+    "}\n"
 
-"ASG(ro) {\n"
-"    RULE(0, NONE)\n"
-"    RULE(1, READ) {\n"
-"        HAG(foo)\n"
-"    }\n"
-"}\n";
+    "ASG(ro) {\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
+    "}\n";
 
 /**
  * Test data with unsupported elements.
@@ -166,22 +581,22 @@ static const char supported_config_5[] = ""
     "HAG(foo) {localhost}\n"
 
     "RECURSIVE_SUB_BLOCKS(1.0, -2.3, +4.5, ARGS, +2.71828E-23, -2.71828e+23, +12, -13, +-14) {\n"
-    "    ALSO_GENERIC() {\n"
-    "        AND_RECURSIVE(FOO) {\n"
-    "            LIST, BODY\n"
-    "        }\n"
-    "    }\n"
+    "	ALSO_GENERIC() {\n"
+    "		AND_RECURSIVE(FOO) {\n"
+    "			LIST, BODY\n"
+    "		}\n"
+    "	}\n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(+1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(+1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -196,31 +611,31 @@ static const char supported_config_6[] = ""
     "HAG(foo) {localhost}\n"
 
     "WITH_KEYWORDS(UAG) {\n"
-    "    ASG(HAL, IMP, CALC, RULE)\n"
-    "    HAL(USG, MAL) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	ASG(HAL, IMP, CALC, RULE)\n"
+    "	HAL(USG, METHOD) {\n"
+    "		PROTOCOL(\"TLS\", AUTHORITY)\n"
+    "	}\n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ignored) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        WITH_KEYWORDS(UAG)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		WITH_KEYWORDS(UAG)\n"
+    "	}\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
-    "    RULE(2, WRITE) {\n"
-    "        WITH_KEYWORDS(UAG)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
+    "	RULE(2, WRITE) {\n"
+    "		WITH_KEYWORDS(UAG)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -234,16 +649,16 @@ static const char supported_config_7[] = ""
     "HAG(foo) {localhost}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "        BAD_PREDICATE(\"x509\")\n"
-    "        BAD_PREDICATE_AS_WELL(\"EPICS Certificate Authority\")\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "		BAD_PREDICATE(\"x509\")\n"
+    "		BAD_PREDICATE_AS_WELL(\"EPICS Certificate Authority\")\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -254,19 +669,42 @@ static const char supported_config_7[] = ""
  * - unexpected permission name in arg list for RULE element ignored
  */
 static const char supported_config_8[] = ""
-        "HAG(foo) {localhost}\n"
+    "HAG(foo) {localhost}\n"
 
-        "ASG(DEFAULT) {\n"
-        "    RULE(0, NONE)\n"
-        "}\n"
+    "ASG(DEFAULT) {\n"
+    "	RULE(0, NONE)\n"
+    "}\n"
 
-        "ASG(ro) {\n"
-        "    RULE(0, NONE)\n"
-        "    RULE(1, ADDITIONAL_PERMISSION) {\n"
-        "        HAG(foo)\n"
-        "    }\n"
-        "}\n"
-        ;
+    "ASG(ro) {\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, ADDITIONAL_PERMISSION) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
+    "}\n"
+    ;
+
+/**
+ * Test data with unsupported elements.
+ * The unsupported elements should be silently ignored, and the rule will not match,
+ * but the rest of the config is processed.
+ *
+ * - RULE containing unexpected protocol name ignored
+ */
+static const char supported_config_9[] = ""
+    "HAG(foo) {localhost}\n"
+
+    "ASG(DEFAULT) {\n"
+    "	RULE(0, NONE)\n"
+    "}\n"
+
+    "ASG(ro) {\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, WRITE) {\n"
+    "		HAG(foo)\n"
+    "		PROTOCOL(UNKNOWN_PROTOCOL)\n"
+    "	}\n"
+    "}\n"
+    ;
 
 /**
  * Test data with unsupported elements.
@@ -281,14 +719,14 @@ static const char unsupported_config_1[] = ""
     "GENERIC(not well-formed arg list)\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -302,18 +740,18 @@ static const char unsupported_config_2[] = ""
     "HAG(foo) {localhost}\n"
 
     "GENERIC(WELL, FORMED, ARG, LIST) {\n"
-    "    NOT WELL-FORMED BODY\n"
+    "	NOT WELL-FORMED BODY\n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -327,18 +765,18 @@ static const char unsupported_config_3[] = ""
     "HAG(foo) {localhost}\n"
 
     "GENERIC {\n"
-    "    WELL, FORMED, LIST, BODY\n"
+    "	WELL, FORMED, LIST, BODY\n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -352,18 +790,18 @@ static const char unsupported_config_4[] = ""
     "HAG(foo) {localhost}\n"
 
     "GENERIC(WELL, FORMED, ARG, LIST) {\n"
-    "    BODY(BAD ARG LIST)\n"
+    "	BODY(BAD ARG LIST)\n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -377,19 +815,19 @@ static const char unsupported_config_5[] = ""
     "HAG(foo) {localhost}\n"
 
     "GENERIC(WELL, FORMED, ARG, LIST) {\n"
-    "    LIST, BODY, MIXED, WITH,\n"
-    "    RECURSIVE_BODY(ARG, LIST)\n"
+    "	LIST, BODY, MIXED, WITH,\n"
+    "	RECURSIVE_BODY(ARG, LIST)\n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -401,14 +839,14 @@ static const char unsupported_mod_1[] = ""
     "HAG(foo) {localhost}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro BAD ARG LIST) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -420,14 +858,14 @@ static const char unsupported_mod_2[] = ""
     "HAG(BAD ARG LIST) {localhost}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -439,14 +877,14 @@ static const char unsupported_mod_3[] = ""
     "HAG(foo) {localhost}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0 BAD ARG LIST)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0 BAD ARG LIST)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -458,14 +896,14 @@ static const char unsupported_mod_4[] = ""
     "HAG(foo) {localhost}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro, UNKNOWN_PERMISSION) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -477,14 +915,14 @@ static const char unsupported_mod_5[] = ""
     "HAG(foo) {localhost}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE, UNKNOWN_FLAG)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE, UNKNOWN_FLAG)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -494,19 +932,19 @@ static const char unsupported_mod_5[] = ""
  */
 static const char unsupported_mod_6[] = ""
     "HAG(foo) {\n"
-    "    localhost,\n"
-    "    NETWORK(\"127.0.0.1\")\n"
+    "	localhost,\n"
+    "	NETWORK(\"127.0.0.1\")\n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -516,19 +954,19 @@ static const char unsupported_mod_6[] = ""
  */
 static const char unsupported_mod_7[] = ""
     "UAG(foo) {\n"
-    "    alice,\n"
-    "    GROUP(admin)\n"
+    "	alice,\n"
+    "	GROUP(admin)\n"
     "}\n"
 
     "ASG(DEFAULT) {\n"
-    "    RULE(0, NONE)\n"
+    "	RULE(0, NONE)\n"
     "}\n"
 
     "ASG(ro) {\n"
-    "    RULE(0, NONE)\n"
-    "    RULE(1, READ) {\n"
-    "        HAG(foo)\n"
-    "    }\n"
+    "	RULE(0, NONE)\n"
+    "	RULE(1, READ) {\n"
+    "		HAG(foo)\n"
+    "	}\n"
     "}\n";
 
 /**
@@ -549,6 +987,78 @@ static void setHost(const char *name)
     asHost = epicsStrDup(name);
 }
 
+static void setMethod(const char *name)
+{
+    free(asMethod);
+    asMethod = epicsStrDup(name);
+}
+
+static void setAuthority(const char *name)
+{
+    free(asAuthority);
+    asAuthority = epicsStrDup(name);
+}
+
+static void setProtocol(enum AsProtocol the_protocol)
+{
+    protocol = the_protocol;
+}
+
+/**
+ * @brief Converts a newline-delimited certificate authority chain into a printable string.
+ *
+ * @details
+ * This function takes the global variable `asAuthority`, which contains a newline-delimited
+ * list of certificate authorities ordered from signer to signee (i.e., root CA first,
+ * issuer CA last), and converts it into a single-line, human-readable string
+ *
+ * The resulting format resembles:
+ *   "Root Certificate Authority -> Intermediate CA -> Issuer CA"
+ *
+ * This makes the chain easier to read from trust anchor down to the end-entity.
+ *
+ * - If `asAuthority` is empty or NULL, the output buffer is set to an empty string.
+ * - The result is written into `parsedCertAuthChainBuf` and truncated to `MAX_AUTH_CHAIN_STRING` bytes.
+ * - Up to MAX_CERT_AUTH_CHAIN_LENGTH authority entries are supported in the chain.
+ *
+ * @param[out] parsedCertAuthChainBuf Buffer to receive the formatted authority chain string.
+ */
+static void parseCertAuthChain(char *parsedCertAuthChainBuf) {
+    if (asAuthority) {
+        parsedCertAuthChainBuf[0] = '\0';
+        char *p = parsedCertAuthChainBuf;
+
+        char unParsedAuthority[MAX_AUTH_CHAIN_STRING];
+        strncpy(unParsedAuthority, asAuthority, sizeof(unParsedAuthority));
+        unParsedAuthority[sizeof(unParsedAuthority) - 1] = '\0';
+
+        const char *token = strtok(unParsedAuthority, "\n");
+        if (token) {
+            size_t len = 0;
+            size_t remainingSpace = MAX_AUTH_CHAIN_STRING;
+            len = strlen(token);
+            if (len < remainingSpace) {
+                strcpy(p, token);
+                p += len;
+                remainingSpace -= len;
+
+                while (((token = strtok(NULL, "\n"))) && remainingSpace > 4) {
+                    len = strlen(token);
+                    if (len + 4 < remainingSpace) {
+                        strcpy(p, " -> ");
+                        p += 4;
+                        strcpy(p, token);
+                        p += len;
+                        remainingSpace -= (len + 4);
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
 /**
  * Test the access control system with the given ASG, user, and hostname
  * This will test that the expected access given by mask is granted
@@ -559,24 +1069,27 @@ static void testAccess(const char *asg, unsigned mask)
 {
     ASMEMBERPVT asp = 0; /* aka dbCommon::asp */
     ASCLIENTPVT client = 0;
-    long ret;
 
-    ret = asAddMember(&asp, asg);
+    static __thread char formattedCertAuthChain[MAX_AUTH_CHAIN_STRING];
+    parseCertAuthChain(&formattedCertAuthChain[0]);
+
+    long ret = asAddMember(&asp, asg);
     if(ret) {
-        testFail("testAccess(ASG:%s, USER:%s, HOST:%s, ASL:%d) -> asAddMember error: %s",
-                 asg, asUser, asHost, asAsl, errSymMsg(ret));
+        testFail("testAccess(ASG:%s, ID:%s, METHOD:%s, AUTHORITY:%s, HOST:%s, PROTOCOL:%s, ASL:%d) -> asAddMember error: %s",
+                 asg, asUser, asMethod?asMethod:"", asAuthority?formattedCertAuthChain:"", asHost, protocol ? "true":"false", asAsl, errSymMsg(ret));
     } else {
-        ret = asAddClient(&client, asp, asAsl, asUser, asHost);
+        ret = asAddClientIdentity(&client, asp, asAsl, (ASIDENTITY){ .user = asUser, .host = asHost, .method = asMethod, .authority = asAuthority, .protocol = protocol });
     }
     if(ret) {
-        testFail("testAccess(ASG:%s, USER:%s, HOST:%s, ASL:%d) -> asAddClient error: %s",
-                 asg, asUser, asHost, asAsl, errSymMsg(ret));
+        testFail("testAccess(ASG:%s, ID:%s, METHOD:%s, AUTHORITY:%s, HOST:%s, PROTOCOL:%s, ASL:%d) -> asAddClient error: %s",
+                 asg, asUser, asMethod?asMethod:"", asAuthority?formattedCertAuthChain:"", asHost, protocol ? "true":"false", asAsl, errSymMsg(ret));
     } else {
         unsigned actual = 0;
         actual |= asCheckGet(client) ? 1 : 0;
         actual |= asCheckPut(client) ? 2 : 0;
-        testOk(actual==mask, "testAccess(ASG:%s, USER:%s, HOST:%s, ASL:%d) -> %x == %x",
-               asg, asUser, asHost, asAsl, actual, mask);
+        actual |= asCheckRPC(client) ? 4 : 0;
+        testOk(actual==mask, "testAccess(ASG:%s, ID:%s, METHOD:%s, AUTHORITY:%s, HOST:%s, PROTOCOL:%s, ASL:%d) -> %x == %x",
+               asg, asUser, asMethod?asMethod:"", asAuthority?formattedCertAuthChain:"", asHost, protocol ? "true":"false", asAsl, actual, mask);
     }
     if(client) asRemoveClient(&client);
     if(asp) asRemoveMember(&asp);
@@ -585,6 +1098,12 @@ static void testAccess(const char *asg, unsigned mask)
 static void testSyntaxErrors(void)
 {
     static const char empty[] = "\n#almost empty file\n\n";
+    static const char duplicateMethod[] = "\nASG(foo) {RULE(0, NONE) {METHOD   (\"x509\"		)  METHOD   (\"x509\"		)}}\n\n";
+    static const char duplicateAuthority[] = "\nASG(foo) {RULE(0, NONE) {AUTHORITY(\"Epics Org Root CA\")  AUTHORITY(\"Epics Org Root CA\")}}\n\n";
+    static const char notDuplicateMethod[] = "\nASG(foo) {RULE(0, NONE) {METHOD   (\"x509\"		)} RULE(1, RPC			) {METHOD   (\"x509\"		)}}\n\n";
+    static const char notDuplicateAuthority[] = "\nASG(foo) {RULE(0, NONE) {AUTHORITY(\"Epics Org Root CA\")} RULE(1, WRITE,TRAPWRITE) {AUTHORITY(\"Epics Org Root CA\")}}\n\n";
+    static const char anotherNotDuplicatedMethod[] = "\nASG(foo) {RULE(0, NONE) {METHOD   (\"x509\"		)  METHOD   (\"ca\"		  )}}\n\n";
+    static const char anotherNotDuplicatedAuthority[] = "\nASG(foo) {RULE(0, NONE) {AUTHORITY(\"Epics Org Root CA\")  AUTHORITY(\"ORNL CA\"	 )}}\n\n";
     long ret;
 
     testDiag("testSyntaxErrors()");
@@ -593,6 +1112,25 @@ static void testSyntaxErrors(void)
     eltc(0);
     ret = asInitMem(empty, NULL);
     testOk(ret==S_asLib_badConfig, "load \"empty\" config -> %s", errSymMsg(ret));
+
+    ret = asInitMem(duplicateMethod, NULL);
+    testOk(ret==S_asLib_badConfig, "load \"duplicate method rule\" config -> %s", errSymMsg(ret));
+
+    ret = asInitMem(duplicateAuthority, NULL);
+    testOk(ret==S_asLib_badConfig, "load \"duplicate authority rule\" config -> %s", errSymMsg(ret));
+
+    ret = asInitMem(notDuplicateMethod, NULL);
+    testOk(ret==0, "load non \"duplicate method rule\" config -> %s", errSymMsg(ret));
+
+    ret = asInitMem(notDuplicateAuthority, NULL);
+    testOk(ret==0, "load non \"duplicate authority rule\" config -> %s", errSymMsg(ret));
+
+    ret = asInitMem(anotherNotDuplicatedMethod, NULL);
+    testOk(ret==0, "load another non \"duplicate method rule\" config -> %s", errSymMsg(ret));
+
+    ret = asInitMem(anotherNotDuplicatedAuthority, NULL);
+    testOk(ret==0, "load another non \"duplicate authority rule\" config -> %s", errSymMsg(ret));
+
     eltc(1);
 }
 
@@ -779,15 +1317,440 @@ static void testFutureProofParser(void)
         testAccess("DEFAULT", 0);
         testAccess("ro", 0);
     }
+
+    ret = asInitMem(supported_config_9, NULL);
+    testOk(ret==0, "rules with unknown protocol names ignored -> %s", errSymMsg(ret));
+    if (!ret) {
+        asAsl = 0;
+        testAccess("DEFAULT", 0);
+        testAccess("ro", 0);
+    }
+}
+
+static void testMethodAndAuth(void)
+{
+    testDiag("testMethodAndAuth()");
+    asCheckClientIP = 0;
+
+    testOk1(asInitMem(method_auth_config, NULL)==0);
+
+    asAsl = 0;
+    testAccess("DEFAULT", 0);
+
+    setHost("localhost"); // Not specified in test rules
+    setUser("boss");
+    setMethod("ca");
+
+    testAccess("ro", 0);
+    testAccess("rw", 0);
+    testAccess("rwx", 0);
+
+    setUser("testing");
+
+    testAccess("ro", 1);
+    testAccess("rw", 0);
+    testAccess("rwx", 0);
+
+    setMethod("x509");
+    setAuthority(
+        "EPICS Org Root CA"
+        );
+
+    testAccess("ro", 0);
+    testAccess("rw", 0);
+    testAccess("rwx", 0);
+
+    setAuthority(
+        "EPICS Org Root CA\n"
+        "Unrelated CA"
+        );
+    setProtocol(AS_PROTOCOL_TLS);
+
+    testAccess("ro", 0);
+    testAccess("rw", 3);
+    testAccess("rwx", 0);
+
+    setAuthority(
+        "EPICS Org Root CA\n"
+        "Intermediate CA\n"
+        "ORNL Org CA"
+        );
+    testAccess("ro", 0);
+    testAccess("rw", 0);
+
+    setUser("boss");
+    testAccess("rwx", 7);
+}
+
+/**
+ * @brief Tests Chains of Authority.
+ *
+ * @details
+ * Validates hierarchical certificate chains passed to the authorization system as newline-separated entries.
+ * The chain represents delegated authority, from the root CA down to the user's certificate.
+ *
+ * Inherited permission is supported: if a user holds a certificate from CA B, and CA B is signed by CA A,
+ * then the user implicitly satisfies rules requiring CA A, even if CA B is not explicitly listed.
+ *
+ * This test data models a fictional lab (ORNL), its light sources, and associated operational groups.
+ *
+ * Organizational Structure:
+ *   ORNL Lab - Stephen Streiffer: Laboratory Director
+ *   --> Spallation Neutron Source (SNS)
+ *       --> SNS Control Systems - Victor Fanelli: Group Leader
+ *       --> SNS Beamline Operations - Fulvia Pilat: Director of Research
+ *   --> High Flux Isotope Reactor (HFIR)
+ *       --> HFIR Control Systems - Brian Weston: Chief Operating Officer
+ *       --> HFIR Sample Environment - Gary Lynn: Section Head
+ *
+ * Certificate Authorities and certificates they manage:
+ *   ORNL Root CA
+ *   --> SNS Intermediate CA
+ *       --> SNS Control Systems CA
+ *           --> CERTIFICATE: Control System Devices
+ *       --> SNS Beamline Operations CA
+ *           --> CERTIFICATE: Beamline IOCs
+ *   --> HFIR Intermediate CA
+ *       --> HFIR Control Systems CA
+ *           --> CERTIFICATE: Control System Devices
+ *       --> HFIR Sample Environment CA
+ *           --> CERTIFICATE: Sample Env. IOCs
+ *   ORNL IT Root CA
+ *   --> ORNL User Certificate Authority
+ *       --> CERTIFICATE: ORNL Users
+ */
+static void testCertificateChains(void) {
+    testDiag("testCertificateChains()");
+    asCheckClientIP = 0;
+
+    testOk1(asInitMem(chained_auth_config, NULL)==0);
+
+    asAsl = 0;
+    setHost("localhost"); // Not specified in test rules
+    setMethod("x509");
+    setProtocol(AS_PROTOCOL_TLS);
+
+    // Laboratory Directorate and global admin
+    setUser("s.streiffer");
+    setAuthority(
+        "ORNL IT Root CA\n"
+        "ORNL User Certificate Authority"
+        );
+    testAccess("ADMIN", 3);
+
+    // Spallation Neutron Source
+    testAccess("SNS:ADMIN", 3);
+
+    // Spallation Neutron Source Controls Group
+    setUser("v.fanelli");
+    testAccess("SNS:ADMIN", 0);
+    testAccess("SNS:CTRL:ADMIN", 3);
+    testAccess("SNS:CONTROLS", 3);
+    setUser("ann.op");
+    testAccess("SNS:CONTROLS", 3);
+
+    setUser("w.blower");
+    testAccess("SNS:CONTROLS", 1);
+    setUser("x.windman");
+    testAccess("SNS:CONTROLS", 1);
+    setUser("y.gale");
+    testAccess("SNS:CONTROLS", 1);
+    setUser("g.squat");   // Wrong Group
+    testAccess("SNS:CONTROLS", 0);
+    setUser("h.lunge");   // Wrong Group
+    testAccess("SNS:CONTROLS", 0);
+    setUser("i.press");   // Wrong Group
+    testAccess("SNS:CONTROLS", 0);
+
+    // Spallation Neutron Source beamline operations
+    setUser("f.pilat");
+    testAccess("SNS:ADMIN", 0);
+    testAccess("SNS:BEAM:ADMIN", 0);  // No such security group
+    testAccess("SNS:BEAMLINE", 3);
+    setUser("bee.op");
+    testAccess("SNS:BEAMLINE", 3);
+
+    setUser("g.squat");
+    testAccess("SNS:BEAMLINE", 1);
+    setUser("h.lunge");
+    testAccess("SNS:BEAMLINE", 1);
+    setUser("i.press");
+    testAccess("SNS:BEAMLINE", 1);
+    setUser("w.blower");  // Wrong Group
+    testAccess("SNS:BEAMLINE", 0);
+    setUser("x.windman"); // Wrong Group
+    testAccess("SNS:BEAMLINE", 0);
+    setUser("y.gale");    // Wrong Group
+    testAccess("SNS:BEAMLINE", 0);
+
+    // Spallation Neutron Source Devices
+    setAuthority(
+        "ORNL Root CA\n"
+        "SNS Intermediate CA\n"
+        "SNS Control Systems CA"
+        );
+    setUser("SNS:CTRL:IOC:VAC01");
+    testAccess("SNS:CONTROLS", 3);
+    setUser("SNS:CTRL:IOC:MOT02");
+    testAccess("SNS:CONTROLS", 3);
+    setUser("SNS:CTRL:IOC:TEMP03");
+    testAccess("SNS:CONTROLS", 3);
+    setUser("SNS:CTRL:IOC:PWR04");
+    testAccess("SNS:CONTROLS", 3);
+
+    setUser("SNS:BEAM:IOC:DET01");
+    testAccess("SNS:BEAMLINE", 0); // Wrong CA chain
+    setAuthority(
+        "ORNL Root CA\n"
+        "SNS Intermediate CA"
+        );
+    testAccess("SNS:BEAMLINE", 0); // Incomplete CA
+    setAuthority( "" );
+    testAccess("SNS:BEAMLINE", 0); // No CA chain
+    setAuthority(
+        "ORNL Root CA\n"
+        "SNS Intermediate CA\n"
+        "SNS Beamline Operations CA\n"
+        "Sub CA"
+        );
+    testAccess("SNS:BEAMLINE", 3); // Unknown Leaf Certificate is ok
+    setAuthority(
+        "ORNL Root CA\n"
+        "SNS Intermediate CA\n"
+        "SNS Beamline Operations CA"
+        );
+    testAccess("SNS:BEAMLINE", 3);
+    setUser("SNS:BEAM:IOC:COLL02");
+    testAccess("SNS:BEAMLINE", 3);
+    setUser("SNS:BEAM:IOC:CHOP03");
+    testAccess("SNS:BEAMLINE", 3);
+    setUser("SNS:BEAM:IOC:MON04");
+    testAccess("SNS:BEAMLINE", 3);
+
+    // High-Flux Isotope Reactor
+    setUser("s.streiffer");
+    setAuthority(
+        "ORNL IT Root CA\n"
+        "ORNL User Certificate Authority"
+        );
+    testAccess("HFIR:ADMIN", 3);
+
+    // High-Flux Isotope Reactor Controls Group
+    setUser("b.weston");
+    testAccess("HFIR:ADMIN", 0);
+    testAccess("HFIR:CTRL:ADMIN", 3);
+    testAccess("HFIR:CONTROLS", 3);
+    setUser("cee.op");
+    testAccess("HFIR:CONTROLS", 3);
+
+    setUser("c.north");
+    testAccess("HFIR:CONTROLS", 1);
+    setUser("d.southerly");
+    testAccess("HFIR:CONTROLS", 1);
+    setUser("e.eastman");
+    testAccess("HFIR:CONTROLS", 1);
+    setUser("g.lynn");   // Wrong Group
+    testAccess("HFIR:CONTROLS", 0);
+    setUser("h.overman");   // Wrong Group
+    testAccess("HFIR:CONTROLS", 0);
+    setUser("i.bachman");   // Wrong Group
+    testAccess("HFIR:CONTROLS", 0);
+
+    // High-Flux Isotope Reactor Sample Environment operations
+    setUser("g.lynn");
+    testAccess("HFIR:ADMIN", 0);
+    testAccess("HFIR:ENV:ADMIN", 3);
+    testAccess("HFIR:ENVIRONMENT", 3);
+    setUser("dee.op");
+    testAccess("HFIR:ENVIRONMENT", 3);
+
+    setUser("h.overman");
+    testAccess("HFIR:ENVIRONMENT", 1);
+    setUser("i.bachman");
+    testAccess("HFIR:ENVIRONMENT", 1);
+    setUser("f.pilat");  // Wrong Group
+    testAccess("HFIR:ENVIRONMENT", 0);
+    setUser("g.squat");  // Wrong Group
+    testAccess("HFIR:ENVIRONMENT", 0);
+    setUser("h.lunge"); // Wrong Group
+    testAccess("HFIR:ENVIRONMENT", 0);
+    setUser("i.press");    // Wrong Group
+    testAccess("HFIR:ENVIRONMENT", 0);
+
+    // High-Flux Isotope Reactor Devices
+    setAuthority(
+        "ORNL Root CA\n"
+        "HFIR Intermediate CA\n"
+        "HFIR Control Systems CA"
+        );
+    setUser("HFIR:CTRL:IOC:REACT01");
+    testAccess("HFIR:CONTROLS", 3);
+    setUser("HFIR:CTRL:IOC:COOL02");
+    testAccess("HFIR:CONTROLS", 3);
+    setUser("HFIR:CTRL:IOC:SHLD03");
+    testAccess("HFIR:CONTROLS", 3);
+
+    setUser("HFIR:ENV:IOC:TEMP01");
+    testAccess("HFIR:ENVIRONMENT", 0); // Wrong CA chain
+    setAuthority(
+        "ORNL Root CA\n"
+        "HFIR Intermediate CA"
+        );
+    testAccess("HFIR:ENVIRONMENT", 0); // Incomplete CA chain
+    setAuthority( "" );
+    testAccess("HFIR:ENVIRONMENT", 0); // No CA chain
+    setAuthority(
+        "ORNL Root CA\n"
+        "HFIR Intermediate CA\n"
+        "HFIR Sample Environment CA\n"
+        "Sub CA"
+        );
+    testAccess("HFIR:ENVIRONMENT", 3); // Extra Certificate Authority in Chain is ok
+    setAuthority(
+        "ORNL Root CA\n"
+        "HFIR Intermediate CA\n"
+        "HFIR Sample Environment CA"
+        );
+    testAccess("HFIR:ENVIRONMENT", 3);
+    setUser("HFIR:ENV:IOC:MAG02");
+    testAccess("HFIR:ENVIRONMENT", 3);
+}
+
+static char* readFile(const char *filename) {
+    FILE *file = fopen(filename, "rb");
+    if (!file) {
+        perror("fopen");
+        return NULL;
+    }
+
+    // Seek to the end to determine file size.
+    if (fseek(file, 0, SEEK_END) != 0) {
+        perror("fseek");
+        fclose(file);
+        return NULL;
+    }
+    long filesize = ftell(file);
+    if (filesize < 0) {
+        perror("ftell");
+        fclose(file);
+        return NULL;
+    }
+    rewind(file);
+
+    // Allocate a buffer for the file contents plus a null terminator.
+    char *buffer = malloc(filesize + 1);
+    if (!buffer) {
+        perror("malloc");
+        fclose(file);
+        return NULL;
+    }
+
+    // Read the file into the buffer.
+    size_t read_size = fread(buffer, 1, filesize, file);
+    if (read_size != (size_t)filesize) {
+        perror("fread");
+        free(buffer);
+        fclose(file);
+        return NULL;
+    }
+    buffer[filesize] = '\0';  // Null-terminate the string.
+
+    fclose(file);
+    return buffer;
+}
+
+static void testDumpOutput(void)
+{
+    testDiag("testDumpOutput()");
+    asCheckClientIP = 0;
+
+    testOk1(asInitMem(method_auth_config, NULL)==0);
+
+    // Create temporary file in current directory
+    char temp_filename[] = "aslib_test_XXXXXX";
+#ifdef _WIN32
+    _mktemp(temp_filename);
+    FILE *fp = fopen(temp_filename, "w+");
+#else
+    int fd = mkstemp(temp_filename);
+    testOk(fd != -1, "Created temporary file");
+    if (fd == -1) return;
+    FILE *fp = fdopen(fd, "w+");
+#endif
+    testOk(fp != NULL, "Opened temporary file stream");
+    if (!fp) {
+#ifndef _WIN32
+        close(fd);
+#endif
+        unlink(temp_filename);
+        return;
+    }
+
+    // Write dump to temporary file
+    asDumpFP(fp, NULL, NULL, 0);
+    fflush(fp);
+    rewind(fp);
+
+    // Read the entire dump into a buffer
+    char *buf = readFile(temp_filename);
+
+    testOk(buf != NULL && strcmp(expected_method_auth_config, buf) == 0,
+           "asDumpFP output matches expected\nExpected:\n%s\nGot:\n%s",
+           expected_method_auth_config, buf ? buf : "NULL");
+
+    // Clean up
+    free(buf);
+    fclose(fp);
+    unlink(temp_filename);  // Delete temporary file
+}
+
+static void runRestDumpRules(const char *rule, const char *expected_config)
+{
+    static char temp_filename[] = "aslib_test_XXXXXX";
+#ifdef _WIN32
+    _mktemp(temp_filename);
+    FILE *fp = fopen(temp_filename, "w+");
+#else
+    int fd = mkstemp(temp_filename);
+    FILE *fp = fdopen(fd, "w+");
+#endif
+    testOk(fp != NULL, "Opened temporary file for rule %s", rule);
+    if (!fp) return;
+    asDumpRulesFP(fp, rule);
+    fclose(fp);
+    char *buf = readFile(temp_filename);
+    unlink(temp_filename);
+    testOk(strcmp(expected_config, buf) == 0,
+           "asDumpFP %s output matches expected\nExpected:\n%s\nGot:\n%s",
+           rule, expected_config, buf);
+    free(buf);
+    strcpy(temp_filename, "aslib_test_XXXXXX");
+}
+
+static void testRulesDumpOutput(void)
+{
+    testDiag("testRulesDumpOutput()");
+    asCheckClientIP = 0;
+
+    testOk1(asInitMem(method_auth_config, NULL)==0);
+
+    runRestDumpRules("DEFAULT",  expected_DEFAULT_rules_config);
+    runRestDumpRules("ro",  expected_ro_rules_config);
+    runRestDumpRules("rw",  expected_rw_rules_config);
+    runRestDumpRules("rwx", expected_rwx_rules_config);
 }
 
 MAIN(aslibtest)
 {
-    testPlan(64);
+    testPlan(168);
     testSyntaxErrors();
-    testFutureProofParser();
     testHostNames();
+    testDumpOutput();
+    testRulesDumpOutput();
     testUseIP();
+    testFutureProofParser();
+    testMethodAndAuth();
+    testCertificateChains();
     errlogFlush();
     return testDone();
 }

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -1694,7 +1694,9 @@ static void testDumpOutput(void)
     // Create temporary file in current directory
     char temp_filename[] = "aslib_test_XXXXXX";
 #ifdef _WIN32
-    _mktemp(temp_filename);
+    char *tmpres = _mktemp(temp_filename);
+    testOk(tmpres != NULL, "Created temporary file");
+    if (tmpres == NULL) return;
     FILE *fp = fopen(temp_filename, "wb+");
 #else
     int fd = mkstemp(temp_filename);

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -1695,12 +1695,12 @@ static void testDumpOutput(void)
     char temp_filename[] = "aslib_test_XXXXXX";
 #ifdef _WIN32
     _mktemp(temp_filename);
-    FILE *fp = fopen(temp_filename, "w+");
+    FILE *fp = fopen(temp_filename, "wb+");
 #else
     int fd = mkstemp(temp_filename);
     testOk(fd != -1, "Created temporary file");
     if (fd == -1) return;
-    FILE *fp = fdopen(fd, "w+");
+    FILE *fp = fdopen(fd, "wb+");
 #endif
     testOk(fp != NULL, "Opened temporary file stream");
     if (!fp) {
@@ -1734,10 +1734,10 @@ static void runRestDumpRules(const char *rule, const char *expected_config)
     static char temp_filename[] = "aslib_test_XXXXXX";
 #ifdef _WIN32
     _mktemp(temp_filename);
-    FILE *fp = fopen(temp_filename, "w+");
+    FILE *fp = fopen(temp_filename, "wb+");
 #else
     int fd = mkstemp(temp_filename);
-    FILE *fp = fdopen(fd, "w+");
+    FILE *fp = fdopen(fd, "wb+");
 #endif
     testOk(fp != NULL, "Opened temporary file for rule %s", rule);
     if (!fp) return;

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -14,19 +14,12 @@
 
 #include <errSymTbl.h>
 #include <epicsString.h>
+#include <epicsThread.h>
 #include <osiFileName.h>
 #include <errlog.h>
+#include <cantProceed.h>
 
 #include <asLib.h>
-
-/* Portable thread-local storage helper for tests */
-#ifdef _MSC_VER
-#  define STORE static __declspec( thread )
-#elif __GNUC__
-#  define STORE static __thread
-#else
-#  define STORE static
-#endif
 
 // The maximum number of links in a chain of authority we will provide in test data.  Increase as needed
 #define MAX_CERT_AUTH_CHAIN_LENGTH 10
@@ -38,6 +31,14 @@ static char *asUser,
             *asAuthority;
 static enum AsProtocol protocol=AS_PROTOCOL_TCP;
 static int asAsl;
+
+/* Per-thread buffer for the formatted certificate authority chain. */
+static epicsThreadPrivateId certAuthChainPvtId;
+
+static void certAuthChainOnce(void *unused)
+{
+    certAuthChainPvtId = epicsThreadPrivateCreate();
+}
 
 /**
  * @brief Test data with Host Access Groups (HAG)
@@ -1079,8 +1080,17 @@ static void testAccess(const char *asg, unsigned mask)
     ASMEMBERPVT asp = 0; /* aka dbCommon::asp */
     ASCLIENTPVT client = 0;
 
-    STORE char formattedCertAuthChain[MAX_AUTH_CHAIN_STRING];
-    parseCertAuthChain(&formattedCertAuthChain[0]);
+    static epicsThreadOnceId certAuthChainOnceId = EPICS_THREAD_ONCE_INIT;
+    epicsThreadOnce(&certAuthChainOnceId, certAuthChainOnce, NULL);
+
+    char *formattedCertAuthChain = epicsThreadPrivateGet(certAuthChainPvtId);
+    if (!formattedCertAuthChain) {
+        formattedCertAuthChain = calloc(1, MAX_AUTH_CHAIN_STRING);
+        if (!formattedCertAuthChain)
+            cantProceed("aslibtest: out of memory for formattedCertAuthChain\n");
+        epicsThreadPrivateSet(certAuthChainPvtId, formattedCertAuthChain);
+    }
+    parseCertAuthChain(formattedCertAuthChain);
 
     long ret = asAddMember(&asp, asg);
     if(ret) {


### PR DESCRIPTION
## Summary

Extends Access Security Group (ASG) rules with METHOD, AUTHORITY, and PROTOCOL predicates, adds the RPC permission type, and introduces a new `asAddClientIdentity()` / `asChangeClientIdentity()` API so PVAccess servers can convey TLS connection metadata to the access-security subsystem.

Supersedes PR #641 (filed from a personal fork). Branch is from `slac-epics/epics-base-tls`, rebased onto current 7.0, with portability fixes and CodeQL `strcpy` issues resolved.

## New ACF predicates

```
AUTHORITY(AUTH_EPICS_ROOT, "EPICS Org Root CA") {
    AUTHORITY(AUTH_ORNL_CA, "ORNL Org CA")
    AUTHORITY(AUTH_UNRELATED_CA, "Unrelated CA")
}

ASG(rw) {
    RULE(1, WRITE, TRAPWRITE) {
        UAG(foo)
        METHOD("x509")
        AUTHORITY(AUTH_UNRELATED_CA)
    }
}

ASG(rwx) {
    RULE(1, RPC) {
        UAG(bar)
        METHOD("x509")
        AUTHORITY(AUTH_UNRELATED_CA, AUTH_ORNL_CA)
        PROTOCOL("TLS")
    }
}
```

- **AUTHORITY** — named chains of X.509 CA common-names (root→issuer); referenced by name in rules
- **METHOD** — `ca`, `x509`, or `anonymous`; multiple values ORed
- **PROTOCOL** — `tcp` or `tls`; multiple values ORed
- **RPC** — new permission level (above WRITE) for RPC-only operations
- Multiple predicates of same type are ORed; different types are ANDed

## New API

```c
#define EPICS_ASLIB_HAS_IDENTITY

typedef struct asIdentity {
    const char *user;
    char       *host;
    const char *method;
    const char *authority;
    enum AsProtocol protocol;
} ASIDENTITY;

long asAddClientIdentity(ASCLIENTPVT *, ASMEMBERPVT, int asl, ASIDENTITY);
long asChangeClientIdentity(ASCLIENTPVT, int asl, ASIDENTITY);
```

The legacy `asAddClient()`/`asChangeClient()` remain and default `method` to `"ca"`.

## ACF forward compatibility

Includes grammar changes from merged PR #624: the parser accepts and warns on unknown top-level sections and rule predicates instead of hard-erroring, so ACF files written for future EPICS versions can still be loaded by older installations.

## Testing

Extended tests in `aslibtest.c` cover METHOD, AUTHORITY, PROTOCOL predicate matching, the RPC permission level, and forward-compatibility parsing.

## Notes

- Portability: uses `epicsStrCaseCmp` (not `strcasecmp`), `osiUnistd.h`, and the EPICS thread-local storage macro
- Memory safety: `strcpy` replaced with bounded `memcpy` in all new authority/method/protocol allocation paths (addresses CodeQL findings from #641)