### PR TITLE
errlog: fix out-of-bounds read when resizing the print buffer

### DIFF
--- a/modules/libcom/src/error/errlog.c
+++ b/modules/libcom/src/error/errlog.c
@@ -638,7 +638,7 @@ void errlogBufResize(struct initArgs config)
     memcpy(logbuf, pvt.log->base, pvt.bufSize);
     pvt.log->base = logbuf;
 
-    memcpy(printbuf, &pvt.print->base, pvt.bufSize);
+    memcpy(printbuf, pvt.print->base, pvt.bufSize);
     pvt.print->base = printbuf;
 
     pvt.bufSize = config.bufsize;


### PR DESCRIPTION
errlogBufResize copied the print buffer from &pvt.print->base (the
address of the char* field inside the buffer_t struct) instead of
pvt.print->base (the buffer it points to), reading bufSize bytes from an
~8-byte struct field.  Drop the stray & so it reads the actual buffer,
matching the adjacent log-buffer copy.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
