### PR TITLE
More CA client protection

### DIFF
--- a/modules/ca/src/client/CAref.html
+++ b/modules/ca/src/client/CAref.html
@@ -3927,6 +3927,39 @@ pointer to the value field.</p>
       elements</dd>
 </dl>
 
+<h3><code><a name="dbr_size_chk">dbr_size_chk()</a></code></h3>
+<pre>#include &lt;db_access.h&gt;
+epicsUInt64 dbr_size_chk ( unsigned TYPE, epicsInt64 COUNT );</pre>
+
+<h4>Description</h4>
+
+<p>A range-checked, overflow-safe equivalent of the <code>dbr_size_n()</code>
+macro. Returns the size in bytes for a DBR_XXXX type with COUNT elements. If the
+DBR type is a structure then the value field is the last field in the
+structure. If COUNT is greater than one then COUNT-1 elements are appended to
+the end of the structure so that they can be addressed as an array through a
+pointer to the value field. A negative COUNT is treated as a single element.</p>
+
+<p>The size is computed and returned using 64-bit arithmetic so that a large
+element count cannot overflow the calculation. An invalid TYPE returns 0.</p>
+
+<h4>Arguments</h4>
+<dl>
+  <dt><code>TYPE</code></dt>
+    <dd>The data type</dd>
+</dl>
+<dl>
+  <dt><code>COUNT</code></dt>
+    <dd>The element count</dd>
+</dl>
+
+<h4>Returns</h4>
+<dl>
+  <dt><code>SIZE</code></dt>
+    <dd>the size in bytes of the specified type with the specified number of
+      elements</dd>
+</dl>
+
 <h3><code><a name="dbr_value_size">dbr_value_size[]</a></code></h3>
 <pre>#include &lt;db_access.h&gt;
 extern unsigned dbr_value_size[/* TYPE */];</pre>

