### PR TITLE
database: define the float/double → integer conversion (remove undefined behaviour)

### DIFF
--- a/modules/database/src/ioc/db/dbConvert.c
+++ b/modules/database/src/ioc/db/dbConvert.c
@@ -18,11 +18,14 @@
 #include <string.h>
 #include <math.h>
 #include <float.h>
+#include <limits.h>
 
 #include "cvtFast.h"
+#include "epicsMath.h"
 #include "dbDefs.h"
 #include "epicsConvert.h"
 #include "epicsStdlib.h"
+#include "epicsTypes.h"
 #include "errlog.h"
 #include "errMdef.h"
 
@@ -123,6 +126,71 @@ static void copyNoConvert(const void *pfrom,
         return 0; \
     } \
     COPYNOCONVERT(sizeof(typeb), pfrom, paddr->pfield, nRequest, no_elements, offset); \
+    return 0; \
+}
+
+/* Saturating floating-point -> integer assignment.
+ *
+ * A bare C cast of a floating value that is out of the integer type's
+ * range, or is NaN, to that integer type is undefined behaviour
+ * (C17 6.3.1.4p1). The value produced diverges by target: x86-64
+ * (cvttsd2si) yields INT_MIN, aarch64 (fcvtzs) saturates and maps NaN
+ * to 0 -- both ordinary EPICS platforms. Define the conversion instead:
+ * clamp to [imin, imax] and map NaN to 0 (the aarch64 behaviour).
+ *
+ * imin/imax are the destination type's min/max as integer constants; the
+ * (double) casts are the saturation thresholds. For the 64-bit types the
+ * true max is not representable as a double and (double)imax rounds up to
+ * 2^63 / 2^64, which is exactly the threshold at which the value no longer
+ * fits, so the comparison stays correct while the assigned constant is the
+ * exact type max. +/-Inf fall through to the imax/imin branches.
+ */
+#define ASSIGN_SAT(pdst, val, typeb, imin, imax) \
+    do { \
+        double _v = (double) (val); \
+        if (isnan(_v))                 *(pdst) = 0; \
+        else if (_v <= (double)(imin)) *(pdst) = (imin); \
+        else if (_v >= (double)(imax)) *(pdst) = (imax); \
+        else                           *(pdst) = (typeb) _v; \
+    } while (0)
+
+#define GET_SAT(typea, typeb, imin, imax) (const dbAddr *paddr, \
+    void *pto, long nRequest, long no_elements, long offset) \
+{ \
+    typea *psrc = (typea *) paddr->pfield; \
+    typeb *pdst = (typeb *) pto; \
+    \
+    if (nRequest==1 && offset==0) { \
+        ASSIGN_SAT(pdst, *psrc, typeb, imin, imax); \
+        return 0; \
+    } \
+    psrc += offset; \
+    while (nRequest--) { \
+        ASSIGN_SAT(pdst, *psrc, typeb, imin, imax); \
+        pdst++; psrc++; \
+        if (++offset == no_elements) \
+            psrc = (typea *) paddr->pfield; \
+    } \
+    return 0; \
+}
+
+#define PUT_SAT(typea, typeb, imin, imax) (dbAddr *paddr, \
+    const void *pfrom, long nRequest, long no_elements, long offset) \
+{ \
+    const typea *psrc = (const typea *) pfrom; \
+    typeb *pdst = (typeb *) paddr->pfield; \
+    \
+    if (nRequest==1 && offset==0) { \
+        ASSIGN_SAT(pdst, *psrc, typeb, imin, imax); \
+        return 0; \
+    } \
+    pdst += offset; \
+    while (nRequest--) { \
+        ASSIGN_SAT(pdst, *psrc, typeb, imin, imax); \
+        pdst++; psrc++; \
+        if (++offset == no_elements) \
+            pdst = (typeb *) paddr->pfield; \
+    } \
     return 0; \
 }
 
@@ -757,17 +825,17 @@ static long getFloatString(const dbAddr *paddr,
     return(status);
 }
 
