### PR TITLE
A few small database/CA client input-validation fixes

### DIFF
--- a/modules/ca/src/client/cac.cpp
+++ b/modules/ca/src/client/cac.cpp
@@ -33,6 +33,7 @@
 #include "epicsSignal.h"
 #include "envDefs.h"
 #include "locationException.h"
+#include "epicsMath.h"
 #include "errlog.h"
 #include "epicsExport.h"
 
@@ -186,10 +187,10 @@ cac::cac (
                                         static_cast <unsigned short> (CA_SERVER_PORT) );
 
         status = envGetDoubleConfigParam ( &EPICS_CA_CONN_TMO, &this->connTMO );
-        if ( status ) {
+        if ( status || ! finite ( this->connTMO ) || this->connTMO <= 0.0 ) {
             this->connTMO = CA_CONN_VERIFY_PERIOD;
             epicsGuard < epicsMutex > cbGuard ( this->cbMutex );
-            errlogPrintf ( "EPICS \"%s\" double fetch failed\n", EPICS_CA_CONN_TMO.name );
+            errlogPrintf ( "EPICS \"%s\" was not a positive real number\n", EPICS_CA_CONN_TMO.name );
             errlogPrintf ( "Defaulting \"%s\" = %f\n", EPICS_CA_CONN_TMO.name, this->connTMO );
         }
 

--- a/modules/ca/src/client/udpiiu.cpp
+++ b/modules/ca/src/client/udpiiu.cpp
@@ -30,6 +30,7 @@
 #include "osiProcess.h"
 #include "osiWireFormat.h"
 #include "epicsAlgorithm.h"
+#include "epicsMath.h"
 #include "errlog.h"
 #include "locationException.h"
 
@@ -73,7 +74,7 @@ double getMaxPeriod()
     if ( envGetConfigParamPtr ( & EPICS_CA_MAX_SEARCH_PERIOD ) ) {
         long longStatus = envGetDoubleConfigParam (
             & EPICS_CA_MAX_SEARCH_PERIOD, & maxPeriod );
-        if ( ! longStatus ) {
+        if ( ! longStatus && finite ( maxPeriod ) && maxPeriod > 0.0 ) {
             if ( maxPeriod < maxSearchPeriodLowerLimit ) {
                 epicsPrintf ( "\"%s\" out of range (low)\n",
                                 EPICS_CA_MAX_SEARCH_PERIOD.name );
@@ -83,7 +84,9 @@ double getMaxPeriod()
             }
         }
         else {
-            epicsPrintf ( "EPICS \"%s\" wasn't a real number\n",
+            /* Reset to default on parse error or out of range value */
+            maxPeriod = maxSearchPeriodDefault;
+            epicsPrintf ( "EPICS \"%s\" was not a positive real number\n",
                             EPICS_CA_MAX_SEARCH_PERIOD.name );
             epicsPrintf ( "Setting \"%s\" = %f seconds\n",
                 EPICS_CA_MAX_SEARCH_PERIOD.name, maxPeriod );

--- a/modules/database/src/ioc/rsrv/online_notify.c
+++ b/modules/database/src/ioc/rsrv/online_notify.c
@@ -27,6 +27,7 @@
 #include "addrList.h"
 #include "dbDefs.h"
 #include "envDefs.h"
+#include "epicsMath.h"
 #include "errlog.h"
 #include "osiSock.h"
 #include "taskwd.h"
@@ -55,9 +56,9 @@ void rsrv_online_notify_task(void *pParm)
     else {
         longStatus = envGetDoubleConfigParam ( & EPICS_CA_BEACON_PERIOD, & maxPeriod );
     }
-    if (longStatus || maxPeriod<=0.0) {
+    if (longStatus || !finite(maxPeriod) || maxPeriod<=0.0) {
         maxPeriod = 15.0;
-        epicsPrintf ("EPICS \"%s\" float fetch failed\n",
+        epicsPrintf ("EPICS \"%s\" was not a positive real number\n",
                         EPICS_CAS_BEACON_PERIOD.name);
         epicsPrintf ("Setting \"%s\" = %f\n",
             EPICS_CAS_BEACON_PERIOD.name, maxPeriod);

--- a/modules/database/src/std/rec/calcRecord.dbd.pod
+++ b/modules/database/src/std/rec/calcRecord.dbd.pod
@@ -636,55 +636,46 @@ manner for the VAL field.
 	}
 	field(INPM,DBF_INLINK) {
 		prompt("Input M")
-		special(SPC_MOD)
 		promptgroup("43 - Input M-R")
 		interest(1)
 	}
 	field(INPN,DBF_INLINK) {
 		prompt("Input N")
-		special(SPC_MOD)
 		promptgroup("43 - Input M-R")
 		interest(1)
 	}
 	field(INPO,DBF_INLINK) {
 		prompt("Input O")
-		special(SPC_MOD)
 		promptgroup("43 - Input M-R")
 		interest(1)
 	}
 	field(INPP,DBF_INLINK) {
 		prompt("Input P")
-		special(SPC_MOD)
 		promptgroup("43 - Input M-R")
 		interest(1)
 	}
 	field(INPQ,DBF_INLINK) {
 		prompt("Input Q")
-		special(SPC_MOD)
 		promptgroup("43 - Input M-R")
 		interest(1)
 	}
 	field(INPR,DBF_INLINK) {
 		prompt("Input R")
-		special(SPC_MOD)
 		promptgroup("43 - Input M-R")
 		interest(1)
 	}
 	field(INPS,DBF_INLINK) {
 		prompt("Input S")
-		special(SPC_MOD)
 		promptgroup("44 - Input S-U")
 		interest(1)
 	}
 	field(INPT,DBF_INLINK) {
 		prompt("Input T")
-		special(SPC_MOD)
 		promptgroup("44 - Input S-U")
 		interest(1)
 	}
 	field(INPU,DBF_INLINK) {
 		prompt("Input U")
-		special(SPC_MOD)
 		promptgroup("44 - Input S-U")
 		interest(1)
 	}


### PR DESCRIPTION
# A few small database/CA client input-validation fixes

## Summary

Four small, independent input-validation fixes, each matching the guard or
declaration idiom already present next to it:

1. **`EPICS_CA_CONN_TMO`** (`cac.cpp`) — a successful parse of a non-positive
   or non-finite value is stored unchecked, leaving the connection-verify
   watchdog deadline permanently in the past (non-positive: continuous
   "Virtual circuit unresponsive" flood + a spinning core) or never reached
   (inf/NaN: circuit verification silently disabled or undefined).
2. **`EPICS_CA_MAX_SEARCH_PERIOD`** (`udpiiu.cpp`) — a non-finite value
   (`inf`/`nan`) slips past the only range gate and reaches an undefined
   float→unsigned conversion: `inf` aborts the client in `malloc`, `nan`
   drives the search-timer wheel off a NaN period. A non-positive value is
   also treated as invalid rather than clamped up to the 60 s lower limit.
3. **Beacon period** (`online_notify.c`) — the same lenient-parse shape on
   the server side: `nan` pins the beacon interval at the 0.02 s startup
   value (a ~50 Hz beacon flood on every interface), `inf` lets the doubling
   delay grow without bound, silencing beacons.
4. **`calcRecord` `INPM`..`INPU`** (`calcRecord.dbd.pod`) — nine input-link
   fields declare a `special(SPC_MOD)` the record's `special()` never
   implements, so every `caput`/`dbPutField` to them fails with
   `S_db_badChoice`; nine documented links are unwritable at run time.

The first three share a root shape (a lenient `envGetDoubleConfigParam`
parse consumed without a usability check); the fourth is a dbd/handler
mismatch in the same subsystem. Each is a separate commit and can be split
if a maintainer prefers.

## `EPICS_CA_CONN_TMO` — a non-positive or non-finite value is accepted

`modules/ca/src/client/cac.cpp`, `cac::cac`:

```cpp
status = envGetDoubleConfigParam ( &EPICS_CA_CONN_TMO, &this->connTMO );
if ( status ) {
    this->connTMO = CA_CONN_VERIFY_PERIOD;   // only the parse-FAILURE path defaults
    ...
}
```

The 30 s default (`CA_CONN_VERIFY_PERIOD`) is applied only when the parse
*fails*. A successful parse of `-5`, `0`, `nan`, or `inf` is stored into
`connTMO` unchecked. `connTMO` is the connection-verify watchdog period (it
is handed to the `tcpiiu` at `cac.cpp:557` and returned by
`cac::connectionTimeout`), so a non-positive value leaves the circuit-verify
deadline permanently in the past: the watchdog fires on every pass, emitting
"Virtual circuit unresponsive" continuously and spinning a CPU. A NaN
period leaves the watchdog deadline arithmetic undefined, and an infinite
period silently disables circuit verification.

### Reachability

`EPICS_CA_CONN_TMO=-5` (or `=0`, `=nan`, `=inf`) — a single
environment/`.cfg` typo — on any CA client (`caget`, `camonitor`, an IOC's
CA client, any `libca` consumer). No special build or platform is required.

### Fix

Fold the validity check into the existing parse-failure branch, so an
unparsable, non-finite, or non-positive value takes the same path: warn
once and fall back to the 30 s `CA_CONN_VERIFY_PERIOD` default. This
mirrors the sibling `EPICS_CA_MAX_ARRAY_BYTES` handling a few lines below,
which already folds a range check (`maxBytesAsALong < 0`) into one
condition with the parse status, and matches the `finite()` gate on
`EPICS_CA_MAX_SEARCH_PERIOD` below.

## `EPICS_CA_MAX_SEARCH_PERIOD` — a non-finite value slips past the range gate

`modules/ca/src/client/udpiiu.cpp`, `getMaxPeriod` / `getNTimers`:

```cpp
if ( ! longStatus ) {
    if ( maxPeriod < maxSearchPeriodLowerLimit ) { ... }   // NaN and inf are both false here
}
...
unsigned nTimers =
    static_cast<unsigned>( 1.0 + log(maxPeriod/minRoundTripEstimate)/log(2.0) );
```

`epicsScanDouble` accepts `"inf"` and `"nan"`, so `envGetDoubleConfigParam`
returns success and writes a non-finite value into `maxPeriod`. The only
value gate is `maxPeriod < maxSearchPeriodLowerLimit`, and that comparison
is `false` for both `inf` and `NaN`, so a non-finite period survives
`getMaxPeriod` untouched and reaches `getNTimers`. There, the
`static_cast<unsigned>` of a non-finite double is an undefined
float→unsigned conversion (C++ `[conv.fpint]`):

- `inf` yields a garbage `nTimers`, which sizes the search-timer
  allocation and aborts the client in `malloc` at startup.
- `NaN` yields a garbage `nTimers` and leaves the search back-off ladder
  driven by NaN arithmetic, where every deadline comparison is `false` and
  resolver cadence is undefined.

`getMaxPeriod()` is the sole caller of `getNTimers()` (both feed the
`udpiiu` member initializer list), so guaranteeing a finite, positive
`maxPeriod` in `getMaxPeriod` makes the conversion well-defined by
construction.

### Reachability

`EPICS_CA_MAX_SEARCH_PERIOD=inf` aborts every CA client at startup;
`=nan` leaves search resolution running off NaN periods. Again a single
environment/`.cfg` value on any `libca` consumer; no special build required.

### Fix

Gate the parsed value on `finite()` (from `epicsMath.h`, which maps to
`isfinite` portably across EPICS targets) and positivity alongside the
existing parse status, and fall back to `maxSearchPeriodDefault` on the
else path. A non-positive period is not a "low" period to be clamped up to
the 60 s lower limit; it takes the same invalid-input path as `inf`/`NaN`.
The reset assignment is a no-op for the genuine parse-failure case
(`envGetDoubleConfigParam` leaves the output unmodified on failure — see
`envSubr.c:201-204` — so `maxPeriod` is still at its default there) and
correctly discards the value that a successful parse wrote on the new path.

All invalid inputs fall back to the 300 s default rather than being split
into low/high clamps. This is the minimal change that removes the UB and
produces a sane, documented value with an honest diagnostic.

## Beacon period — the same shape on the server side

`modules/database/src/ioc/rsrv/online_notify.c` already gates a parse
failure and a non-positive value:

```c
if (longStatus || maxPeriod<=0.0) {     /* NaN and inf are both false here */
    maxPeriod = 15.0;
```

but `nan` and `inf` parse successfully and pass both tests, reaching the
beacon delay loop:

```c
epicsThreadSleep(delay);
if (delay<maxdelay) {
    delay *= 2.0;
    if (delay>maxdelay) {
        delay = maxdelay;
```

With a NaN `maxdelay`, `delay<maxdelay` is `false` forever, so `delay`
stays at its 0.02 s startup value — a ~50 Hz beacon flood on every
configured interface. With an infinite `maxdelay`, the doubling `delay` is
never clamped and grows without bound, silencing beacons entirely (and
with them, client disconnect-recovery hints).

### Fix

Add `!finite(maxPeriod)` to the existing gate, matching the client-side
`EPICS_CA_MAX_SEARCH_PERIOD` handling, and name the actual problem in the
diagnostic instead of "float fetch failed" (the message already covered
the pre-existing non-positive case, which is not a fetch failure).

## `calcRecord` `INPM`..`INPU` — a `special(SPC_MOD)` the record never handles

`modules/database/src/std/rec/calcRecord.dbd.pod` declares `special(SPC_MOD)`
on the nine input links `INPM`..`INPU`:

```
field(INPM,DBF_INLINK) {
    prompt("Input M")
    special(SPC_MOD)      # INPA..INPL carry no special
    ...
}
```

But `calcRecord.c`'s `special()` implements only `SPC_CALC` and rejects
everything else:

```c
static long special(DBADDR *paddr, int after)
{
    if (!after) return 0;
    if (paddr->special == SPC_CALC) { ... return 0; }
    recGblDbaddrError(S_db_badChoice, paddr, "calc::special - bad special value!");
    return S_db_badChoice;
}
```

`SPC_MOD` is not `SPC_CALC`, so any `dbPutField`/`caput` to `INPM`..`INPU`
runs `special(after=TRUE)`, hits the fall-through, and returns
`S_db_badChoice` ("bad special value"). The result is that nine documented
link fields cannot be re-pointed at run time — only set at `.db` load time —
while the twelve sibling links `INPA`..`INPL`, which carry no `special`,
accept writes fine.

### Fix shape chosen — (a) remove the erroneous attribute

I removed `special(SPC_MOD)` from the nine `INPM`..`INPU` fields so they match
`INPA`..`INPL`, rather than (b) making `special()` return 0 for `SPC_MOD`.
The convention decides this:

- **`SPC_MOD` is never a declared-but-no-op attribute in Base.** `special.h`
  documents it as "useful when record support must be notified of a field
  changing value", and every Base record that declares it on a link field
  *handles* it. The sibling `calcoutRecord` declares `special(SPC_MOD)` on
  all of `INPA`..`INPU` **and** implements it — its `special()` re-runs
  `recGblInitConstantLink`, re-evaluates link validity/connection state, and
  posts events. Shape (b) would introduce a declared-but-no-op `SPC_MOD` that
  no Base record uses.
- **`calcRecord` does no run-time link re-initialization**, so there is no
  work for a handler to do. It initializes all 21 constant links once in
  `init_record` and otherwise re-reads links every `process` via `dbGetLink`;
  it has no per-link `special()` machinery like `calcoutRecord`. So the nine
  fields having `SPC_MOD` was simply an erroneous attribute (the `M`..`U`
  expansion picked it up while the handler and the `A`..`L` siblings never
  did), with no backing behaviour to preserve.
- Shape (a) also makes the record internally uniform — all 21 input links
  treated identically, none carrying `special` — and leaves `special()`
  invoked only for `CALC`, the one field that still carries a `special`
  (`SPC_CALC`). The `S_db_badChoice` fall-through is kept as a genuine
  safety net for unexpected special values.

This makes `caput CALC.INPM "other.VAL CP"` succeed, matching `INPA`..`INPL`.

## Family check

- `envGetDoubleConfigParam` has exactly three consumer sites in the tree —
  `cac.cpp` (`EPICS_CA_CONN_TMO`), `udpiiu.cpp`
  (`EPICS_CA_MAX_SEARCH_PERIOD`), and `online_notify.c`
  (`EPICS_CAS_BEACON_PERIOD`/`EPICS_CA_BEACON_PERIOD`) — and all three are
  now gated on finiteness and positivity.
- `udpiiu.cpp` — the other `static_cast<unsigned>` of a period-derived
  double, `beaconAnomalyTimerIndex` at line ~163, derives from the
  compile-time constant `beaconAnomalySearchPeriod`, not from user input,
  so it is finite by construction and is left unchanged. `getNTimers` is
  the only env-input-reachable float→unsigned conversion.
- `calcRecord.dbd.pod` — `special(SPC_MOD)` appears only on `INPM`..`INPU`
  (nine hits, all removed); `SPC_CALC` on `CALC` and the `SPC_NOMOD` fields
  are untouched. Across the other Base records that declare `SPC_MOD`
  (`calcoutRecord`, the `ai/ao`/`SIMM`/`SGNL`/`OUT` etc. fields), each has a
  `special()` that handles it, so `calcRecord` is the sole
  declared-but-unhandled case.

## Testing

Not compiled locally — this checkout has no EPICS support tree configured,
so the module build was not run here. The changes are a syntax-level review
against the surrounding code: `finite` comes from `epicsMath.h` (newly
included in `cac.cpp` and `online_notify.c`, already present in
`udpiiu.cpp`), all guards reuse constants, message idioms, and mutex guards
already present in the touched functions, and the `calcRecord` change only
deletes nine attribute lines so the fields match their existing siblings.
CI will compile the sources and run the test suite.

Suggested manual verification once built:

- `EPICS_CA_CONN_TMO=-5 camonitor SOME:PV` (also `=0`, `=nan`, `=inf`) —
  before: continuous "Virtual circuit unresponsive" flood + a spinning
  core (`-5`/`0`), undefined deadline arithmetic (`nan`), or silently
  disabled circuit verification (`inf`); after: one warning, then the 30 s
  default watchdog period.
- `EPICS_CA_MAX_SEARCH_PERIOD=inf caget SOME:PV` — before: abort in
  `malloc` at startup; after: one warning, then the 300 s default.
- `EPICS_CA_MAX_SEARCH_PERIOD=nan caget SOME:PV` — before: NaN-driven
  search cadence; after: one warning, then the 300 s default.
- `EPICS_CA_BEACON_PERIOD=nan softIoc` — before: ~50 Hz beacon flood;
  `=inf` — before: beacons stop after the delay doubles past any bound;
  after: one warning, then the 15 s default.
- `caput CALC.INPM "other.VAL CP"` on a calc record — before:
  `S_db_badChoice` ("bad special value"); after: the write succeeds, as it
  already does for `caput CALC.INPA ...`.
