### PR TITLE
older gnu toolchains have problems with .incbin

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -3665,7 +3665,7 @@ void  dbReportDeviceConfig(dbBase *pdbbase, FILE *report)
     return;
 }
 
-#if defined(__GNUC__) && defined(__ELF__) && defined(__linux__)
+#if defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 407) && defined(__ELF__) && defined(__linux__)
 /* Loading of GDB python helper script.
  *
  * Need to include the following line in ~/.gdbinit


### PR DESCRIPTION
The assember gives the error "file not found: epics-gdb-helper.py"

Maybe toolchains used by gcc before 4.7 would need an absolute file path in .incbin but they probably have too old gdb versions to use it anyways.

Fixes #908.