### PR TITLE
Fix UAF in caRepeaterThread

### DIFF
--- a/modules/ca/src/client/repeater.cpp
+++ b/modules/ca/src/client/repeater.cpp
@@ -645,6 +645,7 @@ extern "C" void caRepeaterThread ( void * /* pDummy */ )
 {
     taskwdInsert ( epicsThreadGetIdSelf(), NULL, NULL );
     ca_repeater ();
+    taskwdRemove ( 0 );
 }
 
 


### PR DESCRIPTION
The ca_repeater function has some failure cases which can cause it to return. In such a situation, a reference to the current thread's epicsThreadId is kept in the taskwd, causing an eventual use-after-free when the taskwd tries to determine the task's status.

We fix this problem by removing the thread from the taskwd if ca_repeater ever returns.

---

We noticed this when integrating the xpress3 module into our containerized build, which doesn't ship `caRepeater` inside the image (and we lack a `caRepeater` service, too...)

The taskwd was reading memory that had already been freed:

```
==18372== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
==18186== Thread 9 taskwd:
==18186== Invalid read of size 4
==18186==    at 0x4EA5213: epicsThreadIsSuspended (osdThread.c:913)
==18186==    by 0x4EACE79: twdTask (taskwd.c:99)
==18186==    by 0x4EA3E24: start_routine (osdThread.c:444)
==18186==    by 0x5117B7A: start_thread (pthread_create.c:448)
==18186==    by 0x519562F: clone (clone.S:100)
==18186==  Address 0xb8af780 is 128 bytes inside a block of size 180 free'd
==18186==    at 0x484787F: free (vg_replace_malloc.c:989)
==18186==    by 0x5115270: __nptl_deallocate_tsd (nptl_deallocate_tsd.c:73)
==18186==    by 0x5115270: __nptl_deallocate_tsd (nptl_deallocate_tsd.c:22)
==18186==    by 0x5117A4D: start_thread (pthread_create.c:456)
==18186==    by 0x519562F: clone (clone.S:100)
==18186==  Block was alloc'd at
==18186==    at 0x484BBA3: calloc (vg_replace_malloc.c:1675)
==18186==    by 0x4EA3BB6: create_threadInfo (osdThread.c:175)
==18186==    by 0x4EA3BB6: init_threadInfo (osdThread.c:197)
==18186==    by 0x4EA4945: epicsThreadCreateOpt (osdThread.c:608)
==18186==    by 0x4E9F866: epicsThreadCreate (epicsThread.cpp:44)
==18186==    by 0x57A04E6: caStartRepeaterIfNotInstalled (udpiiu.cpp:636)
==18186==    by 0x57A04E6: caStartRepeaterIfNotInstalled(unsigned int) (udpiiu.cpp:582)
==18186==    by 0x57A188E: udpiiu::udpiiu(epicsGuard<epicsMutex>&, epicsTimerQueueActive&, epicsMutex&, epicsMutex&, cacContextNotify&, cac&, unsigned int, tsDLList<SearchDest>&) (udpiiu.cpp:298)
==18186==    by 0x5793930: cac::createChannel(epicsGuard<epicsMutex>&, char const*, cacChannelNotify&, unsigned int) (cac.cpp:528)
==18186==    by 0x57ACE4B: oldChannelNotify::oldChannelNotify(epicsGuard<epicsMutex>&, ca_client_context&, char const*, void (*)(connection_handler_args), void*, unsigned int) (oldChannelNotify.cpp:50)
==18186==    by 0x5796854: ca_create_channel (access.cpp:321)
==18186==    by 0x49F16D7: PVAttribute::PVAttribute(char const*, char const*, char const*, long) (PVAttribute.cpp:66)
==18186==    by 0x49ED863: asynNDArrayDriver::readNDAttributesFile() (asynNDArrayDriver.cpp:441)
==18186==    by 0x49EAFA8: asynNDArrayDriver::writeOctet(asynUser*, char const*, unsigned long, unsigned long*) (asynNDArrayDriver.cpp:528)
```

We recently updated base from 7.0.8.1 to 7.0.10; checking with an older version is still pending, but I did notice commits 1910478297f7565d291a95d632eebe01e383438d and 214b5d935b6fd46b59517d682e143a78279c05b0 which seemed like they could be related to this issue.

Is it expected that once the `CAC-Repeater` thread is created, actually launching the task could still fail (and another instance of the thread remain up, too)? From what I understood of the code, it would seem to only be possible if launching two repeater threads at the same time. I'm only asking this to know if there's something deeper I should also investigate.