-static long getFloatChar GET(epicsFloat32, char)
-static long getFloatUchar GET(epicsFloat32, epicsUInt8)
-static long getFloatShort GET(epicsFloat32, epicsInt16)
-static long getFloatUshort GET(epicsFloat32, epicsUInt16)
-static long getFloatLong GET(epicsFloat32, epicsInt32)
-static long getFloatUlong GET(epicsFloat32, epicsUInt32)
-static long getFloatInt64 GET(epicsFloat32, epicsInt64)
-static long getFloatUInt64 GET(epicsFloat32, epicsUInt64)
+static long getFloatChar GET_SAT(epicsFloat32, char, CHAR_MIN, CHAR_MAX)
+static long getFloatUchar GET_SAT(epicsFloat32, epicsUInt8, 0, UCHAR_MAX)
+static long getFloatShort GET_SAT(epicsFloat32, epicsInt16, SHRT_MIN, SHRT_MAX)
+static long getFloatUshort GET_SAT(epicsFloat32, epicsUInt16, 0, USHRT_MAX)
+static long getFloatLong GET_SAT(epicsFloat32, epicsInt32, INT_MIN, INT_MAX)
+static long getFloatUlong GET_SAT(epicsFloat32, epicsUInt32, 0, UINT_MAX)
+static long getFloatInt64 GET_SAT(epicsFloat32, epicsInt64, epicsInt64Min, epicsInt64Max)
+static long getFloatUInt64 GET_SAT(epicsFloat32, epicsUInt64, 0, epicsUInt64Max)
 static long getFloatFloat GET_NOCONVERT(epicsFloat32, epicsFloat32)
 static long getFloatDouble GET(epicsFloat32, epicsFloat64)
-static long getFloatEnum GET(epicsFloat32, epicsEnum16)
+static long getFloatEnum GET_SAT(epicsFloat32, epicsEnum16, 0, USHRT_MAX)
 
 static long getDoubleString(const dbAddr *paddr,
     void *pto, long nRequest, long no_elements, long offset)
@@ -798,14 +866,14 @@ static long getDoubleString(const dbAddr *paddr,
     return(status);
 }
 
-static long getDoubleChar GET(epicsFloat64, char)
-static long getDoubleUchar GET(epicsFloat64, epicsUInt8)
-static long getDoubleShort GET(epicsFloat64, epicsInt16)
-static long getDoubleUshort GET(epicsFloat64, epicsUInt16)
-static long getDoubleLong GET(epicsFloat64, epicsInt32)
-static long getDoubleUlong GET(epicsFloat64, epicsUInt32)
-static long getDoubleInt64 GET(epicsFloat64, epicsInt64)
-static long getDoubleUInt64 GET(epicsFloat64, epicsUInt64)
+static long getDoubleChar GET_SAT(epicsFloat64, char, CHAR_MIN, CHAR_MAX)
+static long getDoubleUchar GET_SAT(epicsFloat64, epicsUInt8, 0, UCHAR_MAX)
+static long getDoubleShort GET_SAT(epicsFloat64, epicsInt16, SHRT_MIN, SHRT_MAX)
+static long getDoubleUshort GET_SAT(epicsFloat64, epicsUInt16, 0, USHRT_MAX)
+static long getDoubleLong GET_SAT(epicsFloat64, epicsInt32, INT_MIN, INT_MAX)
+static long getDoubleUlong GET_SAT(epicsFloat64, epicsUInt32, 0, UINT_MAX)
+static long getDoubleInt64 GET_SAT(epicsFloat64, epicsInt64, epicsInt64Min, epicsInt64Max)
+static long getDoubleUInt64 GET_SAT(epicsFloat64, epicsUInt64, 0, epicsUInt64Max)
 
 static long getDoubleFloat(const dbAddr *paddr,
     void *pto, long nRequest, long no_elements, long offset)
@@ -828,7 +896,7 @@ static long getDoubleFloat(const dbAddr *paddr,
 }
 
 static long getDoubleDouble GET_NOCONVERT(epicsFloat64, epicsFloat64)
-static long getDoubleEnum GET(epicsFloat64, epicsEnum16)
+static long getDoubleEnum GET_SAT(epicsFloat64, epicsEnum16, 0, USHRT_MAX)
 
 static long getEnumString(const dbAddr *paddr,
     void *pto, long nRequest, long no_elements, long offset)
@@ -1585,17 +1653,17 @@ static long putFloatString(dbAddr *paddr,
     return(status);
 }
 
-static long putFloatChar PUT(epicsFloat32, char)
-static long putFloatUchar PUT(epicsFloat32, epicsUInt8)
-static long putFloatShort PUT(epicsFloat32, epicsInt16)
-static long putFloatUshort PUT(epicsFloat32, epicsUInt16)
-static long putFloatLong PUT(epicsFloat32, epicsInt32)
-static long putFloatUlong PUT(epicsFloat32, epicsUInt32)
-static long putFloatInt64 PUT(epicsFloat32, epicsInt64)
-static long putFloatUInt64 PUT(epicsFloat32, epicsUInt64)
+static long putFloatChar PUT_SAT(epicsFloat32, char, CHAR_MIN, CHAR_MAX)
+static long putFloatUchar PUT_SAT(epicsFloat32, epicsUInt8, 0, UCHAR_MAX)
+static long putFloatShort PUT_SAT(epicsFloat32, epicsInt16, SHRT_MIN, SHRT_MAX)
+static long putFloatUshort PUT_SAT(epicsFloat32, epicsUInt16, 0, USHRT_MAX)
+static long putFloatLong PUT_SAT(epicsFloat32, epicsInt32, INT_MIN, INT_MAX)
+static long putFloatUlong PUT_SAT(epicsFloat32, epicsUInt32, 0, UINT_MAX)
+static long putFloatInt64 PUT_SAT(epicsFloat32, epicsInt64, epicsInt64Min, epicsInt64Max)
+static long putFloatUInt64 PUT_SAT(epicsFloat32, epicsUInt64, 0, epicsUInt64Max)
 static long putFloatFloat PUT_NOCONVERT(epicsFloat32, epicsFloat32)
 static long putFloatDouble PUT(epicsFloat32, epicsFloat64)
