### PR TITLE
iocsh: fix inverted parse test in 'on error wait <delay>'

### DIFF
--- a/modules/libcom/src/iocsh/iocsh.cpp
+++ b/modules/libcom/src/iocsh/iocsh.cpp
@@ -1559,13 +1559,14 @@ static void onCallFunc(const iocshArgBuf *args)
                 USAGE();
             } else if (epicsParseDouble(args->aval.av[3],
                           &context->scope->timeout, NULL)) {
-                context->scope->timeout = 5.0;
-            } else {
+                /* epicsParseDouble returns non-zero on failure */
                 USAGE();
                 fprintf(epicsGetStderr(),
                     ANSI_RED("Invalid 'on error wait' delay '%s'.") "\n",
                     args->aval.av[3]);
+                context->scope->timeout = 5.0;
             }
+            /* else parse succeeded and timeout has been set */
 
         } else {
             USAGE();


### PR DESCRIPTION
epicsParseDouble returns 0 on success and non-zero on failure, but the
branches were swapped: a valid delay printed "Invalid 'on error wait'
delay" and the usage text, while an invalid delay was silently accepted
with timeout forced to 5.0.  Report the error on parse failure and accept
the value on success.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
