### PR TITLE
Assorted libcom/database memory-safety hardening

### DIFF
--- a/modules/database/src/ioc/as/asDbLib.c
+++ b/modules/database/src/ioc/as/asDbLib.c
@@ -157,6 +157,10 @@ int asInit(void)
 int asShutdown(void) {
     volatile ASBASE *pbase = pasbase;
     pasbase = NULL;
+    /* restore the invariant that asActive implies pasbase != NULL; leaving
+       asActive TRUE here would let later AS calls dereference the freed/NULL
+       base or consult stale cached access rights */
+    asActive = FALSE;
     firstTime = TRUE;
     if(pbase)
         asFreeAll((ASBASE*)pbase);

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -2591,7 +2591,10 @@ long dbPutString(DBENTRY *pdbentry,const char *pstring)
         ((char *)pfield)[pflddes->size-1] = 0;
 
         if((pflddes->special == SPC_CALC) && !stringHasMacro) {
-            char  rpcl[RPCL_LEN];
+            /* size the postfix output from the field's actual capacity;
+               a fixed RPCL_LEN sized for an 80-char infix overflows for the
+               larger CALC-type fields (e.g. size 160) */
+            char *rpcl = dbmfMalloc(INFIX_TO_POSTFIX_SIZE(pflddes->size));
             short err;
 
             if (postfix(pstring,rpcl,&err)) {
@@ -2599,6 +2602,7 @@ long dbPutString(DBENTRY *pdbentry,const char *pstring)
                 errlogPrintf("%s in CALC expression '%s'\n",
                               calcErrorStr(err), pstring);
             }
+            dbmfFree(rpcl);
         }
         break;
 
@@ -2746,10 +2750,14 @@ char * dbVerify(DBENTRY *pdbentry, const char *pstring)
         }
 
         if (pflddes->special == SPC_CALC) {
-            char  rpcl[RPCL_LEN];
+            /* size the postfix output from the field's actual capacity;
+               a fixed RPCL_LEN sized for an 80-char infix overflows for the
+               larger CALC-type fields (e.g. size 160) */
+            char *rpcl = dbmfMalloc(INFIX_TO_POSTFIX_SIZE(pflddes->size));
             short err;
 
             status = postfix(pstring, rpcl, &err);
+            dbmfFree(rpcl);
             if (status)  {
                 sprintf(message,"%s in CALC expression '%s'",
                         calcErrorStr(err), pstring);

--- a/modules/database/src/ioc/dbtemplate/dbLoadTemplate.y
+++ b/modules/database/src/ioc/dbtemplate/dbLoadTemplate.y
@@ -31,9 +31,40 @@ static int yyerror(char* str);
 
 static char *sub_collect = NULL;
 static char *sub_locals;
+static char *sub_end;             /* write position (the trailing NUL) */
 static char **vars = NULL;
 static char *db_file_name = NULL;
 static int var_count, sub_count;
+static size_t sub_collect_size;   /* capacity of the sub_collect buffer */
+
+/* Append ",name=value" (or ",name=\"value\"" when quoteme) at sub_end.
+ * The names and values come from the substitution file and the command-line
+ * macro string and are not otherwise length limited, so the append is bounded
+ * against the fixed sub_collect allocation.  Returns non-zero (having logged)
+ * when the buffer is full so the caller can YYABORT rather than silently
+ * loading a truncated substitution. */
+static int sub_append(const char *name, const char *value, int quoteme)
+{
+    size_t need = 1 + strlen(name) + 1 + strlen(value) + (quoteme ? 2 : 0);
+
+    if (sub_end + need + 1 > sub_collect + sub_collect_size) {
+        fprintf(stderr, "dbLoadTemplate: substitution too long near line %d; "
+            "increase dbTemplateMaxVars\n", line_num);
+        return 1;
+    }
+    *sub_end++ = ',';
+    strcpy(sub_end, name);
+    sub_end += strlen(name);
+    *sub_end++ = '=';
+    if (quoteme)
+        *sub_end++ = '"';
+    strcpy(sub_end, value);
+    sub_end += strlen(value);
+    if (quoteme)
+        *sub_end++ = '"';
+    *sub_end = '\0';
+    return 0;
+}
 
 /* We allocate MAX_VAR_FACTOR chars in the sub_collect string for each
  * "variable=value," segment, and will accept at most dbTemplateMaxVars
@@ -92,7 +123,7 @@ global_definitions: GLOBAL O_BRACE C_BRACE
     #ifdef ERROR_STUFF
         fprintf(stderr, "global_definitions: %s\n", sub_collect+1);
     #endif
-        sub_locals += strlen(sub_locals);
+        sub_locals = sub_end;
     }
     ;
 
@@ -191,7 +222,8 @@ pattern_definition: global_definitions
         fprintf(stderr, "    dbLoadRecords(%s)\n", sub_collect+1);
     #endif
         if(msiLoadRecords(db_file_name, sub_collect+1)) YYABORT;
-        *sub_locals = '\0';
+        sub_end = sub_locals;
+        *sub_end = '\0';
         sub_count = 0;
     }
     | WORD O_BRACE pattern_values C_BRACE
@@ -207,7 +239,8 @@ pattern_definition: global_definitions
     #endif
         if(msiLoadRecords(db_file_name, sub_collect+1)) YYABORT;
         dbmfFree($1);
-        *sub_locals = '\0';
+        sub_end = sub_locals;
+        *sub_end = '\0';
         sub_count = 0;
     }
     ;
@@ -223,11 +256,10 @@ pattern_value: QUOTE
         fprintf(stderr, "pattern_value: [%d] = \"%s\"\n", sub_count, $1);
     #endif
         if (sub_count < var_count) {
-            strcat(sub_locals, ",");
-            strcat(sub_locals, vars[sub_count]);
-            strcat(sub_locals, "=\"");
-            strcat(sub_locals, $1);
-            strcat(sub_locals, "\"");
+            if (sub_append(vars[sub_count], $1, 1)) {
+                dbmfFree($1);
+                YYABORT;
+            }
             sub_count++;
         } else {
             fprintf(stderr, "dbLoadTemplate: Too many values given, line %d.\n",
@@ -241,10 +273,10 @@ pattern_value: QUOTE
         fprintf(stderr, "pattern_value: [%d] = %s\n", sub_count, $1);
     #endif
         if (sub_count < var_count) {
-            strcat(sub_locals, ",");
-            strcat(sub_locals, vars[sub_count]);
-            strcat(sub_locals, "=");
-            strcat(sub_locals, $1);
+            if (sub_append(vars[sub_count], $1, 0)) {
+                dbmfFree($1);
+                YYABORT;
+            }
             sub_count++;
         } else {
             fprintf(stderr, "dbLoadTemplate: Too many values given, line %d.\n",
@@ -274,7 +306,8 @@ variable_substitution: global_definitions
         fprintf(stderr, "    dbLoadRecords(%s)\n", sub_collect+1);
     #endif
         if(msiLoadRecords(db_file_name, sub_collect+1)) YYABORT;
-        *sub_locals = '\0';
+        sub_end = sub_locals;
+        *sub_end = '\0';
     }
     | WORD O_BRACE variable_definitions C_BRACE
     {   /* DEPRECATED SYNTAX */
@@ -289,7 +322,8 @@ variable_substitution: global_definitions
     #endif
         if(msiLoadRecords(db_file_name, sub_collect+1)) YYABORT;
         dbmfFree($1);
-        *sub_locals = '\0';
+        sub_end = sub_locals;
+        *sub_end = '\0';
     }
     ;
 
@@ -303,10 +337,10 @@ variable_definition: WORD EQUALS WORD
     #ifdef ERROR_STUFF
         fprintf(stderr, "variable_definition: %s = %s\n", $1, $3);
     #endif
-        strcat(sub_locals, ",");
-        strcat(sub_locals, $1);
-        strcat(sub_locals, "=");
-        strcat(sub_locals, $3);
+        if (sub_append($1, $3, 0)) {
+            dbmfFree($1); dbmfFree($3);
+            YYABORT;
+        }
         dbmfFree($1); dbmfFree($3);
     }
     | WORD EQUALS QUOTE
