### PR TITLE
calcPerform: fix the undefined integer narrowing in MODULO and NINT

### DIFF
--- a/modules/libcom/src/calc/calcPerform.c
+++ b/modules/libcom/src/calc/calcPerform.c
@@ -161,10 +161,17 @@ LIBCOM_API long
 
         case MODULO:
             itop = (epicsInt32) *ptop--;
-            if (itop)
-                *ptop = (epicsInt32) *ptop % itop;
-            else
+            if (itop == 0)
                 *ptop = epicsNAN;
+            else if (itop == -1)
+                /* Every integer is an exact multiple of -1, so the remainder
+                 * is always zero.  C's % operator is undefined for this
+                 * divisor when the dividend is the most negative integer,
+                 * since the quotient it is defined in terms of overflows.
+                 */
+                *ptop = 0;
+            else
+                *ptop = (epicsInt32) *ptop % itop;
             break;
 
         case POWER:

--- a/modules/libcom/src/calc/calcPerform.c
+++ b/modules/libcom/src/calc/calcPerform.c
@@ -34,6 +34,20 @@ static int cond_search(const char **ppinst, int match);
 #define PI 3.14159265358979323
 #endif
 
+/* Be VERY careful converting double to int in case bit 31 is set!
+ * Out-of-range errors give very different results on different systems.
+ * Convert negative doubles to signed and positive doubles to unsigned
+ * first to avoid overflows if bit 32 is set.
+ * The result is always signed, values with bit 31 set are negative
+ * to avoid problems when writing the value to signed integer fields
+ * like longout.VAL or ao.RVAL. However unsigned fields may give
+ * problems on some architectures. (Fewer than giving problems with
+ * signed integer. Maybe the conversion functions should handle
+ * overflows better.)
+ */
+#define d2i(x) ((x)<0?(epicsInt32)(x):(epicsInt32)(epicsUInt32)(x))
+#define d2ui(x) ((x)<0?(epicsUInt32)(epicsInt32)(x):(epicsUInt32)(x))
+
 /* Turn off global optimization for 64-bit MSVC builds */
 #if defined(_WIN32) && defined(_M_X64) && !defined(_MINGW)
 #  pragma optimize("g", off)
@@ -160,7 +174,8 @@ LIBCOM_API long
             break;
 
         case MODULO:
-            itop = (epicsInt32) *ptop--;
+            top = *ptop--;
+            itop = d2i(top);
             if (itop == 0)
                 *ptop = epicsNAN;
             else if (itop == -1)
@@ -171,7 +186,7 @@ LIBCOM_API long
                  */
                 *ptop = 0;
             else
-                *ptop = (epicsInt32) *ptop % itop;
+                *ptop = d2i(*ptop) % itop;
             break;
 
         case POWER:
@@ -297,7 +312,8 @@ LIBCOM_API long
 
         case NINT:
             top = *ptop;
-            *ptop = (epicsInt32) (top >= 0 ? top + 0.5 : top - 0.5);
+            top = top >= 0 ? top + 0.5 : top - 0.5;
+            *ptop = d2i(top);
             break;
 
         case RANDOM:
@@ -317,20 +333,6 @@ LIBCOM_API long
         case REL_NOT:
             *ptop = ! *ptop;
             break;
-
-        /* Be VERY careful converting double to int in case bit 31 is set!
-         * Out-of-range errors give very different results on different systems.
-         * Convert negative doubles to signed and positive doubles to unsigned
-         * first to avoid overflows if bit 32 is set.
-         * The result is always signed, values with bit 31 set are negative
-         * to avoid problems when writing the value to signed integer fields
-         * like longout.VAL or ao.RVAL. However unsigned fields may give
-         * problems on some architectures. (Fewer than giving problems with
-         * signed integer. Maybe the conversion functions should handle
-         * overflows better.)
-         */
-        #define d2i(x) ((x)<0?(epicsInt32)(x):(epicsInt32)(epicsUInt32)(x))
-        #define d2ui(x) ((x)<0?(epicsUInt32)(epicsInt32)(x):(epicsUInt32)(x))
 
         case BIT_OR:
             top = *ptop--;

--- a/modules/libcom/test/epicsCalcTest.cpp
+++ b/modules/libcom/test/epicsCalcTest.cpp
@@ -312,7 +312,7 @@ MAIN(epicsCalcTest)
                  m=13.0, n=14.0, o=15.0, p=16.0, q=17.0, r=18.0,
                  s=19.0, t=20.0, u=21.0;
 
