### PR TITLE
macOS: Drop the XCode -flat_namespace flag when possible

### DIFF
--- a/configure/os/CONFIG.darwinCommon.darwinCommon
+++ b/configure/os/CONFIG.darwinCommon.darwinCommon
@@ -60,7 +60,9 @@ GNU = NO
 #
 # Darwin shared libraries
 #
-SHRLIB_LDFLAGS = -dynamiclib -flat_namespace \
+FLAT_NAMESPACE = $(shell \
+    test $(or $(CLANG_MAJOR),99) -lt 15 && echo -flat_namespace)
+SHRLIB_LDFLAGS = -dynamiclib $(FLAT_NAMESPACE) \
     -install_name $(abspath $(INSTALL_LIB))/$@ \
     $(addprefix -compatibility_version , $(SHRLIB_VERSION)) \
     $(addprefix -current_version , $(SHRLIB_VERSION))

--- a/documentation/new-notes/PR-897.md
+++ b/documentation/new-notes/PR-897.md
@@ -1,0 +1,9 @@
+### macOS: Drop the `-flat_namespace` linker flag
+
+It's not clear when this flag was no longer required on macOS, we
+tried dropping it
+[in 2019](https://github.com/epics-base/epics-base/commit/cbb13bf6b170c6ba6660d594bdd9ca44a5bdaea5)
+but had to [restore it](https://github.com/epics-base/epics-base/commit/8c3c5a9731887c6d8b1918394090564af38461b5).
+XCode 15 seems a safe version though. See discussion in issue
+[#895](https://github.com/epics-base/epics-base/issues/895) for
+more details.


### PR DESCRIPTION
Exactly when this flag was no longer required is unclear, see some discussion in the linked issue.

Fixes #895.