### PR TITLE
RSRV message validation

### DIFF
--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -2437,9 +2437,15 @@ int camessage ( struct client *client )
                 SEND_UNLOCK(client);
                 log_header ( "CAS: Client version too old",
                     client, &msg, 0, nmsg );
-                client->recvBytesToDrain = msgsize - bytes_left;
-                client->recv.stk = client->recv.cnt;
-                status = RSRV_OK;
+                if (msgsize >= bytes_left) {
+                    client->recvBytesToDrain = msgsize - bytes_left;
+                    client->recv.stk = client->recv.cnt;
+                    status = RSRV_OK;
+                    break;
+                } else { // msgsize < bytes_left
+                    client->recv.stk += msgsize;
+                    continue;
+                }
             } else {
                 /* silently ignore UDP from old clients */
                 status = RSRV_ERROR;

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -2417,6 +2417,14 @@ int camessage ( struct client *client )
             }
             msg.m_postsize  = ntohl ( pLW[0] );
             msg.m_count     = ntohl ( pLW[1] );
+            if (msg.m_postsize >= 0xffffffff - (sizeof(*mp) + 2 * sizeof ( *pLW ))) {
+                if(CASDEBUG>0) {
+                    errlogPrintf("Client ext msg size too large 0x%08x\n",
+                                 (unsigned)msg.m_postsize);
+                }
+                status = RSRV_ERROR;
+                break;
+            }
             msgsize = msg.m_postsize + sizeof(*mp) + 2 * sizeof ( *pLW );
             pBody = pLW + 2;
         }

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -972,7 +972,6 @@ struct dbChannel *dbch,
 unsigned    cid
 )
 {
-    static unsigned     bucketID;
     unsigned        *pCID;
     struct channel_in_use   *pchannel;
     int         status;
@@ -1005,6 +1004,7 @@ unsigned    cid
     LOCK_CLIENTQ;
 
     do {
+        static unsigned     bucketID;
         /*
          * bypass read only warning
          */

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -119,13 +119,21 @@ static void *casCalloc(size_t count, size_t size)
  *
  * used to be a macro
  */
-static struct channel_in_use *MPTOPCIU (const caHdrLargeArray *mp)
+static struct channel_in_use *MPTOPCIU (const caHdrLargeArray *mp,
+                                       struct client *client)
 {
     struct channel_in_use   *pciu;
     const unsigned      id = mp->m_cid;
 
     LOCK_CLIENTQ;
     pciu = bucketLookupItemUnsignedId (pCaBucket, &id);
+
+    if (pciu && pciu->client != client) {
+        /* reject attempt to use server assigned ID from another client
+         */
+        pciu = NULL;
+    }
+
     UNLOCK_CLIENTQ;
 
     return pciu;
@@ -161,7 +169,7 @@ va_list                 args
     case CA_PROTO_READ_NOTIFY:
     case CA_PROTO_WRITE:
     case CA_PROTO_WRITE_NOTIFY:
-        pciu = MPTOPCIU(curp);
+        pciu = MPTOPCIU(curp, client);
         if(pciu){
             cid = pciu->cid;
         }
@@ -284,7 +292,7 @@ static void log_header (
 
     ipAddrToDottedIP (&client->addr, hostName, sizeof(hostName));
 
-    pciu = MPTOPCIU(mp);
+    pciu = MPTOPCIU(mp, client);
 
     if (pContext) {
         epicsPrintf ("CAS: request from %s => %s\n",
@@ -600,7 +608,7 @@ static void read_reply ( void *pArg, struct dbChannel *dbch,
  */
 static int read_action ( caHdrLargeArray *mp, void *pPayloadIn, struct client *pClient )
 {
-    struct channel_in_use *pciu = MPTOPCIU ( mp );
+    struct channel_in_use *pciu = MPTOPCIU ( mp, pClient );
     int readAccess;
     ca_uint32_t payloadSize;
     void *pPayload;
@@ -698,7 +706,7 @@ static int read_notify_action ( caHdrLargeArray *mp, void *pPayload, struct clie
         return RSRV_ERROR;
     }
 
-    pciu = MPTOPCIU ( mp );
+    pciu = MPTOPCIU ( mp, client );
     if ( !pciu ) {
         logBadId ( client, mp, pPayload );
         return RSRV_ERROR;
@@ -734,7 +742,7 @@ static int write_action ( caHdrLargeArray *mp,
     long                    dbStatus;
     void                    *asWritePvt;
 
-    pciu = MPTOPCIU(mp);
+    pciu = MPTOPCIU(mp, client);
     if(!pciu){
         logBadId(client, mp, pPayload);
         return RSRV_ERROR;
@@ -1640,7 +1648,7 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
     int status;
     struct channel_in_use *pciu;
 
-    pciu = MPTOPCIU(mp);
+    pciu = MPTOPCIU(mp, client);
     if(!pciu){
         logBadId ( client, mp, pPayload );
         return RSRV_ERROR;
@@ -1772,7 +1780,7 @@ static int event_add_action (caHdrLargeArray *mp, void *pPayload, struct client 
         return RSRV_ERROR;
     }
 
-    pciu = MPTOPCIU ( mp );
+    pciu = MPTOPCIU ( mp, client );
     if ( ! pciu ) {
         logBadId ( client, mp, pPayload );
         return RSRV_ERROR;
@@ -1882,8 +1890,8 @@ static int clear_channel_reply ( caHdrLargeArray *mp,
       * Verify the channel
       *
       */
-     pciu = MPTOPCIU(mp);
-     if(pciu?pciu->client!=client:TRUE){
+     pciu = MPTOPCIU(mp, client);
+     if(!pciu){
          logBadId ( client, mp, pPayload );
          return RSRV_ERROR;
      }
@@ -1991,8 +1999,8 @@ static int event_cancel_reply ( caHdrLargeArray *mp, void *pPayload, struct clie
       * Verify the channel
       *
       */
-     pciu = MPTOPCIU(mp);
-     if (pciu?pciu->client!=client:TRUE) {
+     pciu = MPTOPCIU(mp, client);
+     if (!pciu) {
          logBadId ( client, mp, pPayload );
          return RSRV_ERROR;
      }

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -304,11 +304,6 @@ static void log_header (
 
     epicsPrintf ( "CAS: Request from %s =>   available=0x%x \tN=%u paddr=%p\n",
         hostName, mp->m_available, mnum, (pciu ? pciu->dbch : NULL));
-
-    if (mp->m_cmmd==CA_PROTO_WRITE && mp->m_dataType==DBF_STRING && pPayLoad ) {
-        epicsPrintf ( "CAS: Request from %s =>   Wrote string \"%s\"\n",
-        hostName, (char *)pPayLoad );
-    }
 }
 
 /*

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -628,6 +628,9 @@ static int read_action ( caHdrLargeArray *mp, void *pPayloadIn, struct client *p
         SEND_UNLOCK ( pClient );
         return RSRV_ERROR;
     }
+    if (mp->m_count > dbChannelFinalElements(pciu->dbch)) {
+        mp->m_count = dbChannelFinalElements(pciu->dbch);
+    }
 
     payloadSize = dbr_size_n ( mp->m_dataType, mp->m_count );
     status = cas_copy_in_header ( pClient, mp->m_cmmd, payloadSize,
@@ -712,6 +715,10 @@ static int read_notify_action ( caHdrLargeArray *mp, void *pPayload, struct clie
         return RSRV_ERROR;
     }
 
+    if (mp->m_count > dbChannelFinalElements(pciu->dbch)) {
+        mp->m_count = dbChannelFinalElements(pciu->dbch);
+    }
+
     evext.msg = *mp;
     evext.pciu = pciu;
     evext.pdbev = NULL;
@@ -741,10 +748,24 @@ static int write_action ( caHdrLargeArray *mp,
     int                     status;
     long                    dbStatus;
     void                    *asWritePvt;
+    unsigned                size;
 
     pciu = MPTOPCIU(mp, client);
     if(!pciu){
         logBadId(client, mp, pPayload);
+        return RSRV_ERROR;
+    }
+
+    if (INVALID_DB_REQ(mp->m_dataType)) {
+        log_header ("bad put data type", client, mp, pPayload, 0);
+        return RSRV_ERROR;
+    }
+    if (mp->m_count > dbChannelFinalElements(pciu->dbch)) {
+        mp->m_count = dbChannelFinalElements(pciu->dbch);
+    }
+
+    size = dbr_size_n (mp->m_dataType, mp->m_count);
+    if (size > mp->m_postsize) {
         return RSRV_ERROR;
     }
 
@@ -1654,10 +1675,13 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
         return RSRV_ERROR;
     }
 
-    if (mp->m_dataType > LAST_BUFFER_TYPE) {
+    if (INVALID_DB_REQ(mp->m_dataType)) {
         log_header ("bad put notify data type", client, mp, pPayload, 0);
         putNotifyErrorReply (client, mp, ECA_BADTYPE);
         return RSRV_ERROR;
+    }
+    if (mp->m_count > dbChannelFinalElements(pciu->dbch)) {
+        mp->m_count = dbChannelFinalElements(pciu->dbch);
     }
 
     if(!rsrvCheckPut(pciu)){
@@ -1666,6 +1690,9 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
     }
 
     size = dbr_size_n (mp->m_dataType, mp->m_count);
+    if (size > mp->m_postsize) {
+        return RSRV_ERROR;
+    }
 
     if ( pciu->pPutNotify ) {
 
@@ -1776,7 +1803,7 @@ static int event_add_action (caHdrLargeArray *mp, void *pPayload, struct client 
     struct channel_in_use *pciu;
     struct event_ext *pevext;
 
-    if ( INVALID_DB_REQ(mp->m_dataType) ) {
+    if ( INVALID_DB_REQ(mp->m_dataType) || mp->m_postsize < sizeof(*pmi) ) {
         return RSRV_ERROR;
     }
 
@@ -1808,6 +1835,10 @@ static int event_add_action (caHdrLargeArray *mp, void *pPayload, struct client 
             RECORD_NAME(pciu->dbch));
         SEND_UNLOCK(client);
         return RSRV_ERROR;
+    }
+
+    if (mp->m_count > dbChannelFinalElements(pciu->dbch)) {
+        mp->m_count = dbChannelFinalElements(pciu->dbch);
     }
 
     pevext->msg = *mp;
@@ -2425,7 +2456,7 @@ int camessage ( struct client *client )
             }
             msg.m_postsize  = ntohl ( pLW[0] );
             msg.m_count     = ntohl ( pLW[1] );
-            if (msg.m_postsize >= 0xffffffff - (sizeof(*mp) + 2 * sizeof ( *pLW ))) {
+            if (msg.m_postsize >= ca_uint32_max - (sizeof(*mp) + 2 * sizeof ( *pLW ))) {
                 if(CASDEBUG>0) {
                     errlogPrintf("Client ext msg size too large 0x%08x\n",
                                  (unsigned)msg.m_postsize);


### PR DESCRIPTION
Extend validation of CA messages by RSRV to reduce the scope for remote maleficence.  Principally avoiding integer overflows, and cross-checking between interrelated `msgsize`, `dtype`, and `count` header fields.

This change set was developed in response to a confidential security report by Shubham Raj shubham@causalsecurity.com.  It is being released early after a subsequent unconfidential report of an overlapping set of issues.  Thank you to @anjohnson @dirk-zimoch @simon-ess for review during the embargo period.

Anyone attempting to backport these fixes to releases before 2017 would also need: e430d097b727de920aeb22af0e282678036d8a0d .