### PR TITLE
dbConvert: fix UInt64->String conversion truncating to 32 bits

### DIFF
--- a/modules/database/src/ioc/db/dbConvert.c
+++ b/modules/database/src/ioc/db/dbConvert.c
@@ -1528,12 +1528,12 @@ static long putUInt64String(dbAddr *paddr,
 
 
     if (nRequest==1 && offset==0) {
-        cvtUlongToString(*psrc, pdst);
+        cvtUInt64ToString(*psrc, pdst);
         return 0;
     }
     pdst += (size*offset);
     while (nRequest--) {
-        cvtUlongToString(*psrc, pdst);
+        cvtUInt64ToString(*psrc, pdst);
         psrc++;
         if (++offset == no_elements)
             pdst = (char *) paddr->pfield;


### PR DESCRIPTION
putUInt64String used cvtUlongToString, which is cvtUInt32ToString, so the
64-bit source was narrowed to its low 32 bits (e.g. 0x1_0000_0007 printed
as "7").  Use cvtUInt64ToString, matching getUInt64String and every other
width-specific putXxxString.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
