### PR TITLE
biRecord.c/boRecord.c: Fix gcc -Wsizeof-pointer-memaccess

### DIFF
--- a/modules/database/src/std/rec/biRecord.c
+++ b/modules/database/src/std/rec/biRecord.c
@@ -35,6 +35,7 @@
 #include "recSup.h"
 #include "recGbl.h"
 #include "special.h"
+#include "epicsTypes.h"
 
 #define GEN_SIZE_OFFSET
 #include "biRecord.h"
@@ -188,10 +189,10 @@ static long get_enum_str(const DBADDR *paddr, char *pstring)
     if(index!=biRecordVAL) {
         strcpy(pstring,"Illegal_Value");
     } else if(*pfield==0) {
-        strncpy(pstring,prec->znam,sizeof(prec->znam));
+        snprintf(pstring, MAX_STRING_SIZE, "%s", prec->znam);
         pstring[sizeof(prec->znam)] = 0;
     } else if(*pfield==1) {
-        strncpy(pstring,prec->onam,sizeof(prec->onam));
+        snprintf(pstring, MAX_STRING_SIZE, "%s", prec->onam);
         pstring[sizeof(prec->onam)] = 0;
     } else {
         strcpy(pstring,"Illegal_Value");
@@ -205,9 +206,9 @@ static long get_enum_strs(const DBADDR *paddr,struct dbr_enumStrs *pes)
 
     pes->no_str = 2;
     memset(pes->strs,'\0',sizeof(pes->strs));
-    strncpy(pes->strs[0],prec->znam,sizeof(prec->znam));
+    snprintf(pes->strs[0], MAX_STRING_SIZE, "%s", prec->znam);
     if(*prec->znam!=0) pes->no_str=1;
-    strncpy(pes->strs[1],prec->onam,sizeof(prec->onam));
+    snprintf(pes->strs[1], MAX_STRING_SIZE, "%s", prec->onam);
     if(*prec->onam!=0) pes->no_str=2;
     return(0);
 }

--- a/modules/database/src/std/rec/biRecord.c
+++ b/modules/database/src/std/rec/biRecord.c
@@ -35,7 +35,6 @@
 #include "recSup.h"
 #include "recGbl.h"
 #include "special.h"
-#include "epicsTypes.h"
 
 #define GEN_SIZE_OFFSET
 #include "biRecord.h"
@@ -186,16 +185,16 @@ static long get_enum_str(const DBADDR *paddr, char *pstring)
 
 
     index = dbGetFieldIndex(paddr);
-    if(index!=biRecordVAL) {
-        strcpy(pstring,"Illegal_Value");
-    } else if(*pfield==0) {
-        snprintf(pstring, MAX_STRING_SIZE, "%s", prec->znam);
+    if(index != biRecordVAL) {
+        strcpy(pstring, "Illegal_Value");
+    } else if(*pfield == 0) {
+        memcpy(pstring, prec->znam, sizeof(prec->znam));
         pstring[sizeof(prec->znam)] = 0;
-    } else if(*pfield==1) {
-        snprintf(pstring, MAX_STRING_SIZE, "%s", prec->onam);
+    } else if(*pfield == 1) {
+        memcpy(pstring, prec->onam, sizeof(prec->onam));
         pstring[sizeof(prec->onam)] = 0;
     } else {
-        strcpy(pstring,"Illegal_Value");
+        strcpy(pstring, "Illegal_Value");
     }
     return(0);
 }
@@ -206,10 +205,15 @@ static long get_enum_strs(const DBADDR *paddr,struct dbr_enumStrs *pes)
 
     pes->no_str = 2;
     memset(pes->strs,'\0',sizeof(pes->strs));
-    snprintf(pes->strs[0], MAX_STRING_SIZE, "%s", prec->znam);
-    if(*prec->znam!=0) pes->no_str=1;
-    snprintf(pes->strs[1], MAX_STRING_SIZE, "%s", prec->onam);
-    if(*prec->onam!=0) pes->no_str=2;
+
+    STATIC_ASSERT(sizeof(prec->znam) <= sizeof(pes->strs[0]));
+    memcpy(pes->strs[0], prec->znam, sizeof(prec->znam));
+    if(*prec->znam != 0) pes->no_str = 1;
+
+    STATIC_ASSERT(sizeof(prec->onam) <= sizeof(pes->strs[1]));
+    memcpy(pes->strs[1], prec->onam, sizeof(prec->onam));
+    if(*prec->onam != 0) pes->no_str = 2;
+
     return(0);
 }
 

