### PR TITLE
Add search path for epics-gdb-helper.py to assembler options

### DIFF
--- a/modules/database/src/ioc/dbStatic/Makefile
+++ b/modules/database/src/ioc/dbStatic/Makefile
@@ -32,4 +32,6 @@ dbCore_SRCS += dbStaticRun.c
 dbCore_SRCS += dbStaticIocRegister.c
 dbCore_SRCS += dbCompleteRecord.cpp
 
+dbStaticLib_CFLAGS_Linux = -Wa,-I,..
+
 CLEANS += dbLex.c dbYacc.c


### PR DESCRIPTION
Gcc before version 4.7 does not pass -I options to the assembler automatically.
Fixes #908.

MD: edit to correct GCC version.  see https://github.com/epics-base/epics-base/issues/908#issuecomment-4936001279