### PR TITLE
dbStaticLib: fix dbGetStringNum reading UINT64 through a 32-bit pointer

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -2118,9 +2118,9 @@ char *dbGetStringNum(DBENTRY *pdbentry)
         break;
     case DBF_UINT64:
         if (cvttype==CT_DECIMAL)
-            cvtUInt64ToString(*(epicsUInt32 *) pfield, message);
+            cvtUInt64ToString(*(epicsUInt64 *) pfield, message);
         else
-            cvtUInt64ToHexString(*(epicsUInt32 *) pfield, message);
+            cvtUInt64ToHexString(*(epicsUInt64 *) pfield, message);
         break;
     case DBF_FLOAT:
         floatToString(*(epicsFloat32 *) pfield, message);


### PR DESCRIPTION
The DBF_UINT64 case dereferenced the 8-byte field as *(epicsUInt32 *),
reading only its low 32 bits, so large UINT64 values printed wrong
(e.g. 0x1_0000_0000 as "0") and save/restore round-tripping broke.  Cast
to epicsUInt64*, matching the adjacent DBF_INT64 case.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
