### PR TITLE
Make EPICS_ABORT_ON_ASSERT affect cantProceed()

### DIFF
--- a/modules/libcom/src/misc/cantProceed.c
+++ b/modules/libcom/src/misc/cantProceed.c
@@ -15,6 +15,7 @@
 #include <stdarg.h>
 
 #include "errlog.h"
+#include "envDefs.h"
 #include "cantProceed.h"
 #include "epicsThread.h"
 #include "epicsStackTrace.h"
@@ -53,20 +54,30 @@ LIBCOM_API void * mallocMustSucceed(size_t size, const char *msg)
 
 LIBCOM_API void cantProceed(const char *msg, ...)
 {
+    int shouldAbort = 0;
     va_list pvar;
     va_start(pvar, msg);
     if (msg)
         errlogVprintf(msg, pvar);
     va_end(pvar);
 
-    errlogPrintf(ANSI_RED("CRITICAL ERROR") " Thread %s (%p) can't proceed, suspending.\n",
-            epicsThreadGetNameSelf(), epicsThreadGetIdSelf());
+    envGetBoolConfigParam(&EPICS_ABORT_ON_ASSERT, &shouldAbort);
+
+    errlogPrintf(ANSI_RED("CRITICAL ERROR") " Thread %s (%p) can't proceed, %s.\n",
+            epicsThreadGetNameSelf(), epicsThreadGetIdSelf(), shouldAbort ? "aborting" : "suspending");
 
     epicsStackTrace();
 
     errlogFlush();
 
     epicsThreadSleep(1.0);
-    while (1)
-        epicsThreadSuspendSelf();
+
+    if (shouldAbort) {
+        errlogPrintf("cantProceed() Calling abort()\n");
+        errlogFlush();
+        abort();
+    } else {
+        while (1)
+            epicsThreadSuspendSelf();
+    }
 }

--- a/modules/libcom/src/misc/cantProceed.h
+++ b/modules/libcom/src/misc/cantProceed.h
@@ -34,12 +34,14 @@
 extern "C" {
 #endif
 
-/** \brief Suspend this thread, the caller cannot continue or return.
+/** \brief Suspend this thread or call abort(), the caller cannot continue
+ *         or return.
  *
  * The effect of calling this is to print the error message followed by
- * the name of the thread that is being suspended. A stack trace will
+ * the name of the thread that can't proceed. A stack trace will
  * also be shown if supported by the OS, and the thread is suspended
- * inside an infinite loop.
+ * inside an infinite loop, or the process aborted, depending on
+ * EPICS_ABORT_ON_ASSERT.
  * \param errorMessage A printf-style error message describing the error.
  * \param ... Any parameters required for the error message.
  */

--- a/modules/libcom/src/osi/epicsMutex.h
+++ b/modules/libcom/src/osi/epicsMutex.h
@@ -213,12 +213,12 @@ LIBCOM_API epicsMutexLockStatus epicsStdCall epicsMutexLock(
  * This routine does not return if the identifier is invalid.
  * \param ID The mutex identifier.
  **/
-#define epicsMutexMustLock(ID) {                            \
-    epicsMutexLockStatus status = epicsMutexLock(ID);       \
-    if(status != epicsMutexLockOK) {                        \
-        cantProceed("epicsMutexMustLock() failed at %s:%d", \
-            __FILE__, __LINE__);                            \
-    }                                                       \
+#define epicsMutexMustLock(ID) {                                \
+    epicsMutexLockStatus status = epicsMutexLock(ID);           \
+    if(status != epicsMutexLockOK) {                            \
+        cantProceed("epicsMutexMustLock() failed at %s:%d\n",   \
+            __FILE__, __LINE__);                                \
+    }                                                           \
 }
 
 /**\brief Similar to epicsMutexLock() except that the call returns immediately,

--- a/modules/libcom/src/osi/epicsMutex.h
+++ b/modules/libcom/src/osi/epicsMutex.h
@@ -41,6 +41,7 @@
 #ifndef epicsMutexh
 #define epicsMutexh
 
+#include "cantProceed.h"
 #include "epicsAssert.h"
 
 #include "libComAPI.h"
@@ -212,9 +213,12 @@ LIBCOM_API epicsMutexLockStatus epicsStdCall epicsMutexLock(
  * This routine does not return if the identifier is invalid.
  * \param ID The mutex identifier.
  **/
-#define epicsMutexMustLock(ID) {                        \
-    epicsMutexLockStatus status = epicsMutexLock(ID);   \
-    assert(status == epicsMutexLockOK);                 \
+#define epicsMutexMustLock(ID) {                            \
+    epicsMutexLockStatus status = epicsMutexLock(ID);       \
+    if(status != epicsMutexLockOK) {                        \
+        cantProceed("epicsMutexMustLock() failed at %s:%d", \
+            __FILE__, __LINE__);                            \
+    }                                                       \
 }
 
 /**\brief Similar to epicsMutexLock() except that the call returns immediately,

--- a/modules/libcom/src/osi/epicsThread.cpp
+++ b/modules/libcom/src/osi/epicsThread.cpp
@@ -26,8 +26,8 @@
 #include "epicsAlgorithm.h"
 #include "epicsTime.h"
 #include "epicsThread.h"
-#include "epicsAssert.h"
 #include "epicsGuard.h"
+#include "cantProceed.h"
 #include "errlog.h"
 
 using namespace std;
@@ -345,7 +345,8 @@ extern "C" {
     {
         epicsThreadId id = epicsThreadCreate (
             name, priority, stackSize, funptr, parm );
-        assert ( id );
+        if ( !id )
+            cantProceed("epicsThreadMustCreate: epicsThreadCreate failed\n");
         return id;
     }
 } // extern "C"

--- a/modules/libcom/src/osi/os/RTEMS-score/osdTime.cpp
+++ b/modules/libcom/src/osi/os/RTEMS-score/osdTime.cpp
@@ -15,18 +15,19 @@
 
 #define EPICS_EXPOSE_LIBCOM_MONOTONIC_PRIVATE
 #include <epicsStdio.h>
-#include <rtems.h>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <rtems/rtems_bsdnet_internal.h>
 #include "epicsTime.h"
 #include "osdTime.h"
 #include "osiNTPTime.h"
 #include "osiClockTime.h"
 #include "generalTimeSup.h"
+
+#include <rtems.h>
+#include <rtems/rtems_bsdnet_internal.h>
 
 extern "C" {
 


### PR DESCRIPTION
When I implemented `EPICS_ABORT_ON_ASSERT` (in #565) I completely forgot about the `xxxMustBlah` APIs that EPICS has. Unfortunately, as a result, that PR introduced some inconsistency in the behavior of those functions. All `xxxMustBlah` APIs call `cantProceed` except for `epicsThreadMustCreate` and `epicsMutexMustLock` which use `assert()`, and are thus affected by `EPICS_ABORT_ON_ASSERT`.

This PR does two things:
- Switches `epicsMutexMustLock` and `epicsThreadMustCreate` to `cantProceed`
- Makes `EPICS_ABORT_ON_ASSERT` change the behavior of `cantProceed`

When `EPICS_ABORT_ON_ASSERT=YES`, it is probably desirable to kill the IOC on failure of `xxxMustBlah` instead of suspending the calling thread. I'm not sure if this is worth a new configuration option or not.