-static long putFloatEnum PUT(epicsFloat32, epicsEnum16)
+static long putFloatEnum PUT_SAT(epicsFloat32, epicsEnum16, 0, USHRT_MAX)
 
 static long putDoubleString(dbAddr *paddr,
     const void *pfrom, long nRequest, long no_elements, long offset)
@@ -1627,14 +1695,14 @@ static long putDoubleString(dbAddr *paddr,
     return status;
 }
 
-static long putDoubleChar PUT(epicsFloat64, char)
-static long putDoubleUchar PUT(epicsFloat64, epicsUInt8)
-static long putDoubleShort PUT(epicsFloat64, epicsInt16)
-static long putDoubleUshort PUT(epicsFloat64, epicsUInt16)
-static long putDoubleLong PUT(epicsFloat64, epicsInt32)
-static long putDoubleUlong PUT(epicsFloat64, epicsUInt32)
-static long putDoubleInt64 PUT(epicsFloat64, epicsInt64)
-static long putDoubleUInt64 PUT(epicsFloat64, epicsUInt64)
+static long putDoubleChar PUT_SAT(epicsFloat64, char, CHAR_MIN, CHAR_MAX)
+static long putDoubleUchar PUT_SAT(epicsFloat64, epicsUInt8, 0, UCHAR_MAX)
+static long putDoubleShort PUT_SAT(epicsFloat64, epicsInt16, SHRT_MIN, SHRT_MAX)
+static long putDoubleUshort PUT_SAT(epicsFloat64, epicsUInt16, 0, USHRT_MAX)
+static long putDoubleLong PUT_SAT(epicsFloat64, epicsInt32, INT_MIN, INT_MAX)
+static long putDoubleUlong PUT_SAT(epicsFloat64, epicsUInt32, 0, UINT_MAX)
+static long putDoubleInt64 PUT_SAT(epicsFloat64, epicsInt64, epicsInt64Min, epicsInt64Max)
+static long putDoubleUInt64 PUT_SAT(epicsFloat64, epicsUInt64, 0, epicsUInt64Max)
 
 static long putDoubleFloat(dbAddr *paddr,
     const void *pfrom, long nRequest, long no_elements, long offset)
@@ -1656,7 +1724,7 @@ static long putDoubleFloat(dbAddr *paddr,
 }
 
 static long putDoubleDouble PUT_NOCONVERT(epicsFloat64, epicsFloat64)
-static long putDoubleEnum PUT(epicsFloat64, epicsEnum16)
+static long putDoubleEnum PUT_SAT(epicsFloat64, epicsEnum16, 0, USHRT_MAX)
 
 static long putEnumString(dbAddr *paddr,
     const void *pfrom, long nRequest, long no_elements, long offset)

--- a/modules/database/src/ioc/db/dbFastLinkConv.c
+++ b/modules/database/src/ioc/db/dbFastLinkConv.c
@@ -17,13 +17,16 @@
 #include <string.h>
 #include <math.h>
 #include <float.h>
+#include <limits.h>
 
 #include "alarm.h"
 #include "cvtFast.h"
+#include "epicsMath.h"
 #include "dbDefs.h"
 #include "epicsConvert.h"
 #include "epicsStdlib.h"
 #include "epicsStdio.h"
+#include "epicsTypes.h"
 #include "errlog.h"
 #include "errMdef.h"
 
@@ -69,6 +72,32 @@
  *  A DB_LINK that is not initialized with recGblInitFastXXXLink()
  *     will have this conversion.
  */
