### PR TITLE
Disable MSVC warning C4250 "inherit via dominance"

### DIFF
--- a/configure/os/CONFIG.win32-x86.win32-x86
+++ b/configure/os/CONFIG.win32-x86.win32-x86
@@ -104,7 +104,9 @@ CODE_CPPFLAGS += -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE
 # -w44355 "'this' used in the base initializer list"
 # -w44344 "behavior change: use of explicit template arguments results in ..."
 # -w44251 "class needs to have dll-interface to be used by clients of ..."
-WARN_CXXFLAGS_YES = -W3 -w44355 -w44344 -w44251
+# -w44250 "class1 inherits class2::member via dominance"
+
+WARN_CXXFLAGS_YES = -W3 -w44355 -w44344 -w44251 -w44250
 WARN_CXXFLAGS_NO  = -W1
 
 # Silence tr1 namespace deprecation warnings


### PR DESCRIPTION
This warning is utterly pointless and an annoyance when compiling pvData or pvAccess because it is reported by every compilation unit that includes for example pvData.h.

https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4250
