### PR TITLE
Fix possible stack overflows in dbReportDeviceConfig

### DIFF
--- a/documentation/new-notes/PR-930.md
+++ b/documentation/new-notes/PR-930.md
@@ -1,0 +1,15 @@
+### Hardening of the iocsh command `dbReportDeviceConfig`
+
+This command had a tiny chance that its internal buffers could overflow and
+write over parts of the stack, although that required an unusually long device
+support name and huge engineering unit limits. Both these issues have been
+remediated, and the output format of the report improved.
+
+A header line is now shown (in BOLD) at the top of the report.
+
+`DTYP` strings in the 3rd column are now shortened by replacing characters from
+the middle of the string with an ellipsis `...`.
+
+Any ai and ao records with `LINEAR` conversions have their `EGUL` and `EGUF`
+fields shown in a `cvt(EGUL, EGUF)` format after the record name.
+These two values are now displayed with limited precision.

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -22,6 +22,7 @@
 #include "dbDefs.h"
 #include "dbmf.h"
 #include "ellLib.h"
+#include "epicsMath.h"
 #include "epicsPrint.h"
 #include "epicsStdio.h"
 #include "epicsStdlib.h"
@@ -3591,11 +3592,12 @@ void  dbReportDeviceConfig(dbBase *pdbbase, FILE *report)
         status = dbFirstRecord(pdbentry);
         while (!status) {
             int ilink;
+            int titlesPrinted = 0;
 
             for (ilink=0; ilink<nlinks; ilink++) {
                 char linkValue[messagesize];
-                char dtypValue[50];
-                char cvtValue[40];
+                char dtypValue[31];
+                char cvtValue[40] = "";
                 struct link *plink;
                 int linkType;
 
@@ -3629,28 +3631,34 @@ void  dbReportDeviceConfig(dbBase *pdbbase, FILE *report)
                 if (status)
                     break;  /* Next record type */
 
-                strcpy(dtypValue, dbGetString(pdbentry));
-                status = dbFindField(pdbentry, "LINR");
-                if (status) {
-                    cvtValue[0] = 0;
+                {
+                    const char *dtyp = dbGetString(pdbentry);
+                    const size_t maxlen = sizeof(dtypValue) - 1;
+                    size_t srclen = strlen(dtyp);
+
+                    if (srclen > maxlen)                /* elide the middle */
+                        epicsSnprintf(dtypValue, sizeof(dtypValue), "%.*s...%s",
+                            (int) (maxlen - 3) / 2, dtyp,
+                            dtyp + srclen - (maxlen - 2) / 2);
+                    else
+                        strcpy(dtypValue, dtyp);
                 }
-                else {
-                    if (strcmp(dbGetString(pdbentry), "LINEAR") != 0) {
-                        cvtValue[0] = 0;
-                    }
-                    else {
-                        strcpy(cvtValue,"cvt(");
-                        status = dbFindField(pdbentry, "EGUL");
-                        if (!status)
-                            strcat(cvtValue, dbGetString(pdbentry));
-                        status = dbFindField(pdbentry, "EGUF");
-                        if (!status) {
-                            strcat(cvtValue, ",");
-                            strcat(cvtValue, dbGetString(pdbentry));
-                        }
-                        strcat(cvtValue, ")");
-                    }
+                if (!dbFindField(pdbentry, "LINR") &&
+                    strcmp(dbGetString(pdbentry), "LINEAR") == 0) {
+                    epicsFloat64 egul = epicsNAN, eguf = epicsNAN;
+
+                    if (!dbFindField(pdbentry, "EGUL") &&
+                        pdbentry->pflddes->field_type == DBF_DOUBLE)
+                        egul = *(epicsFloat64 *) pdbentry->pfield;
+                    if (!dbFindField(pdbentry, "EGUF") &&
+                        pdbentry->pflddes->field_type == DBF_DOUBLE)
+                        eguf = *(epicsFloat64 *) pdbentry->pfield;
+                    epicsSnprintf(cvtValue, sizeof(cvtValue),
+                        "cvt(%.8g, %.8g)", egul, eguf);
                 }
+                if (!titlesPrinted++)
+                    fprintf(stream, ANSI_BOLD("%-8s %-20s %-20s %-20s") "\n",
+                        "Type", "INP/OUT", "DTYP", "Record");
                 fprintf(stream,"%-8s %-20s %-20s %-20s %-s\n",
                         bus[linkType], linkValue, dtypValue,
                         dbGetRecordName(pdbentry), cvtValue);

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.c
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.c
@@ -3597,7 +3597,7 @@ void  dbReportDeviceConfig(dbBase *pdbbase, FILE *report)
             for (ilink=0; ilink<nlinks; ilink++) {
                 char linkValue[messagesize];
                 char dtypValue[31];
-                char cvtValue[40] = "";
+                char cvtValue[60] = "";
                 struct link *plink;
                 int linkType;
 
@@ -3654,12 +3654,12 @@ void  dbReportDeviceConfig(dbBase *pdbbase, FILE *report)
                         pdbentry->pflddes->field_type == DBF_DOUBLE)
                         eguf = *(epicsFloat64 *) pdbentry->pfield;
                     epicsSnprintf(cvtValue, sizeof(cvtValue),
-                        "cvt(%.8g, %.8g)", egul, eguf);
+                        "\n             cvt(%.8g, %.8g)", egul, eguf);
                 }
                 if (!titlesPrinted++)
-                    fprintf(stream, ANSI_BOLD("%-8s %-20s %-20s %-20s") "\n",
+                    fprintf(stream, ANSI_BOLD("%-8s %-20s %-30s %-20s") "\n",
                         "Type", "INP/OUT", "DTYP", "Record");
-                fprintf(stream,"%-8s %-20s %-20s %-20s %-s\n",
+                fprintf(stream,"%-8s %-20s %-30s %s %s\n",
                         bus[linkType], linkValue, dtypValue,
                         dbGetRecordName(pdbentry), cvtValue);
                 break;


### PR DESCRIPTION
Writes to both dtypValue and cvtValue strings could overflow. Instead of just expanding the string buffers, change the output. Long DTYP strings are truncated to 30 char's by this, and the cvt(<EGUL>,<EGUF>) range added for ai/ao LINR conversions is limited to avoid overflow.

This version also adds a header line (in BOLD) to the report.

Replaces #921