### PR TITLE
convert dbr_size_n from macro to inline function

### DIFF
--- a/documentation/new-notes/PR-923.md
+++ b/documentation/new-notes/PR-923.md
@@ -1,0 +1,12 @@
+### dbr_size_n() modified
+
+`dbr_size_n()` has been changed from a macro returning `unsigned`
+to an `inline` function returning `size_t`.
+
+This may cause warnings in code that assigns the result of
+`dbr_size_n()` to an `unsigned` variable on architectures where
+`size_t` is larger than `unsigned` (i.e. 64 bit architectures).
+
+The function now asserts valid ranges of its arguments.
+In particular it asserts that the given `count` together with
+the selected `dbr_type` does not overflow `size_t`.

--- a/modules/ca/src/client/CAref.html
+++ b/modules/ca/src/client/CAref.html
@@ -2288,7 +2288,7 @@ int main ( int argc, char ** argv )
 {
     struct dbr_time_double * pTD;
     const dbr_double_t * pValue;
-    unsigned nBytes;
+    size_t nBytes;
     unsigned elementCount;
     char timeString[32];
     unsigned i;

--- a/modules/ca/src/client/catime.c
+++ b/modules/ca/src/client/catime.c
@@ -445,7 +445,7 @@ static void printSearchStat ( const ti * pi, unsigned iterations )
  * timeIt ()
  */
 void timeIt ( tf *pfunc, ti *pItems, unsigned iterations,
-    unsigned nBytesSent, unsigned nBytesRecv )
+    size_t nBytesSent, size_t nBytesRecv )
 {
     epicsTimeStamp      end_time;
     epicsTimeStamp      start_time;
@@ -476,8 +476,8 @@ void timeIt ( tf *pfunc, ti *pItems, unsigned iterations,
  */
 static void test ( ti *pItems, unsigned iterations )
 {
-    unsigned payloadSize, dblPayloadSize;
-    unsigned nBytesSent, nBytesRecv;
+    unsigned dblPayloadSize;
+    size_t payloadSize, nBytesSent, nBytesRecv;
 
     payloadSize =
         dbr_size_n ( pItems[0].type, pItems[0].count );
@@ -487,10 +487,10 @@ static void test ( ti *pItems, unsigned iterations )
     dblPayloadSize = CA_MESSAGE_ALIGN ( dblPayloadSize );
 
     if ( payloadSize > dblPayloadSize ) {
-        unsigned factor = payloadSize / dblPayloadSize;
+        size_t factor = payloadSize / dblPayloadSize;
         while ( factor ) {
             if ( iterations > 10 * factor ) {
-                iterations /= factor;
+                iterations /= (unsigned)factor; // cast is safe: factor is small
                 break;
             }
             factor /= 2;
@@ -534,7 +534,7 @@ int catime ( const char * channelName,
     unsigned i;
     int j;
     unsigned strsize;
-    unsigned nBytesSent, nBytesRecv;
+    size_t nBytesSent, nBytesRecv;
     ti *pItemList;
 
     if ( channelCount == 0 ) {

--- a/modules/ca/src/client/db_access.h
+++ b/modules/ca/src/client/db_access.h
@@ -63,8 +63,8 @@ typedef epicsOldString dbr_class_name_t;
 #define DBF_DOUBLE      6
 #define DBF_NO_ACCESS   7
 #define LAST_TYPE       DBF_DOUBLE
-#define VALID_DB_FIELD(x)       ((x >= 0) && (x <= LAST_TYPE))
-#define INVALID_DB_FIELD(x)     ((x < 0) || (x > LAST_TYPE))
+#define VALID_DB_FIELD(x)       ((unsigned)(x) <= LAST_TYPE)
+#define INVALID_DB_FIELD(x)     !VALID_DB_FIELD(x)
 
 /* data request buffer types */
 #define DBR_STRING      DBF_STRING
@@ -112,8 +112,8 @@ typedef epicsOldString dbr_class_name_t;
 #define DBR_STSACK_STRING DBR_PUT_ACKS + 1
 #define DBR_CLASS_NAME DBR_STSACK_STRING + 1
 #define LAST_BUFFER_TYPE        DBR_CLASS_NAME
-#define VALID_DB_REQ(x) ((x >= 0) && (x <= LAST_BUFFER_TYPE))
-#define INVALID_DB_REQ(x)       ((x < 0) || (x > LAST_BUFFER_TYPE))
+#define VALID_DB_REQ(x)     ((unsigned)(x) <= LAST_BUFFER_TYPE)
+#define INVALID_DB_REQ(x)   !VALID_DB_REQ(x)
 
 /*
  * The enumeration "epicsType" is an index to this array
@@ -668,8 +668,8 @@ union db_access_val{
 #define db_state_dim            MAX_ENUM_STATES
 #define db_state_text_dim       MAX_ENUM_STRING_SIZE
 
-#define dbf_type_is_valid(type)   ((type) >= 0 && (type) <= LAST_TYPE)
-#define dbr_type_is_valid(type)   ((type) >= 0 && (type) <= LAST_BUFFER_TYPE)
+#define dbf_type_is_valid(type)   VALID_DB_FIELD(type)
+#define dbr_type_is_valid(type)   VALID_DB_REQ(type)
 #define dbr_type_is_plain(type)   \
                 ((type) >= DBR_STRING && (type) <= DBR_DOUBLE)
 #define dbr_type_is_STS(type)   \
@@ -681,26 +681,19 @@ union db_access_val{
 #define dbr_type_is_CTRL(type)   \
                 ((type) >= DBR_CTRL_STRING && (type) <= DBR_CTRL_DOUBLE)
 #define dbr_type_is_STRING(type)   \
-                ((type) >= 0 && (type) <= LAST_BUFFER_TYPE && \
-                 (type)%(LAST_TYPE+1) == DBR_STRING)
+                (dbr_type_is_valid(type) && (type)%(LAST_TYPE+1) == DBR_STRING)
 #define dbr_type_is_SHORT(type)   \
-                ((type) >= 0 && (type) <= LAST_BUFFER_TYPE && \
-                 (type)%(LAST_TYPE+1) == DBR_SHORT)
+                (dbr_type_is_valid(type) && (type)%(LAST_TYPE+1) == DBR_SHORT)
 #define dbr_type_is_FLOAT(type)   \
-                ((type) >= 0 && (type) <= LAST_BUFFER_TYPE && \
-                 (type)%(LAST_TYPE+1) == DBR_FLOAT)
+                (dbr_type_is_valid(type) && (type)%(LAST_TYPE+1) == DBR_FLOAT)
 #define dbr_type_is_ENUM(type)   \
-                ((type) >= 0 && (type) <= LAST_BUFFER_TYPE && \
-                 (type)%(LAST_TYPE+1) == DBR_ENUM)
+                (dbr_type_is_valid(type) && (type)%(LAST_TYPE+1) == DBR_ENUM)
 #define dbr_type_is_CHAR(type)   \
-                ((type) >= 0 && (type) <= LAST_BUFFER_TYPE && \
-                 (type)%(LAST_TYPE+1) == DBR_CHAR)
+                (dbr_type_is_valid(type) && (type)%(LAST_TYPE+1) == DBR_CHAR)
 #define dbr_type_is_LONG(type)   \
-                ((type) >= 0 && (type) <= LAST_BUFFER_TYPE && \
-                 (type)%(LAST_TYPE+1) == DBR_LONG)
+                (dbr_type_is_valid(type) && (type)%(LAST_TYPE+1) == DBR_LONG)
 #define dbr_type_is_DOUBLE(type)   \
-                ((type) >= 0 && (type) <= LAST_BUFFER_TYPE && \
-                 (type)%(LAST_TYPE+1) == DBR_DOUBLE)
+                (dbr_type_is_valid(type) && (type)%(LAST_TYPE+1) == DBR_DOUBLE)
 
 #define dbf_type_to_text(type)   \
     (  ((type+1) >= 0 && (type) < dbf_text_dim-2) ? \

--- a/modules/ca/src/client/db_access.h
+++ b/modules/ca/src/client/db_access.h
@@ -19,6 +19,7 @@
 
 #include "epicsTypes.h"
 #include "epicsTime.h"
+#include "epicsAssert.h"
 
 #include "libCaAPI.h"
 
@@ -516,23 +517,6 @@ struct dbr_ctrl_double{
         dbr_double_t    value;                  /* current value */
 };
 
-/** \brief Returns the size in bytes for a `DBR_XXXX` type with `COUNT` elements.
- *
- * If the DBR type is a structure then the value field is the last field in the
- * structure. If `COUNT` is greater than one then `COUNT-1` elements are
- * appended to the end of the structure so that they can be addressed as an
- * array through a pointer to the value field.
- *
- * \sa dbr_size, dbr_value_size
- *
- * \param[in] TYPE The data type.
- * \param[in] COUNT The element count.
- * \returns The size in bytes of the specified type
- * with the specified number of elements.
- */
-#define dbr_size_n(TYPE,COUNT)\
-((unsigned)((COUNT)<0?dbr_size[TYPE]:dbr_size[TYPE]+((COUNT)-1)*dbr_value_size[TYPE]))
-
 /** \brief Size in bytes for each `DBR_XXXX` type.
  *
  * Array indexed by the `DBR_XXXX` type code.
@@ -553,6 +537,28 @@ LIBCA_API extern const unsigned short dbr_size[];
 LIBCA_API extern const unsigned short dbr_value_size[];
 
 #ifndef db_accessHFORdb_accessC
+/** \brief Returns the size in bytes for a `DBR_XXXX` type with `count` elements.
+ *
+ * If the DBR type is a structure then the value field is the last field in the
+ * structure. If `count` is greater than one then `count-1` elements are
+ * appended to the end of the structure so that they can be addressed as an
+ * array through a pointer to the value field.
+ *
+ * \sa dbr_size, dbr_value_size
+ *
+ * \param[in] dbr_type The data type.
+ * \param[in] count The element count.
+ * \returns The size in bytes of the specified type
+ * with the specified number of elements.
+ */
+
+static EPICS_ALWAYS_INLINE size_t dbr_size_n(unsigned dbr_type, long count)
+{
+    assert(VALID_DB_REQ(dbr_type));
+    assert(count < 0 || (((size_t)~0UL)-dbr_size[dbr_type])/dbr_value_size[dbr_type] > (unsigned long)count);
+    return count < 0 ? dbr_size[dbr_type] : dbr_size[dbr_type]+((size_t)(count)-1)*dbr_value_size[dbr_type];
+}
+
 /* class for each type's value */
 enum dbr_value_class_e {
                 dbr_class_int,

--- a/modules/ca/src/client/db_access.h
+++ b/modules/ca/src/client/db_access.h
@@ -37,20 +37,20 @@ extern "C" {
  *
  * (so far this is sufficient for all archs we have ported to)
  */
-typedef epicsOldString dbr_string_t;
-typedef epicsUInt8 dbr_char_t;
-typedef epicsInt16 dbr_short_t;
+typedef epicsOldString  dbr_string_t;
+typedef epicsUInt8      dbr_char_t;
+typedef epicsInt16      dbr_short_t;
 typedef epicsUInt16     dbr_ushort_t;
-typedef epicsInt16 dbr_int_t;
-typedef epicsUInt16 dbr_enum_t;
-typedef epicsInt32 dbr_long_t;
-typedef epicsUInt32 dbr_ulong_t;
-typedef epicsFloat32 dbr_float_t;
-typedef epicsFloat64 dbr_double_t;
+typedef epicsInt16      dbr_int_t;
+typedef epicsUInt16     dbr_enum_t;
+typedef epicsInt32      dbr_long_t;
+typedef epicsUInt32     dbr_ulong_t;
+typedef epicsFloat32    dbr_float_t;
+typedef epicsFloat64    dbr_double_t;
 typedef epicsUInt16     dbr_put_ackt_t;
 typedef epicsUInt16     dbr_put_acks_t;
-typedef epicsOldString dbr_stsack_string_t;
-typedef epicsOldString dbr_class_name_t;
+typedef epicsOldString  dbr_stsack_string_t;
+typedef epicsOldString  dbr_class_name_t;
 
 #ifndef db_accessHFORdb_accessC
 /* database field types */
@@ -64,8 +64,8 @@ typedef epicsOldString dbr_class_name_t;
 #define DBF_DOUBLE      6
 #define DBF_NO_ACCESS   7
 #define LAST_TYPE       DBF_DOUBLE
-#define VALID_DB_FIELD(x)       ((unsigned)(x) <= LAST_TYPE)
-#define INVALID_DB_FIELD(x)     !VALID_DB_FIELD(x)
+#define VALID_DB_FIELD(x)   ((unsigned)(x) <= LAST_TYPE)
+#define INVALID_DB_FIELD(x) !VALID_DB_FIELD(x)
 
 /* data request buffer types */
 #define DBR_STRING      DBF_STRING
@@ -108,11 +108,11 @@ typedef epicsOldString dbr_class_name_t;
 #define DBR_CTRL_CHAR   32
 #define DBR_CTRL_LONG   33
 #define DBR_CTRL_DOUBLE 34
-#define DBR_PUT_ACKT    DBR_CTRL_DOUBLE + 1
-#define DBR_PUT_ACKS    DBR_PUT_ACKT + 1
-#define DBR_STSACK_STRING DBR_PUT_ACKS + 1
-#define DBR_CLASS_NAME DBR_STSACK_STRING + 1
-#define LAST_BUFFER_TYPE        DBR_CLASS_NAME
+#define DBR_PUT_ACKT        DBR_CTRL_DOUBLE + 1
+#define DBR_PUT_ACKS        DBR_PUT_ACKT + 1
+#define DBR_STSACK_STRING   DBR_PUT_ACKS + 1
+#define DBR_CLASS_NAME      DBR_STSACK_STRING + 1
+#define LAST_BUFFER_TYPE    DBR_CLASS_NAME
 #define VALID_DB_REQ(x)     ((unsigned)(x) <= LAST_BUFFER_TYPE)
 #define INVALID_DB_REQ(x)   !VALID_DB_REQ(x)
 

--- a/modules/ca/src/client/getCopy.cpp
+++ b/modules/ca/src/client/getCopy.cpp
@@ -60,8 +60,7 @@ void getCopy::completion (
     arrayElementCount countIn, const void *pDataIn )
 {
     if ( this->type == typeIn ) {
-        unsigned size = dbr_size_n ( typeIn, countIn );
-        memcpy ( this->pValue, pDataIn, size );
+        memcpy ( this->pValue, pDataIn, dbr_size_n ( typeIn, countIn ) );
         this->cacCtx.decrementOutstandingIO ( guard, this->ioSeqNo );
         this->cacCtx.destroyGetCopy ( guard, *this );
         // this object destroyed by preceding function call

--- a/modules/ca/src/client/syncGroupReadNotify.cpp
+++ b/modules/ca/src/client/syncGroupReadNotify.cpp
@@ -89,8 +89,7 @@ void syncGroupReadNotify::completion (
     }
 
     if ( this->pValue ) {
-        size_t size = dbr_size_n ( type, count );
-        memcpy ( this->pValue, pData, size );
+        memcpy ( this->pValue, pData, dbr_size_n ( type, count ) );
     }
     this->sg.completionNotify ( guard, *this );
     this->idIsValid = false;

--- a/modules/database/src/ioc/db/dbCAC.h
+++ b/modules/database/src/ioc/db/dbCAC.h
@@ -193,7 +193,7 @@ private:
     chronIntIdResTable < dbBaseIO > ioTable;
     dbContextReadNotifyCache readNotifyCache;
     dbEventCtx ctx;
-    unsigned long stateNotifyCacheSize;
+    size_t stateNotifyCacheSize;
     epicsMutex & mutex;
     epicsMutex & cbMutex;
     cacContextNotify & notify;

--- a/modules/database/src/ioc/db/dbContext.cpp
+++ b/modules/database/src/ioc/db/dbContext.cpp
@@ -147,7 +147,7 @@ void dbContext::callStateNotify ( struct dbChannel * dbch,
         cacStateNotify & notifyIn )
 {
     long realcount = (count==0)?dbChannelElements(dbch):count;
-    unsigned long size = dbr_size_n ( type, realcount );
+    size_t size = dbr_size_n ( type, realcount );
 
     if ( type > INT_MAX ) {
         epicsGuard < epicsMutex > guard ( this->mutex );
@@ -378,8 +378,9 @@ void dbContext::show (
     printf ( "dbContext at %p\n",
         static_cast <const void *> ( this ) );
     if ( level > 0u ) {
-        printf ( "\tevent call back cache location %p, and its size %lu\n",
-            static_cast <void *> ( this->pStateNotifyCache ), this->stateNotifyCacheSize );
+        printf ( "\tevent call back cache location %p, and its size %llu\n",
+            static_cast <void *> ( this->pStateNotifyCache ),
+            static_cast <unsigned long long>(this->stateNotifyCacheSize) );
         this->readNotifyCache.show ( guard, level - 1 );
     }
     if ( level > 1u ) {

--- a/modules/database/src/ioc/db/dbContextReadNotifyCache.cpp
+++ b/modules/database/src/ioc/db/dbContextReadNotifyCache.cpp
@@ -77,9 +77,8 @@ void dbContextReadNotifyCache::callReadNotify (
     }
 
     long realcount = (count==0)?maxcount:count;
-    unsigned long size = dbr_size_n ( type, realcount );
 
-    privateAutoDestroyPtr ptr ( _allocator, size );
+    privateAutoDestroyPtr ptr ( _allocator, dbr_size_n ( type, realcount ) );
     int status;
     {
         epicsGuardRelease < epicsMutex > unguard ( guard );

--- a/modules/database/src/ioc/db/dbPutNotifyBlocker.cpp
+++ b/modules/database/src/ioc/db/dbPutNotifyBlocker.cpp
@@ -76,7 +76,7 @@ void dbPutNotifyBlocker::cancel (
 }
 
 void dbPutNotifyBlocker::expandValueBuf (
-    epicsGuard < epicsMutex > & guard, unsigned long newSize )
+    epicsGuard < epicsMutex > & guard, size_t newSize )
 {
     guard.assertIdenticalMutex ( this->mutex );
     if ( this->maxValueSize < newSize ) {
@@ -176,7 +176,7 @@ void dbPutNotifyBlocker::initiatePutNotify (
     this->pn.doneCallback = putNotifyCompletion;
     this->pn.usrPvt = this;
 
-    unsigned long size = dbr_size_n ( type, count );
+    size_t size = dbr_size_n ( type, count );
     this->expandValueBuf ( guard, size );
     memcpy ( this->pbuffer, pValue, size );
 

--- a/modules/database/src/ioc/db/dbPutNotifyBlocker.h
+++ b/modules/database/src/ioc/db/dbPutNotifyBlocker.h
@@ -55,7 +55,7 @@ private:
     epicsEvent block;
     epicsMutex & mutex;
     cacWriteNotify * pNotify;
-    unsigned long maxValueSize;
+    size_t maxValueSize;
     // arguments for db_put_field
     void *pbuffer;
     long nRequest;
@@ -63,7 +63,7 @@ private:
     // end arguments for db_put_field
     dbSubscriptionIO * isSubscription ();
     void expandValueBuf (
-        epicsGuard < epicsMutex > &, unsigned long newSize );
+        epicsGuard < epicsMutex > &, size_t newSize );
     friend void putNotifyCompletion ( processNotify * ppn );
     friend int  putNotifyPut ( processNotify *ppn, notifyPutType type );
     dbPutNotifyBlocker ( const dbPutNotifyBlocker & );


### PR DESCRIPTION
The macro returned `unsigned`, the function now returns `size_t`.

The new function now asserts valid ranges of its arguments.