--- a/modules/ca/src/client/cac.cpp
+++ b/modules/ca/src/client/cac.cpp
@@ -1109,7 +1109,7 @@ bool cac::exceptionRespAction ( callbackManager & cbMutexIn, tcpiiu & iiu,
 
     // execute the exception message
     pExcepProtoStubTCP pStub;
-    if ( hdr.m_cmmd >= NELEMENTS ( cac::tcpExcepJumpTableCAC ) ) {
+    if ( req.m_cmmd >= NELEMENTS ( cac::tcpExcepJumpTableCAC ) ) {
         pStub = &cac::defaultExcep;
     }
     else {

--- a/modules/ca/src/client/cac.cpp
+++ b/modules/ca/src/client/cac.cpp
@@ -896,6 +896,13 @@ bool cac::readNotifyRespAction ( callbackManager &, tcpiiu & iiu,
             // this does *not* assign a new resource id
             this->ioTable.add ( *pmiu );
         }
+        if ( INVALID_DB_REQ ( hdr.m_dataType ) ||
+             hdr.m_postsize < dbr_size_n ( hdr.m_dataType, hdr.m_count ) ) {
+            pmiu->exception ( guard, *this, ECA_BADTYPE,
+                "server response inconsistent with payload size",
+                hdr.m_dataType, hdr.m_count );
+            return true;
+        }
         if ( caStatus == ECA_NORMAL ) {
             /*
              * convert the data buffer from net
@@ -960,6 +967,13 @@ bool cac::eventRespAction ( callbackManager &, tcpiiu &iiu,
     //
     baseNMIU * pmiu = this->ioTable.lookup ( hdr.m_available );
     if ( pmiu ) {
+        if ( INVALID_DB_REQ ( hdr.m_dataType ) ||
+             hdr.m_postsize < dbr_size_n ( hdr.m_dataType, hdr.m_count ) ) {
+            pmiu->exception ( guard, *this, ECA_BADTYPE,
+                "server response inconsistent with payload size",
+                hdr.m_dataType, hdr.m_count );
+            return true;
+        }
         /*
          * convert the data buffer from net format to host format
          */
@@ -992,6 +1006,13 @@ bool cac::readRespAction ( callbackManager &, tcpiiu &,
     // it is in use here.
     //
     if ( pmiu ) {
+        if ( INVALID_DB_REQ ( hdr.m_dataType ) ||
+             hdr.m_postsize < dbr_size_n ( hdr.m_dataType, hdr.m_count ) ) {
+            pmiu->exception ( guard, *this, ECA_BADTYPE,
+                "server response inconsistent with payload size",
+                hdr.m_dataType, hdr.m_count );
+            return true;
+        }
         pmiu->completion ( guard, *this,
             hdr.m_dataType, hdr.m_count, pMsgBdy );
     }

--- a/modules/ca/src/client/cac.cpp
+++ b/modules/ca/src/client/cac.cpp
@@ -864,6 +864,22 @@ bool cac::writeNotifyRespAction (
     return true;
 }
 
+// Reject a data response whose header is inconsistent with its payload.
+// Returns an exception to the server and returns true on error.
+bool cac::badResponsePayload (
+    epicsGuard < epicsMutex > & guard, baseNMIU & miu,
+    const caHdrLargeArray & hdr )
+{
+    if ( INVALID_DB_REQ ( hdr.m_dataType ) ||
+         hdr.m_postsize < dbr_size_chk ( hdr.m_dataType, hdr.m_count ) ) {
+        miu.exception ( guard, *this, ECA_BADTYPE,
+            "server response inconsistent with payload size",
+            hdr.m_dataType, hdr.m_count );
+        return true;
+    }
+    return false;
+}
+
 bool cac::readNotifyRespAction ( callbackManager &, tcpiiu & iiu,
     const epicsTime &, const caHdrLargeArray & hdr, void * pMsgBdy )
 {
@@ -896,11 +912,7 @@ bool cac::readNotifyRespAction ( callbackManager &, tcpiiu & iiu,
             // this does *not* assign a new resource id
             this->ioTable.add ( *pmiu );
         }
-        if ( INVALID_DB_REQ ( hdr.m_dataType ) ||
-             hdr.m_postsize < dbr_size_n ( hdr.m_dataType, hdr.m_count ) ) {
-            pmiu->exception ( guard, *this, ECA_BADTYPE,
-                "server response inconsistent with payload size",
-                hdr.m_dataType, hdr.m_count );
+        if ( this->badResponsePayload ( guard, *pmiu, hdr ) ) {
             return true;
         }
         if ( caStatus == ECA_NORMAL ) {
@@ -967,11 +979,7 @@ bool cac::eventRespAction ( callbackManager &, tcpiiu &iiu,
     //
     baseNMIU * pmiu = this->ioTable.lookup ( hdr.m_available );
     if ( pmiu ) {
-        if ( INVALID_DB_REQ ( hdr.m_dataType ) ||
-             hdr.m_postsize < dbr_size_n ( hdr.m_dataType, hdr.m_count ) ) {
-            pmiu->exception ( guard, *this, ECA_BADTYPE,
-                "server response inconsistent with payload size",
-                hdr.m_dataType, hdr.m_count );
+        if ( this->badResponsePayload ( guard, *pmiu, hdr ) ) {
             return true;
         }
         /*
@@ -1006,11 +1014,7 @@ bool cac::readRespAction ( callbackManager &, tcpiiu &,
     // it is in use here.
     //
     if ( pmiu ) {
-        if ( INVALID_DB_REQ ( hdr.m_dataType ) ||
-             hdr.m_postsize < dbr_size_n ( hdr.m_dataType, hdr.m_count ) ) {
-            pmiu->exception ( guard, *this, ECA_BADTYPE,
-                "server response inconsistent with payload size",
-                hdr.m_dataType, hdr.m_count );
+        if ( this->badResponsePayload ( guard, *pmiu, hdr ) ) {
             return true;
         }
         pmiu->completion ( guard, *this,

--- a/modules/ca/src/client/cac.cpp
+++ b/modules/ca/src/client/cac.cpp
@@ -1108,6 +1108,9 @@ bool cac::exceptionRespAction ( callbackManager & cbMutexIn, tcpiiu & iiu,
     if ( hdr.m_postsize < bytesSoFar ) {
         return false;
     }
+    // Ensure the context string is NULL-terminated
+    static_cast < char * > ( pMsgBdy ) [hdr.m_postsize - 1] = '\0';
+
     caHdrLargeArray req;
     req.m_cmmd = AlignedWireRef < const epicsUInt16 > ( pReq->m_cmmd );
     req.m_postsize = AlignedWireRef < const epicsUInt16 > ( pReq->m_postsize );

--- a/modules/ca/src/client/cac.h
+++ b/modules/ca/src/client/cac.h
@@ -317,6 +317,8 @@ private:
         const epicsTime & currentTime, const caHdrLargeArray &, void *pMsgBdy );
     bool badTCPRespAction ( callbackManager &, tcpiiu &,
         const epicsTime & currentTime, const caHdrLargeArray &, void *pMsgBdy );
+    bool badResponsePayload ( epicsGuard < epicsMutex > &,
+        baseNMIU &, const caHdrLargeArray & );
 
     typedef bool ( cac::*pProtoStubTCP ) (
         callbackManager &, tcpiiu &,

--- a/modules/ca/src/client/comQueSend.cpp
+++ b/modules/ca/src/client/comQueSend.cpp
@@ -358,16 +358,14 @@ void comQueSend::insertRequestWithPayLoad (
         else {
             maxBytes = MAX_TCP - sizeof ( caHdr );
         }
-        arrayElementCount maxElem =
-            ( maxBytes - sizeof (dbr_double_t) - dbr_size[dataType] ) /
-                dbr_value_size[dataType];
-        if ( nElem >= maxElem ) {
+        // nElem is bounded to the channel's native element count in
+        // nciu::write, so this 64-bit size cannot overflow; the dbr_double_t
+        // margin allows for the alignment rounding below.
+        epicsUInt64 fullSize = dbr_size_chk ( dataType, nElem );
+        if ( fullSize + sizeof (dbr_double_t) > maxBytes ) {
             throw cacChannel::outOfBounds();
         }
-        // the above checks verify that the total size
-        // is lest that 0xffffffff
-        size = static_cast < ca_uint32_t >
-            ( dbr_size_n ( dataType, nElem ) );
+        size = static_cast < ca_uint32_t > ( fullSize );
         payloadSize = CA_MESSAGE_ALIGN ( size );
         this->insertRequestHeader ( request, payloadSize,
             static_cast <ca_uint16_t> ( dataType ),

--- a/modules/ca/src/client/convert.cpp
+++ b/modules/ca/src/client/convert.cpp
@@ -583,6 +583,8 @@ arrayElementCount   num         /* number of values     */
     pDest->status           = dbr_ntohs(pSrc->status);
     pDest->severity         = dbr_ntohs(pSrc->severity);
     pDest->no_str           = dbr_ntohs(pSrc->no_str);
+    if ( pDest->no_str > MAX_ENUM_STATES || pDest->no_str < 0 )
+        pDest->no_str = MAX_ENUM_STATES;
     if ( s != d ) {
         memcpy(pDest->strs, pSrc->strs, sizeof(pSrc->strs));
     }
@@ -1003,6 +1005,8 @@ arrayElementCount   num         /* number of values     */
     pDest->status           = dbr_ntohs(pSrc->status);
     pDest->severity         = dbr_ntohs(pSrc->severity);
     pDest->no_str           = dbr_ntohs(pSrc->no_str);
+    if ( pDest->no_str > MAX_ENUM_STATES || pDest->no_str < 0 )
+        pDest->no_str = MAX_ENUM_STATES;
     if ( s != d ) {
         memcpy(pDest->strs, pSrc->strs, sizeof(pSrc->strs));
     }

--- a/modules/ca/src/client/db_access.h
+++ b/modules/ca/src/client/db_access.h
@@ -19,6 +19,7 @@
 
 #include "epicsTypes.h"
 #include "epicsTime.h"
+#include "compilerSpecific.h"
 
 #include "libCaAPI.h"
 
@@ -551,6 +552,39 @@ LIBCA_API extern const unsigned short dbr_size[];
  * \sa dbr_size_n()
  */
 LIBCA_API extern const unsigned short dbr_value_size[];
+
+/** \brief Returns the size in bytes for a `DBR_XXXX` type with `count` elements.
+ *
+ * This is a range-checked, overflow-safe equivalent of the dbr_size_n() macro.
+ * If the DBR type is a structure then the value field is the last field in the
+ * structure. If `count` is greater than one then `count-1` elements are
+ * appended to the end of the structure so that they can be addressed as an
+ * array through a pointer to the value field. A negative `count` is treated as
+ * a single element.
+ *
+ * The result is computed and returned using 64-bit arithmetic so that a large
+ * (or malicious) element count cannot overflow the calculation. An invalid
+ * data type returns 0.
+ *
+ * \sa dbr_size, dbr_value_size, dbr_size_n
+ *
+ * \param[in] type The data type.
+ * \param[in] count The element count.
+ * \returns The size in bytes of the specified type
+ * with the specified number of elements.
+ */
+#ifndef db_accessHFORdb_accessC
+static EPICS_ALWAYS_INLINE
+epicsUInt64 dbr_size_chk(unsigned type, epicsInt64 count)
+{
+    if (type > (unsigned) LAST_BUFFER_TYPE)
+        return 0;
+    if (count < 0)
+        return dbr_size[type];
+    return (epicsUInt64) dbr_size[type]
+        + (epicsUInt64) (count - 1) * dbr_value_size[type];
+}
+#endif /*db_accessHFORdb_accessC*/
 
 #ifndef db_accessHFORdb_accessC
 /* class for each type's value */

--- a/modules/ca/src/client/getCopy.cpp
+++ b/modules/ca/src/client/getCopy.cpp
@@ -59,7 +59,7 @@ void getCopy::completion (
     epicsGuard < epicsMutex > & guard, unsigned typeIn,
     arrayElementCount countIn, const void *pDataIn )
 {
-    if ( this->type == typeIn ) {
+    if ( this->type == typeIn && countIn <= this->count ) {
         unsigned size = dbr_size_n ( typeIn, countIn );
         memcpy ( this->pValue, pDataIn, size );
         this->cacCtx.decrementOutstandingIO ( guard, this->ioSeqNo );

--- a/modules/ca/src/client/syncGroup.h
+++ b/modules/ca/src/client/syncGroup.h
@@ -86,6 +86,8 @@ private:
     CASG & sg;
     void * pValue;
     const unsigned magic;
+    arrayElementCount requestedCount;
+    unsigned requestedType;
     cacChannel::ioid id;
     bool idIsValid;
     bool ioComplete;

--- a/modules/ca/src/client/syncGroupReadNotify.cpp
+++ b/modules/ca/src/client/syncGroupReadNotify.cpp
@@ -40,6 +40,8 @@ void syncGroupReadNotify::begin (
     unsigned type, arrayElementCount count )
 {
     this->chan->eliminateExcessiveSendBacklog ( guard );
+    this->requestedType = type;
+    this->requestedCount = count;
     this->ioComplete = false;
     boolFlagManager mgr ( this->idIsValid );
     this->chan->read ( guard, type, count, *this, &this->id );
@@ -88,7 +90,8 @@ void syncGroupReadNotify::completion (
         return;
     }
 
-    if ( this->pValue ) {
+    if ( this->pValue && type == this->requestedType &&
+         count <= this->requestedCount ) {
         size_t size = dbr_size_n ( type, count );
         memcpy ( this->pValue, pData, size );
     }

--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -814,15 +814,17 @@ bool udpiiu::exceptionRespAction (
     char date[64];
     currentTime.strftime ( date, sizeof ( date ), "%a %b %d %Y %H:%M:%S");
 
-    if ( msg.m_postsize > sizeof ( caHdr ) ){
-        errlogPrintf (
-            ERL_ERROR " condition \"%s\" detected by %s with context \"%s\" at %s\n",
-            ca_message ( msg.m_available ),
-            name, reinterpret_cast <const char *> ( &reqMsg + 1 ), date );
+    int len = msg.m_postsize - sizeof( caHdr );
+    if ( len > 0 ) {
+        const char *ctx = reinterpret_cast<const char *>( &reqMsg + 1 );
+        len = epicsStrnLen ( ctx, len );
+        errlogPrintf ( ERL_ERROR
+            " condition \"%s\" detected by %s with context \"%.*s\" at %s\n",
+            ca_message ( msg.m_available ), name, len, ctx, date );
     }
-    else{
-        errlogPrintf (
-            ERL_ERROR " condition \"%s\" detected by %s at %s\n",
+    else {
+        errlogPrintf ( ERL_ERROR
+            " condition \"%s\" detected by %s at %s\n",
             ca_message ( msg.m_available ), name, date );
     }
 


### PR DESCRIPTION
This is an extension of my cac-protection branch PR #907 with the added `inline dbr_size_n()` function and action method checks using it within the CA Client code.

The original PR also included several other CA client hardening changes.