+
+/* Saturating floating-point -> integer assignment.
+ *
+ * A bare C cast of a floating value that is out of the integer type's
+ * range, or is NaN, to that integer type is undefined behaviour
+ * (C17 6.3.1.4p1). The value produced diverges by target: x86-64
+ * (cvttsd2si) yields INT_MIN, aarch64 (fcvtzs) saturates and maps NaN
+ * to 0 -- both ordinary EPICS platforms. Define the conversion instead:
+ * clamp to [imin, imax] and map NaN to 0 (the aarch64 behaviour). This
+ * matches dbConvert.c's GET_SAT/PUT_SAT on the CA/network conversion path.
+ *
+ * imin/imax are the destination type's min/max as integer constants; the
+ * (double) casts are the saturation thresholds. For the 64-bit types the
+ * true max is not representable as a double and (double)imax rounds up to
+ * 2^63 / 2^64, which is exactly the threshold at which the value no longer
+ * fits, so the comparison stays correct while the assigned constant is the
+ * exact type max. +/-Inf fall through to the imax/imin branches.
+ */
+#define ASSIGN_SAT(pdst, val, typeb, imin, imax) \
+    do { \
+        double _v = (double) (val); \
+        if (isnan(_v))                 *(pdst) = 0; \
+        else if (_v <= (double)(imin)) *(pdst) = (imin); \
+        else if (_v >= (double)(imax)) *(pdst) = (imax); \
+        else                           *(pdst) = (typeb) _v; \
+    } while (0)
 
 /* Convert String to String */
 static long cvt_st_st(const void *f, void *t, const dbAddr *paddr)
@@ -1235,7 +1264,7 @@ static long cvt_f_c(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat32 *from = (const epicsFloat32 *) f;
     epicsInt8 *to = (epicsInt8 *) t;
-    *to=(epicsInt8)*from;
+    ASSIGN_SAT(to, *from, epicsInt8, SCHAR_MIN, SCHAR_MAX);
     return 0;
 }
 
@@ -1244,7 +1273,7 @@ static long cvt_f_uc(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat32 *from = (const epicsFloat32 *) f;
     epicsUInt8 *to = (epicsUInt8 *) t;
-    *to=(epicsUInt8)*from;
+    ASSIGN_SAT(to, *from, epicsUInt8, 0, UCHAR_MAX);
     return 0;
 }
 
@@ -1253,7 +1282,7 @@ static long cvt_f_s(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat32 *from = (const epicsFloat32 *) f;
     epicsInt16 *to = (epicsInt16 *) t;
-    *to=(epicsInt16)*from;
+    ASSIGN_SAT(to, *from, epicsInt16, SHRT_MIN, SHRT_MAX);
     return 0;
 }
 
@@ -1262,7 +1291,7 @@ static long cvt_f_us(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat32 *from = (const epicsFloat32 *) f;
     epicsUInt16 *to = (epicsUInt16 *) t;
-    *to=(epicsUInt16)*from;
+    ASSIGN_SAT(to, *from, epicsUInt16, 0, USHRT_MAX);
     return 0;
 }
 
@@ -1271,7 +1300,7 @@ static long cvt_f_l(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat32 *from = (const epicsFloat32 *) f;
     epicsInt32 *to = (epicsInt32 *) t;
-    *to=(epicsInt32)*from;
+    ASSIGN_SAT(to, *from, epicsInt32, INT_MIN, INT_MAX);
     return 0;
 }
 
@@ -1280,7 +1309,7 @@ static long cvt_f_ul(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat32 *from = (const epicsFloat32 *) f;
     epicsUInt32 *to = (epicsUInt32 *) t;
-    *to=(epicsUInt32)*from;
+    ASSIGN_SAT(to, *from, epicsUInt32, 0, UINT_MAX);
     return 0;
 }
 
@@ -1289,7 +1318,7 @@ static long cvt_f_q(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat32 *from = (const epicsFloat32 *) f;
     epicsInt64 *to = (epicsInt64 *) t;
-    *to=*from;
+    ASSIGN_SAT(to, *from, epicsInt64, epicsInt64Min, epicsInt64Max);
     return 0;
 }
 
@@ -1298,7 +1327,7 @@ static long cvt_f_uq(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat32 *from = (const epicsFloat32 *) f;
     epicsUInt64 *to = (epicsUInt64 *) t;
-    *to=*from;
+    ASSIGN_SAT(to, *from, epicsUInt64, 0, epicsUInt64Max);
     return 0;
 }
 
@@ -1325,7 +1354,7 @@ static long cvt_f_e(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat32 *from = (const epicsFloat32 *) f;
     epicsEnum16 *to = (epicsEnum16 *) t;
-    *to=(epicsEnum16)*from;
+    ASSIGN_SAT(to, *from, epicsEnum16, 0, USHRT_MAX);
     return 0;
 }
 
@@ -1351,7 +1380,7 @@ static long cvt_d_c(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat64 *from = (const epicsFloat64 *) f;
     epicsInt8 *to = (epicsInt8 *) t;
-    *to=(epicsInt8)*from;
+    ASSIGN_SAT(to, *from, epicsInt8, SCHAR_MIN, SCHAR_MAX);
     return 0;
 }
 