--- a/modules/database/src/std/rec/boRecord.c
+++ b/modules/database/src/std/rec/boRecord.c
@@ -328,10 +328,10 @@ static long get_enum_str(const DBADDR *paddr, char *pstring)
     if(index!=indexof(VAL)) {
         strcpy(pstring,"Illegal_Value");
     } else if(*pfield==0) {
-        strncpy(pstring,prec->znam,sizeof(prec->znam));
+        snprintf(pstring, MAX_STRING_SIZE, "%s", prec->znam);
         pstring[sizeof(prec->znam)] = 0;
     } else if(*pfield==1) {
-        strncpy(pstring,prec->onam,sizeof(prec->onam));
+        snprintf(pstring, MAX_STRING_SIZE, "%s", prec->onam);
         pstring[sizeof(prec->onam)] = 0;
     } else {
         strcpy(pstring,"Illegal_Value");
@@ -346,9 +346,9 @@ static long get_enum_strs(const DBADDR *paddr,struct dbr_enumStrs *pes)
     /*SETTING no_str=0 breaks channel access clients*/
     pes->no_str = 2;
     memset(pes->strs,'\0',sizeof(pes->strs));
-    strncpy(pes->strs[0],prec->znam,sizeof(pes->strs[0]));
+    snprintf(pes->strs[0], MAX_STRING_SIZE, "%s", prec->znam);
     if(*prec->znam!=0) pes->no_str=1;
-    strncpy(pes->strs[1],prec->onam,sizeof(pes->strs[1]));
+    snprintf(pes->strs[1], MAX_STRING_SIZE, "%s", prec->onam);
     if(*prec->onam!=0) pes->no_str=2;
     return(0);
 }

--- a/modules/database/src/std/rec/boRecord.c
+++ b/modules/database/src/std/rec/boRecord.c
@@ -325,31 +325,36 @@ static long get_enum_str(const DBADDR *paddr, char *pstring)
 
 
     index = dbGetFieldIndex(paddr);
-    if(index!=indexof(VAL)) {
-        strcpy(pstring,"Illegal_Value");
-    } else if(*pfield==0) {
-        snprintf(pstring, MAX_STRING_SIZE, "%s", prec->znam);
+    if(index != indexof(VAL)) {
+        strcpy(pstring, "Illegal_Value");
+    } else if(*pfield == 0) {
+        memcpy(pstring, prec->znam, sizeof(prec->znam));
         pstring[sizeof(prec->znam)] = 0;
-    } else if(*pfield==1) {
-        snprintf(pstring, MAX_STRING_SIZE, "%s", prec->onam);
+    } else if(*pfield == 1) {
+        memcpy(pstring, prec->onam, sizeof(prec->onam));
         pstring[sizeof(prec->onam)] = 0;
     } else {
-        strcpy(pstring,"Illegal_Value");
+        strcpy(pstring, "Illegal_Value");
     }
     return(0);
 }
 
 static long get_enum_strs(const DBADDR *paddr,struct dbr_enumStrs *pes)
 {
-    boRecord    *prec=(boRecord *)paddr->precord;
+    boRecord    *prec = (boRecord *)paddr->precord;
 
     /*SETTING no_str=0 breaks channel access clients*/
     pes->no_str = 2;
     memset(pes->strs,'\0',sizeof(pes->strs));
-    snprintf(pes->strs[0], MAX_STRING_SIZE, "%s", prec->znam);
-    if(*prec->znam!=0) pes->no_str=1;
-    snprintf(pes->strs[1], MAX_STRING_SIZE, "%s", prec->onam);
-    if(*prec->onam!=0) pes->no_str=2;
+
+    STATIC_ASSERT(sizeof(prec->znam) <= sizeof(pes->strs[0]));
+    memcpy(pes->strs[0], prec->znam, sizeof(pes->strs[0]));
+    if(*prec->znam != 0) pes->no_str = 1;
+
+    STATIC_ASSERT(sizeof(prec->onam) <= sizeof(pes->strs[1]));
+    memcpy(pes->strs[1], prec->onam, sizeof(pes->strs[1]));
+    if(*prec->onam != 0) pes->no_str = 2;
+
     return(0);
 }
 static long put_enum_str(const DBADDR *paddr, const char *pstring)


### PR DESCRIPTION
On RL8 and 9, `gcc` prints the following warning:
```
../rec/biRecord.c:191:42: warning: argument to ‘sizeof’ in ‘strncpy’ 
call is the same expression as the source; did you mean to use the 
size of the destination? [-Wsizeof-pointer-memaccess]
  191 |         strncpy(pstring,prec->znam,sizeof(prec->znam));
      |                                          ^
```
No way to tell `pstring` size since it is provided from support modules. `snprintf` is used instead to copy `prec->znam` to `pstring`.

The warning was reproduced and tested outside of EPICS base with this simple snippet
```c
#include <stdio.h>
#include <string.h>

#define MAX_STRING_SIZE 40

typedef struct
{
    char znam[26];
} biRecord;

long get_enum_str(biRecord *prec, char *pstring)
{
    // Same strncpy generates -Wsizeof-pointer-memaccess
    // strncpy(pstring,prec->znam,sizeof(prec->znam));
    snprintf(pstring, MAX_STRING_SIZE, "%s", prec->znam);
    pstring[sizeof(prec->znam)] = 0;
    return(0);
}

int main()
{
    biRecord record;
    char buffer[2];
    snprintf(record.znam, sizeof(record.znam), "HELLO WORLD");

    get_enum_str(&record, buffer);

    printf("Buffer: %s\n", buffer);

    return 0;
}
```