### PR TITLE
dbStaticLib: fix stack overflows in dbReportDeviceConfig

### DIFF
--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -3594,8 +3594,12 @@ void  dbReportDeviceConfig(dbBase *pdbbase, FILE *report)
 
             for (ilink=0; ilink<nlinks; ilink++) {
                 char linkValue[messagesize];
-                char dtypValue[50];
-                char cvtValue[40];
+                /* dbGetString() returns up to messagesize-1 characters, and
+                   cvtValue holds "cvt(" + two such strings + ",)" ; the old
+                   50/40-byte buffers could be overrun by a long DTYP choice
+                   or high-precision EGUL/EGUF values */
+                char dtypValue[messagesize];
+                char cvtValue[2*messagesize + 8];
                 struct link *plink;
                 int linkType;
 


### PR DESCRIPTION
dbGetString() returns up to messagesize-1 (275) characters, but
dbReportDeviceConfig copied DTYP into dtypValue[50] and built
"cvt(EGUL,EGUF)" in cvtValue[40] with strcpy/strcat.  A long DTYP choice
or high-precision EGUL/EGUF (e.g. 1.7976931348623157e+308) overflowed
these stack buffers.  Size them from messagesize so the copies fit.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
