### PR TITLE
epicsRingBytes: fix reversed operands in ResetHighWaterMark

### DIFF
--- a/modules/libcom/src/ring/epicsRingBytes.c
+++ b/modules/libcom/src/ring/epicsRingBytes.c
@@ -244,7 +244,7 @@ LIBCOM_API void epicsStdCall epicsRingBytesResetHighWaterMark(epicsRingBytesId i
     ringPvt *pring = (ringPvt *)id;
     int used;
     if (pring->lock) epicsSpinLock(pring->lock);
-    used = pring->nextGet - pring->nextPut;
+    used = pring->nextPut - pring->nextGet;
     if (used < 0) used += pring->size;
     pring->highWaterMark = used;
     if (pring->lock) epicsSpinUnlock(pring->lock);

--- a/modules/libcom/test/ringBytesTest.c
+++ b/modules/libcom/test/ringBytesTest.c
@@ -60,7 +60,7 @@ MAIN(ringBytesTest)
     char get[RINGSIZE+1];
     epicsRingBytesId ring;
 
-    testPlan(292);
+    testPlan(314);
 
     pinfo = calloc(1,sizeof(info));
     if (!pinfo) {
@@ -99,6 +99,8 @@ MAIN(ringBytesTest)
     n = epicsRingBytesPut(ring, put+RINGSIZE, 1);
     testOk(n==0, "put to full ring");
     check(ring, 0, RINGSIZE);
+    epicsRingBytesResetHighWaterMark(ring);
+    check(ring, 0, RINGSIZE);
     for(i = 0 ; i < RINGSIZE ; i++) {
         n = epicsRingBytesGet(ring, get+i, 1);
         testOk(n==1, "ring get 1, %d", i);
@@ -123,6 +125,20 @@ MAIN(ringBytesTest)
     n = epicsRingBytesGet(ring, get, 1);
     testOk(n==1, "ring get %d", 1);
     check(ring, RINGSIZE, 1);
+
+    /* Reset must lower a grown mark to the current non-zero usage.
+     * Fill the ring (mark -> RINGSIZE), drain half so usage < mark,
+     * then reset and confirm the mark drops to the half that remains.
+     */
+    epicsRingBytesResetHighWaterMark(ring);
+    n = epicsRingBytesPut(ring, put, RINGSIZE);
+    testOk(n==RINGSIZE, "ring put %d", RINGSIZE);
+    check(ring, 0, RINGSIZE);
+    n = epicsRingBytesGet(ring, get, RINGSIZE/2);
+    testOk(n==RINGSIZE/2, "ring get %d", RINGSIZE/2);
+    check(ring, RINGSIZE/2, RINGSIZE);
+    epicsRingBytesResetHighWaterMark(ring);
+    check(ring, RINGSIZE/2, RINGSIZE/2);
 
     epicsRingBytesDelete(ring);
     epicsEventDestroy(consumerEvent);

--- a/modules/libcom/test/ringPointerTest.c
+++ b/modules/libcom/test/ringPointerTest.c
@@ -117,6 +117,20 @@ static void testSingle(void)
     testOk1(epicsRingPointerGetUsed(ring)==0);
     testOk1(epicsRingPointerGetHighWaterMark(ring)==rsize);
 
+    testDiag("Reset lowers a grown mark to the current non-zero usage");
+    /* Mark is still rsize from the fill above; push half so that
+     * usage < mark, then reset and confirm the mark drops to usage
+     * (not to zero, not left unchanged, not the reversed complement).
+     */
+    for(i=0; i<rsize/2; i++)
+        epicsRingPointerPush(ring, int2ptr(i+1));
+    testOk1(epicsRingPointerGetUsed(ring)==rsize/2);
+    testOk1(epicsRingPointerGetHighWaterMark(ring)==rsize);
+    epicsRingPointerResetHighWaterMark(ring);
+    testOk1(epicsRingPointerGetHighWaterMark(ring)==rsize/2);
+    while(epicsRingPointerPop(ring)) {}     /* drain for following tests */
+    testOk1(epicsRingPointerIsEmpty(ring));
+
     testDiag("Fill it up again");
     for(i=2; i<2*rsize; i++) {
         int ret;
@@ -255,7 +269,7 @@ MAIN(ringPointerTest)
     epicsThreadOpts opts = EPICS_THREAD_OPTS_INIT;
     epicsEventId stop = epicsEventMustCreate(epicsEventEmpty);
 
-    testPlan(42);
+    testPlan(46);
     testSingle();
     /* testPair() needs to run with a priority > 0.
      * Start a new thread since main() is a "non-epics"


### PR DESCRIPTION
The used-bytes count is nextPut - nextGet everywhere else in this file
(epicsRingBytesPut, epicsRingBytesUsedBytes), but
epicsRingBytesResetHighWaterMark computed nextGet - nextPut.  For a ring
holding u bytes it therefore stored size-u; since Put only raises the
mark, the high-water mark stayed permanently inflated and wrong.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
