### PR TITLE
printfRecord: fix one-byte VAL overflow in %ls conversion

### DIFF
--- a/modules/database/src/std/rec/printfRecord.c
+++ b/modules/database/src/std/rec/printfRecord.c
@@ -250,6 +250,8 @@ static void doPrintf(printfRecord *prec)
                             int padding;
 
                             /* Terminate string and measure its length */
+                            if (n > vspace)
+                                n = vspace;
                             pval[n] = 0;
                             added = strlen(pval);
                             padding = width - added;


### PR DESCRIPTION
In the long-string (%ls) branch, n was vspace+1 and dbGetLink(DBR_CHAR)
fills up to n characters without reserving a terminator, so pval[n] = 0
writes at pval[vspace+1], which is one byte past the sizv-byte VAL buffer
(pval + vspace + 1 == prec->val + sizv).  Read at most vspace characters
(and precision, not precision+1) so the terminator lands in bounds.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
