### PR TITLE
selRecord: fix the precision reported for the A-L and LA-LL fields

### DIFF
--- a/modules/database/src/std/rec/selRecord.c
+++ b/modules/database/src/std/rec/selRecord.c
@@ -156,8 +156,8 @@ static long get_precision(const DBADDR *paddr, long *precision)
     pvalue = &prec->a;
     plvalue = &prec->la;
     for(i=0; i<SEL_MAX; i++, pvalue++, plvalue++) {
-        if(paddr->pfield==&pvalue
-        || paddr->pfield==&plvalue){
+        if(paddr->pfield==pvalue
+        || paddr->pfield==plvalue){
             return(0);
         }
     }

--- a/modules/database/test/std/rec/Makefile
+++ b/modules/database/test/std/rec/Makefile
@@ -93,6 +93,13 @@ testHarness_SRCS += seqTest.c
 TESTFILES += ../seqTest.db
 TESTS += seqTest
 
+TESTPROD_HOST += selTest
+selTest_SRCS += selTest.c
+selTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp
+testHarness_SRCS += selTest.c
+TESTFILES += ../selTest.db
+TESTS += selTest
+
 TESTPROD_HOST += longoutTest
 longoutTest_SRCS += longoutTest.c
 longoutTest_SRCS += recTestIoc_registerRecordDeviceDriver.cpp

--- a/modules/database/test/std/rec/selTest.c
+++ b/modules/database/test/std/rec/selTest.c
@@ -1,0 +1,68 @@
+/*************************************************************************\
+* SPDX-License-Identifier: EPICS
+* EPICS BASE is distributed subject to a Software License Agreement found
+* in file LICENSE that is included with this distribution.
+\*************************************************************************/
+
+#include "dbUnitTest.h"
+#include "testMain.h"
+#include "errlog.h"
+#include "dbAccess.h"
+
+void recTestIoc_registerRecordDeviceDriver(struct dbBase *);
+
+static
+void testPrecEqual(const char *pv, long expected){
+    DBADDR addr;
+    struct {
+        DBRprecision
+        epicsFloat64 value;
+    } buf;
+    long options = DBR_PRECISION;
+    long nRequest = 1;
+
+    if (dbNameToAddr(pv, &addr) ||
+        dbGetField(&addr, DBR_DOUBLE, &buf, &options, &nRequest, NULL)) {
+        testFail("Can't read the precision of %s", pv);
+        return;
+    }
+    testOk(buf.precision.dp == expected, "%s precision (%ld) == %ld",
+        pv, buf.precision.dp, expected);
+}
+
+/*
+ * PREC gives the precision of VAL and of the A-L and LA-LL fields.
+ * The remaining DOUBLE fields get theirs from recGblGetPrec(), which
+ * substitutes 15 for a PREC outside the range it can print.
+ * */
+static
+void testSelPrecision(void){
+    testPrecEqual("sel0.VAL", 17);
+    testPrecEqual("sel0.A", 17);
+    testPrecEqual("sel0.L", 17);
+    testPrecEqual("sel0.LA", 17);
+    testPrecEqual("sel0.LL", 17);
+    testPrecEqual("sel0.HIHI", 15);
+}
+
+MAIN(selTest) {
+    testPlan(6);
+
+    testdbPrepare();
+
+    testdbReadDatabase("recTestIoc.dbd", NULL, NULL);
+    recTestIoc_registerRecordDeviceDriver(pdbbase);
+
+    testdbReadDatabase("selTest.db", NULL, NULL);
+
+    eltc(0);
+    testIocInitOk();
+    eltc(1);
+
+    testSelPrecision();
+
+    testIocShutdownOk();
+    testdbCleanup();
+
+    return testDone();
+}

--- a/modules/database/test/std/rec/selTest.db
+++ b/modules/database/test/std/rec/selTest.db
@@ -1,0 +1,3 @@
+record(sel, "sel0"){
+    field(PREC, "17")
+}


### PR DESCRIPTION
`get_precision()` compares `paddr->pfield` against `&pvalue`/`&plvalue` — the addresses of two local pointer variables — so the test has never matched, and every A-L / LA-LL precision request has fallen through to `recGblGetPrec()` since the loop was added in 1992 (`e87551df24`). Those fields report `recGblGetPrec`'s clamped 15 for a record PREC of 17, while VAL reports 17. (A `(void *)` cast on the comparison hid the type error from the compiler until it was removed in 2025; the logic was already dead.)

Fix: compare against `pvalue`/`plvalue` — the field pointers themselves. New `selTest` covers VAL, A, L, LA, LL and HIHI; the A-L/LA-LL cases fail before the change (report 15 for PREC 17) and pass after.