@@ -314,11 +348,10 @@ variable_definition: WORD EQUALS WORD
     #ifdef ERROR_STUFF
         fprintf(stderr, "variable_definition: %s = \"%s\"\n", $1, $3);
     #endif
-        strcat(sub_locals, ",");
-        strcat(sub_locals, $1);
-        strcat(sub_locals, "=\"");
-        strcat(sub_locals, $3);
-        strcat(sub_locals, "\"");
+        if (sub_append($1, $3, 1)) {
+            dbmfFree($1); dbmfFree($3);
+            YYABORT;
+        }
         dbmfFree($1); dbmfFree($3);
     }
     ;
@@ -374,7 +407,8 @@ int dbLoadTemplate(const char *sub_file, const char *cmd_collect, const char *pa
     }
 
     vars = malloc(dbTemplateMaxVars * sizeof(char*));
-    sub_collect = malloc(dbTemplateMaxVars * MAX_VAR_FACTOR);
+    sub_collect_size = (size_t)dbTemplateMaxVars * MAX_VAR_FACTOR;
+    sub_collect = malloc(sub_collect_size);
     if (!vars || !sub_collect) {
         free(vars);
         free(sub_collect);
@@ -385,12 +419,21 @@ int dbLoadTemplate(const char *sub_file, const char *cmd_collect, const char *pa
     strcpy(sub_collect, ",");
 
     if (cmd_collect && *cmd_collect) {
+        if (strlen(cmd_collect) + 2 > sub_collect_size) {
+            fprintf(stderr, "dbLoadTemplate: macro string too long; "
+                "increase dbTemplateMaxVars\n");
+            free(vars);
+            free(sub_collect);
+            fclose(fp);
+            return -1;
+        }
         strcat(sub_collect, cmd_collect);
         sub_locals = sub_collect + strlen(sub_collect);
     } else {
         sub_locals = sub_collect;
         *sub_locals = '\0';
     }
+    sub_end = sub_locals;
     var_count = 0;
     sub_count = 0;
 

--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -38,6 +38,13 @@ static epicsMutexId asLock;
 #define LOCK epicsMutexMustLock(asLock)
 #define UNLOCK epicsMutexUnlock(asLock)
 
+/* pasbase points to the currently active access-security configuration, or
+ * NULL when none is loaded.  asActive is set TRUE once a configuration has
+ * been successfully loaded and must only be TRUE while pasbase is non-NULL;
+ * when FALSE the asCheck* macros default to granting access.  Code that tears
+ * down the configuration (eg. asShutdown) must clear asActive before/when it
+ * clears pasbase so the two stay consistent.
+ */
 /*following must be global because asCa nneeds it*/
 ASBASE volatile *pasbase=NULL;
 static ASBASE *pasbasenew=NULL;

--- a/modules/libcom/src/as/asLib_lex.l
+++ b/modules/libcom/src/as/asLib_lex.l
@@ -22,6 +22,7 @@ link        [A-U]
 
 %{
 #include "epicsStdlib.h"
+#include "epicsStdio.h"
 
 static ASINPUTFUNCPTR *my_yyinput;
 #undef YY_INPUT
@@ -54,7 +55,8 @@ INP{link} {
         char *end;
         if (epicsParseDouble((char *)yytext, &yylval.Float64, &end) ) {
             char message[40];
-            sprintf(message, "Error parsing Float64: %s", (char *)yytext);
+            epicsSnprintf(message, sizeof(message),
+                "Error parsing Float64: %s", (char *)yytext);
             yyerror(message);
         } else {
             return(tokenFLOAT64);
@@ -65,7 +67,8 @@ INP{link} {
         char *end;
         if (epicsParseInt64((char *)yytext, &yylval.Int64, 10, &end) ) {
             char message[40];
-            sprintf(message, "Error parsing Int64: %s", (char *)yytext);
+            epicsSnprintf(message, sizeof(message),
+                "Error parsing Int64: %s", (char *)yytext);
             yyerror(message);
         } else {
             return(tokenINT64);

--- a/modules/libcom/src/calc/postfix.c
+++ b/modules/libcom/src/calc/postfix.c
@@ -300,6 +300,10 @@ LIBCOM_API long
                 goto bad;
             }
             /* Convert fetch into a store on the stack */
+            if (pstacktop >= &stack[NELEMENTS(stack) - 1]) {
+                *perror = CALC_ERR_OVERFLOW;
+                goto bad;
+            }
             *++pstacktop = *pel;
             pstacktop->code = STORE_A + *pout - FETCH_A;
             runtime_depth -= 1;
@@ -320,6 +324,10 @@ LIBCOM_API long
             }
 
             /* Push new operator onto stack */
+            if (pstacktop >= &stack[NELEMENTS(stack) - 1]) {
+                *perror = CALC_ERR_OVERFLOW;
+                goto bad;
+            }
             pstacktop++;
             *pstacktop = *pel;
             break;
@@ -337,6 +345,10 @@ LIBCOM_API long
             }
 
             /* Push new operator onto stack */
+            if (pstacktop >= &stack[NELEMENTS(stack) - 1]) {
+                *perror = CALC_ERR_OVERFLOW;
+                goto bad;
+            }
             pstacktop++;
             *pstacktop = *pel;
 
@@ -417,6 +429,10 @@ LIBCOM_API long
             if (pel->name[0] == ':') {
                 if (--cond_count < 0) {
                     *perror = CALC_ERR_CONDITIONAL;
+                    goto bad;
+                }
+                if (pstacktop >= &stack[NELEMENTS(stack) - 1]) {
+                    *perror = CALC_ERR_OVERFLOW;
                     goto bad;
                 }
                 pstacktop++;

--- a/modules/libcom/src/log/iocLogServer.c
+++ b/modules/libcom/src/log/iocLogServer.c
@@ -989,11 +989,12 @@ static int getDirectory(void)
         if (dir[0] != '\0') {
             char *name = ioc_log_file_name;
             char *slash = strrchr(ioc_log_file_name, '/');
-            char temp[256];
+            char temp[sizeof(ioc_log_file_name)];
 
             if (slash != NULL) name = slash + 1;
-            strcpy(temp,name);
-            sprintf(ioc_log_file_name,"%s/%s",dir,temp);
+            epicsSnprintf(temp, sizeof(temp), "%s", name);
+            epicsSnprintf(ioc_log_file_name, sizeof(ioc_log_file_name),
+                "%s/%s", dir, temp);
         }
     }
     return IOCLS_OK;


### PR DESCRIPTION
Reworked per review: the CA/RSRV header-validation changes have been removed
from this PR (they are being handled in #934 for RSRV and #931 for libca),
and what remains is a sequence of one-commit-per-change, independent
memory-safety fixes in libcom/database. Apologies again for the earlier
bundling and for cutting across the private disclosure on the CA parts.

All six commits build cleanly (`make`, no new warnings). The reworked
`dbLoadTemplate` accumulator was smoke-tested with `softIoc` (records expand
correctly, including quoted values containing `,` and `=`).

### Commits
1. **asLib: bound numeric parse-error message formatting** — over-range numeric
   literal in a `.acf` formatted unbounded `yytext` into `message[40]`; use
   `epicsSnprintf`.
2. **asShutdown: clear asActive to keep the asActive/pasbase invariant** — plus
   a comment documenting the relationship at their definitions (may partly
   address #667).
3. **calc: bound the postfix expression translation stack** — nested parens
   could overflow the fixed `stack[80]`; guard each push with
   `CALC_ERR_OVERFLOW`.
4. **dbStaticLib: size CALC validation buffer from the field capacity** — the
   `RPCL_LEN`/`MAX_POSTFIX_SIZE` invariant note is still open; happy to switch
   to `MAX_POSTFIX_SIZE` (fixing the second use in `dbVerify()` too) once you
   and @anjohnson settle on the preferred form.
5. **dbLoadTemplate: bound the substitution accumulator** — the four append
   groups now go through a bounded `sub_append(name, value, quoteme)` that
   tracks the write position (no `strlen(sub_collect)`) and returns non-zero on
   overflow so the yacc actions `YYABORT` instead of loading a truncated
   substitution.
6. **iocLogServer: bound the getDirectory() filename copy** — `strcpy` of an up
   to 511-char name into `temp[256]`; use bounded `epicsSnprintf`. (Noted this
   is low priority / effectively deprecated.)