-    testPlan(693);
+    testPlan(698);
 
     /* LITERAL_OPERAND elements */
     testExpr(0);
@@ -565,6 +565,15 @@ MAIN(epicsCalcTest)
     testExpr(NINT(0.6));
     testExpr(NINT(-0.4));
     testExpr(NINT(-0.6));
+
+    /* NINT narrows through d2i(), so a result with bit 31 set comes back
+     * negative, the same answer the bitwise operators give for it.  The
+     * NINT() macro above converts through a 64-bit long, so these cases
+     * have to spell the expected value out.
+     */
+    testCalc("NINT(3e9)", -1294967296.0);
+    testCalc("NINT(2.5e9)", -1794967296.0);
+    testCalc("3e9 & 0xffffffff", -1294967296.0);
     testExpr(sin(0.5));
     testExpr(sinh(0.5));
     testExpr(SQR(10.));
@@ -615,6 +624,12 @@ MAIN(epicsCalcTest)
     testCalc("-2147483648 % -1", 0);
     testCalc("3e9 % -1", 0);
     testCalc("NaN % -1", 0);
+
+    /* Both operands narrow through d2i(), so an out-of-range dividend
+     * wraps into the signed range instead of pinning to one end of it.
+     */
+    testCalc("3e9 % 7", 0);
+    testCalc("3e9 % 10", -6);
 
     testExpr(7 & 4);
 

--- a/modules/libcom/test/epicsCalcTest.cpp
+++ b/modules/libcom/test/epicsCalcTest.cpp
@@ -312,7 +312,7 @@ MAIN(epicsCalcTest)
                  m=13.0, n=14.0, o=15.0, p=16.0, q=17.0, r=18.0,
                  s=19.0, t=20.0, u=21.0;
 
-    testPlan(687);
+    testPlan(693);
 
     /* LITERAL_OPERAND elements */
     testExpr(0);
@@ -604,6 +604,17 @@ MAIN(epicsCalcTest)
     testExpr(-7 % 4);
     testExpr(63 % 16 % 6)
     testCalc("1 % 0", NaN);
+
+    /* A divisor of -1 divides every dividend exactly, so the remainder is
+     * zero.  These can't be written as C expressions: the most negative
+     * dividend makes C's % undefined, which is what we're avoiding here.
+     */
+    testCalc("7 % -1", 0);
+    testCalc("-7 % -1", 0);
+    testCalc("-2147483647 % -1", 0);
+    testCalc("-2147483648 % -1", 0);
+    testCalc("3e9 % -1", 0);
+    testCalc("NaN % -1", 0);
 
     testExpr(7 & 4);
 


### PR DESCRIPTION
Two related defects in `calcPerform()`.

**MODULO by −1 can crash the whole IOC.** `%` is a signed integer remainder on values narrowed from `double`. The zero divisor is guarded; `INT_MIN % -1` is not — undefined in C, and on x86 the `idiv` behind `%` traps the quotient overflow as `#DE`/SIGFPE. It is reachable from ordinary data, because the dividend is narrowed by a raw `(epicsInt32)` cast that maps any out-of-range double or NaN onto `0x80000000` = `INT_MIN`. Commit 1 guards the whole `divisor == -1` column: every integer is an exact multiple of −1, so the remainder is 0 for any dividend, keeping `%` the true mathematical remainder and leaving NaN to mean only the zero divisor.

**NINT and MODULO skip the `d2i` guard their siblings use.** Every bitwise/shift operator narrows through the `d2i()`/`d2ui()` macros written precisely to make out-of-range double→int conversions well-defined (the macro comment says so); NINT and MODULO were left on the raw cast. Commit 2 hoists `d2i`/`d2ui` to file scope and routes both MODULO operands and the NINT result through `d2i`.

Commit 2 **changes results for out-of-range operands**: `NINT(3e9)` → `-1294967296` (matching what `3e9 & 0xffffffff` already returns), `3e9 % 7` → `0`. In-range arithmetic is unchanged. This brings NINT/MODULO to parity with the sibling operators; making `d2i` itself total (it currently defines only the `[2^31, 2^32)` window) would change those siblings too and is left as a separate decision.

`epicsCalcTest` grows 687 → 698; the new MODULO cases take the test binary down with SIGFPE before commit 1 and pass after. Full `libcom` suite (4549 tests) passes.

The synApps `calc` sCalc/aCalc engines carry the same MODULO SIGFPE; a separate fix is submitted there (epics-modules/calc#38).