@@ -1360,7 +1389,7 @@ static long cvt_d_uc(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat64 *from = (const epicsFloat64 *) f;
     epicsUInt8 *to = (epicsUInt8 *) t;
-    *to=(epicsUInt8)*from;
+    ASSIGN_SAT(to, *from, epicsUInt8, 0, UCHAR_MAX);
     return 0;
 }
 
@@ -1369,7 +1398,7 @@ static long cvt_d_s(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat64 *from = (const epicsFloat64 *) f;
     epicsInt16 *to = (epicsInt16 *) t;
-    *to=(epicsInt16)*from;
+    ASSIGN_SAT(to, *from, epicsInt16, SHRT_MIN, SHRT_MAX);
     return 0;
 }
 
@@ -1378,7 +1407,7 @@ static long cvt_d_us(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat64 *from = (const epicsFloat64 *) f;
     epicsUInt16 *to = (epicsUInt16 *) t;
-    *to=(epicsUInt16)*from;
+    ASSIGN_SAT(to, *from, epicsUInt16, 0, USHRT_MAX);
     return 0;
 }
 
@@ -1387,7 +1416,7 @@ static long cvt_d_l(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat64 *from = (const epicsFloat64 *) f;
     epicsInt32 *to = (epicsInt32 *) t;
-    *to=*from;
+    ASSIGN_SAT(to, *from, epicsInt32, INT_MIN, INT_MAX);
     return 0;
 }
 
@@ -1396,7 +1425,7 @@ static long cvt_d_ul(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat64 *from = (const epicsFloat64 *) f;
     epicsUInt32 *to = (epicsUInt32 *) t;
-    *to=*from;
+    ASSIGN_SAT(to, *from, epicsUInt32, 0, UINT_MAX);
     return 0;
 }
 
@@ -1405,7 +1434,7 @@ static long cvt_d_q(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat64 *from = (const epicsFloat64 *) f;
     epicsInt64 *to = (epicsInt64 *) t;
-    *to=*from;
+    ASSIGN_SAT(to, *from, epicsInt64, epicsInt64Min, epicsInt64Max);
     return 0;
 }
 
@@ -1414,7 +1443,7 @@ static long cvt_d_uq(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat64 *from = (const epicsFloat64 *) f;
     epicsUInt64 *to = (epicsUInt64 *) t;
-    *to=*from;
+    ASSIGN_SAT(to, *from, epicsUInt64, 0, epicsUInt64Max);
     return 0;
 }
 
@@ -1439,7 +1468,7 @@ static long cvt_d_e(const void *f, void *t, const dbAddr *paddr)
 {
     const epicsFloat64 *from = (const epicsFloat64 *) f;
     epicsEnum16 *to = (epicsEnum16 *) t;
-    *to=(epicsEnum16)*from;
+    ASSIGN_SAT(to, *from, epicsEnum16, 0, USHRT_MAX);
     return 0;
 }
 

