### PR TITLE
dbJLink: fix assignment-instead-of-compare in dbJLinkMapAll

### DIFF
--- a/modules/database/src/ioc/db/dbJLink.c
+++ b/modules/database/src/ioc/db/dbJLink.c
@@ -551,7 +551,7 @@ long dbJLinkMapAll(char *recname, jlink_map_fn rtn, void *ctx)
     DBENTRY * const pdbentry = &dbentry;
     long status;
 
-    if (recname && (recname[0] = '\0' || !strcmp(recname, "*")))
+    if (recname && (recname[0] == '\0' || !strcmp(recname, "*")))
         recname = NULL;
 
     dbInitEntry(pdbbase, pdbentry);


### PR DESCRIPTION
The guard used recname[0] = '\0' (assignment) instead of == , which wrote
a NUL into the caller's string, truncating it to "", and evaluated to 0
so recname was left non-NULL pointing at "".  Every record then failed
the name comparison and nothing was mapped.  Use ==, matching dbjlr.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
