### PR TITLE
histogramRecord: fix heap OOB write when SGNL approaches ULIM

### DIFF
--- a/modules/database/src/std/rec/histogramRecord.c
+++ b/modules/database/src/std/rec/histogramRecord.c
@@ -338,7 +338,8 @@ static long add_count(histogramRecord *prec)
         return 0;
 
     temp = prec->sgnl - prec->llim;
-    for (i = 1; i <= prec->nelm; i++){
+    /* stop at nelm-1 so a rounded wdth can't push i past the last bin */
+    for (i = 1; i < prec->nelm; i++){
         if (temp <= (double) i * prec->wdth)
             break;
     }


### PR DESCRIPTION
The bin-search loop in add_count() assumes nelm*wdth == ulim-llim, but
wdth is a rounded quotient so nelm*wdth can be strictly less than
ulim-llim.  A SGNL value just below ULIM then leaves the loop with
i == nelm+1, and pdest = bptr + nelm writes one epicsUInt32 past the
nelm-element buffer.  This is reachable over Channel Access by putting a
value near ULIM to the SGNL field (special SPC_MOD).  Clamp the index to
nelm.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
