### PR TITLE
RTEMS-posix: free the epicsEventOSD in epicsEventDestroy()

### DIFF
--- a/modules/libcom/src/osi/os/RTEMS-posix/osdEvent.c
+++ b/modules/libcom/src/osi/os/RTEMS-posix/osdEvent.c
@@ -45,6 +45,7 @@ LIBCOM_API void
 epicsEventDestroy(epicsEventId pSem)
 {
     rtems_binary_semaphore_destroy(&pSem->rbs);
+    free(pSem);
 }
 
 LIBCOM_API epicsEventStatus


### PR DESCRIPTION
Found while testing on RTEMS 6 (qemu): `epicsEventCreate()` mallocs the wrapper but `epicsEventDestroy()` never frees it, so memory grows on every CA client connect/disconnect. This adds the missing `free(pSem)`.