--- a/modules/database/test/std/rec/printfTest.c
+++ b/modules/database/test/std/rec/printfTest.c
@@ -375,7 +375,10 @@ static void test_prec_flag(void){
 static void test_h_flag(void){
 
     const char format_string[] = "Format test string %hx";
-    const char result_string[] = "Format test string baba";
+    /* The 'h' modifier makes doPrintf() fetch the link as a DBR_USHORT.
+     * 0xffbaba is out of range for an epicsUInt16, so the conversion from
+     * the DBF_DOUBLE input field saturates at USHRT_MAX. */
+    const char result_string[] = "Format test string ffff";
 
     /* set format string */
     testdbPutFieldOk("test_printf_rec.FMT", DBF_STRING, format_string);
@@ -392,7 +395,10 @@ static void test_h_flag(void){
 static void test_hh_flag(void){
 
     const char format_string[] = "Format test string %hhx";
-    const char result_string[] = "Format test string c1";
+    /* The 'hh' modifier makes doPrintf() fetch the link as a DBR_UCHAR.
+     * 0xffc0c1 is out of range for an epicsUInt8, so the conversion from
+     * the DBF_DOUBLE input field saturates at UCHAR_MAX. */
+    const char result_string[] = "Format test string ff";
 
     /* set format string */
     testdbPutFieldOk("test_printf_rec.FMT", DBF_STRING, format_string);
@@ -400,14 +406,10 @@ static void test_hh_flag(void){
     /* set value on inp0 */
     testdbPutFieldOk("test_printf_inp0_rec.VAL", DBF_LONG, 0xffc0c1);
 
-    /* verify that string is formatted as expected */
-    #ifdef __rtems__
-    testTodoBegin("Fails on UB-20 gcc-9 on RTEMS");
-    #endif
+    /* verify that string is formatted as expected.
+     * The out-of-range conversion is now defined, so this no longer
+     * needs the RTEMS testTodo() it used to carry. */
     testdbGetFieldEqual("test_printf_rec.VAL", DBF_STRING, result_string);
-    #ifdef __rtems__
-    testTodoEnd();
-    #endif
 
     // number of tests = 3
 }

--- a/modules/libcom/src/misc/epicsTypes.h
+++ b/modules/libcom/src/misc/epicsTypes.h
@@ -56,6 +56,20 @@ typedef double          epicsFloat64;
 typedef epicsInt32      epicsStatus;
  /** @} */
 
+/**
+ * \name Limits of the 64-bit integer types
+ *
+ * \<limits.h\> only defines LLONG_MIN, LLONG_MAX and ULLONG_MAX in C99
+ * and later; the RTEMS 4.x cross-compilers default to C89 and do not
+ * provide them. The types above have a fixed width, so give the limits
+ * here instead.
+ * @{
+ */
+#define epicsInt64Min   (-0x7fffffffffffffffLL - 1)
+#define epicsInt64Max     0x7fffffffffffffffLL
+#define epicsUInt64Max    0xffffffffffffffffULL
+ /** @} */
+
 #define MAX_STRING_SIZE 40
 
 /**


### PR DESCRIPTION
# database: define the float/double → integer conversion (remove undefined behaviour)

## Summary

EPICS converts a floating-point value to an integer field on two paths, and
both do it with a **bare C cast**, `*dst = (typeb) *src;`:

- `modules/database/src/ioc/db/dbConvert.c` — the standard get/put conversion
  routines used on the **CA / network / dbPutField** path (the `GET`/`PUT`
  macros).
- `modules/database/src/ioc/db/dbFastLinkConv.c` — the per-value converters
  used on the **record-to-record fast-link (DB link)** path (the `cvt_f_*` /
  `cvt_d_*` functions).

When the floating value is outside the destination integer type's range, or is
a NaN, that cast is **undefined behaviour** (C17 6.3.1.4p1) — no clamp, no
diagnostic — and the two hardware targets EPICS ships on produce *different*
values for the same input. This PR replaces the bare cast on
**float/double-source → integer-destination** conversions on **both** paths
with a defined, portable saturating conversion (out-of-range clamps to the
destination min/max, NaN → 0), closing the float→int UB family across the
whole database layer. Every other (well-defined) conversion is left untouched.

It is split into **two commits, one per file**, both under the single
"float→int UB → saturation" finding:

1. `dbConvert: saturate float/double conversion to integer fields`
2. `dbFastLinkConv: saturate float/double conversion to integer fields`

This is a **behaviour-defining** change, not a crash fix — please see the
compatibility note below, and treat the saturation choice as a proposal open
to the maintainers' preference.

## The defect

Both files end their float→integer conversions in `*dst = (typeb) *src;`:

- `dbConvert.c`'s `GET(typea, typeb)` / `PUT(typea, typeb)` macros (scalar
  fast path and array-copy loop), instantiated once per (source, destination)
  type pair.
- `dbFastLinkConv.c`'s individual `cvt_f_*` / `cvt_d_*` functions, e.g.
  `cvt_f_l` did `*to = (epicsInt32) *from;`.

For a **floating source** (`epicsFloat32` / `epicsFloat64`) and an **integer
destination**, an out-of-range or NaN value makes that cast undefined. The
result diverges by target:

| target  | instruction | out of range        | NaN        |
|---------|-------------|---------------------|------------|
| x86-64  | `cvttsd2si` | → `INT_MIN`         | → `INT_MIN`|
| aarch64 | `fcvtzs`    | → **saturates**     | → **0**    |

So `3.0e9 → DBF_LONG` stores `-2147483648` on an x86-64 IOC but `2147483647`
on a Raspberry Pi / Zynq (aarch64) one — both ordinary EPICS platforms, on
both the network put path and the DB-link path. There is no single "what C
does" here to preserve; the behaviour is genuinely undefined and
target-dependent.

### Reachability

- **`dbConvert.c` (network path):** any CA/PVA client writing an out-of-range
  double to an integer field reaches this on the put path — e.g. a `caput` of
  a numeric value that is not one of an enum's choice strings is sent as
  `DBR_DOUBLE`, so `caput SCAN -1` arrives as `-1.0` and lands in
  `putDoubleEnum` (same macro body → the `epicsEnum16` cast). The read
  direction (`GET`) has the same cast when a floating field is fetched into an
  integer client buffer.
- **`dbFastLinkConv.c` (fast-link path):** any DB input/output link from a
  floating field to an integer field (`INP`/`DOL`/`OUT` chaining an `ai`/`calc`
  into a `longout`/`mbbo`/waveform etc.) runs one of these converters every
  time the value propagates — this is the more common, purely internal path,
  reached with no external client at all.

## The fix

Add one saturating float→integer assignment helper and route **only** the
float/double → integer conversions through it, on both paths. Everything else
keeps its original code.

```c
#define ASSIGN_SAT(pdst, val, typeb, imin, imax) \
    do { \
        double _v = (double) (val); \
        if (isnan(_v))                 *(pdst) = 0; \
        else if (_v <= (double)(imin)) *(pdst) = (imin); \
        else if (_v >= (double)(imax)) *(pdst) = (imax); \
        else                           *(pdst) = (typeb) _v; \
    } while (0)
```

- `imin`/`imax` are the destination type's `<limits.h>` constants
  (`INT_MIN`/`INT_MAX`, `SCHAR_MIN`/`SCHAR_MAX`, `USHRT_MAX`, `ULLONG_MAX`, …),
  so the exact type range is used per destination and `char`/`epicsInt8`
  signedness is respected on every platform.
- The `(double)` casts of those constants are the saturation thresholds. For
  the 64-bit destinations the true max is not representable as a `double` and
  `(double)imax` rounds up to `2^63` / `2^64` — which is exactly the first
  value that no longer fits — so the comparison stays correct while the
  *assigned* value is the exact type max held as an integer constant.
- `±Inf` fall through naturally to the `imax` / `imin` branches; `NaN` is
  caught first and mapped to `0`.

**`dbConvert.c`** keeps its macro-instantiation style: the helper is wrapped in
a `GET_SAT`/`PUT_SAT` macro pair identical to `GET`/`PUT` except the two cast
sites route through `ASSIGN_SAT`, and only the float/double→integer
instantiations are switched to them. **`dbFastLinkConv.c`** keeps its
individual-function style: the same `ASSIGN_SAT` helper is added and each of
the 18 float/double→integer `cvt_*` bodies uses it in place of the bare cast.

This matches the aarch64 hardware behaviour and the behaviour of Rust's
saturating `as` conversion. The boundary values were verified with standalone
programs for every destination width on both files — see Testing.

### Why saturate (and an alternative)

Saturation is proposed because it (a) removes the UB, (b) aligns the two
platforms EPICS ships on onto one already-existing behaviour (aarch64's), and
(c) yields a value that is in range and usable rather than an indefinite one.
For the enum/menu destinations it is also benign: a negative ordinal
saturates to `0`, which is always a valid menu ordinal (`SCAN → Passive`,
a severity field → `NO_ALARM`).

Alternatives the maintainers may prefer instead, and which this PR does not
presume: returning a conversion error / status for out-of-range input, or
leaving the behaviour undefined but documenting it. Happy to adjust.

## Compatibility note — this is an observable behaviour change on x86-64

On **x86-64** this changes the stored value for out-of-range / NaN input, on
both paths:

- out-of-range double that today yields `INT_MIN` (e.g. `3.0e9 → DBF_LONG`
  gives `-2147483648`) will now **saturate** to the destination max
  (`2147483647`);
- NaN that today yields `INT_MIN` will now yield `0`.

On **aarch64** there is effectively no change — the hardware already
saturates and maps NaN to 0. So this PR aligns x86-64 onto the aarch64
semantics. Maintainers should weigh this: it is a deliberate,
platform-observable change of a value that was previously undefined.

## Family check — what changed and what was deliberately left

**Anchor:** the float→integer conversion sites in both database conversion
files —
`GET\((epicsFloat32|epicsFloat64),` / `PUT\((epicsFloat32|epicsFloat64),`
in `dbConvert.c` (there `typea` is the source, `typeb` the destination —
verified from the macro bodies), and the `cvt_f_* / cvt_d_*` functions whose
destination pointer is an integer type in `dbFastLinkConv.c`.

**Same defect — fixed now:**

- **`dbConvert.c` — 36 instantiations.** float32/float64 source → integer
  destination, for the nine integer destinations `char`, `epicsUInt8`,
  `epicsInt16`, `epicsUInt16`, `epicsInt32`, `epicsUInt32`, `epicsInt64`,
  `epicsUInt64`, `epicsEnum16`, in both the read (`getFloat*`, `getDouble*`)
  and write (`putFloat*`, `putDouble*`) directions. Every changed `static long`
  line is a float→int instantiation.
- **`dbFastLinkConv.c` — 18 functions.** the float/double → integer converters:
  `cvt_f_c`, `cvt_f_uc`, `cvt_f_s`, `cvt_f_us`, `cvt_f_l`, `cvt_f_ul`,
  `cvt_f_q`, `cvt_f_uq`, `cvt_f_e` (float32 source) and `cvt_d_c`, `cvt_d_uc`,
  `cvt_d_s`, `cvt_d_us`, `cvt_d_l`, `cvt_d_ul`, `cvt_d_q`, `cvt_d_uq`,
  `cvt_d_e` (float64 source). Destinations `epicsInt8`, `epicsUInt8`,
  `epicsInt16`, `epicsUInt16`, `epicsInt32`, `epicsUInt32`, `epicsInt64`,
  `epicsUInt64`, `epicsEnum16` (DBF_MENU/DBF_ENUM both use `cvt_*_e`; there is
  no separate menu converter).

**Distinct — deliberately NOT changed (both files):**

- **float → float / float → double** (`getFloatFloat`, `getFloatDouble`,
  `getDoubleDouble` + put twins; `cvt_f_f`, `cvt_f_d`, `cvt_d_f`, `cvt_d_d`) —
  widening/exact FP conversions, well-defined (`cvt_d_f` already clamps via
  `epicsConvertDoubleToFloat`); left as-is.
- **integer / enum → float or double** (`getCharFloat` … `getEnumDouble`,
  `putCharFloat` … `putEnumDouble`; `cvt_c_f` … `cvt_e_d`) — integer→float is
  well-defined; untouched. (The 6 integer→`epicsInt8`/`epicsUInt8` narrowing
  casts still present in `dbFastLinkConv.c`, e.g. `cvt_s_c`, `cvt_e_uc`, are
  integer→integer conversions — defined modular arithmetic, C17 6.3.1.3p2 —
  and are correctly left bare.)
- **→ string** (`getStringDouble`, `cvt_d_st`, `cvt_st_menu`, etc.) — separate
  hand-written functions using `cvt*ToString` / menu-choice lookup, not these
  casts; out of scope and well-defined.
- **same-type copies** (`*_NOCONVERT`, `cvt_x_x`) — no conversion; untouched.

**Out of scope by adjudication (unchanged, documented for completeness):** the
calc engines' `d2i`/`d2ui` in `calcPerform.c` are `(epicsInt32)(epicsUInt32)d`
— a *defined* modular reinterpretation, not a narrowing cast — and every
integer-source conversion is defined modular arithmetic. Those are not part of
this UB family and are not touched.

## Testing

**Not compiled inside the EPICS build here** — this worktree has no configured
support/host build tree, so `make` was not run against the module; CI will
compile it. Best-effort local checks were done for both files:

1. **Boundary semantics** — the `ASSIGN_SAT` logic was extracted into
   standalone C programs and checked against the intended saturating result
   for every destination width, including the tricky 64-bit rounding cases and
   the `epicsInt8`/`SCHAR` destination that is unique to `dbFastLinkConv.c`.
   All pass, e.g.:
   - `3.0e9 → epicsInt32` = `2147483647` (was `-2147483648` on x86-64)
   - `-3.0e9 → epicsInt32` = `-2147483648`
   - `NaN → epicsInt32` = `0` (was `-2147483648` on x86-64)
   - `±Inf → epicsInt32` = `INT_MAX` / `INT_MIN`
   - `500.0 → epicsInt8` = `127`; `-500.0 → epicsInt8` = `-128`
   - `1e19 → epicsInt64` = `9223372036854775807`;
     `9223372036854774784.0` (largest double < 2^63) stays in range
   - `2e19 → epicsUInt64` = `18446744073709551615`; `-1.0 → epicsUInt64` = `0`
2. **Macro / function syntax** — the `GET_SAT`/`PUT_SAT` expansions and a
   rendered `cvt_*` function body were `-fsyntax-only` / `-Wall -Wextra`
   compiled with `gcc -std=c99` (clean).

Suggested in-IOC verification once built (x86-64):

- **Network path:** `caput SOME:LONGOUT 3.0e9` — before: `-2147483648`;
  after: `2147483647`.
- **Fast-link path:** an `ai`/`calc` producing `3.0e9` with `OUT`/a forward
  link into a `DBF_LONG` field — before (x86-64): `-2147483648`; after:
  `2147483647`. A waveform `aao` `FTVL=SHORT` DOL of
  `[1.7, 2.2, -3.9, 70000, 5, 6]` — before: `[1, 2, -3, 4464, 5, 6]`; after:
  `[1, 2, -3, 32767, 5, 6]`.
- write a NaN-producing calc result into a `DBF_LONG` field — before
  (x86-64): `-2147483648`; after: `0`.
