### PR TITLE
RTEMS: fix two boot-path faults in POSIX_Init

### DIFF
--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -1161,8 +1161,13 @@ POSIX_Init ( void *argument __attribute__((unused)))
 
     printf ("***** Preparing EPICS application *****\n");
     iocshRegisterRTEMS ();
-    set_directory (argv[1]);
-    epicsEnvSet ("IOC_STARTUP_SCRIPT", argv[1]);
+    /* No startup script when the application declares that it needs no
+     * filesystem (epicsRtemsFSImage == NULL).
+     */
+    if (argv[1] != NULL) {
+        set_directory (argv[1]);
+        epicsEnvSet ("IOC_STARTUP_SCRIPT", argv[1]);
+    }
     atexit(exitHandler);
     printf ("***** Starting EPICS application *****\n");
 
@@ -1180,7 +1185,7 @@ POSIX_Init ( void *argument __attribute__((unused)))
                      NULL);
 #endif
 
-    result = main ((sizeof argv / sizeof argv[0]) - 1, argv);
+    result = main (argv[1] != NULL ? 2 : 1, argv);
     printf ("***** IOC application terminating *****\n");
     epicsThreadSleep(1.0);
     epicsExit(result);

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -1064,11 +1064,12 @@ POSIX_Init ( void *argument __attribute__((unused)))
     epicsEventWaitStatus stat;
     printf("\n ---- Waiting for DHCP ...\n");
     stat = epicsEventWaitWithTimeout(dhcpDone, 600);
-    if (stat == epicsEventOK)
-        epicsEventDestroy(dhcpDone);
-    else if (stat == epicsEventWaitTimeout)
+    /* dhcpcd_hook_handler() stays registered and signals dhcpDone on every
+     * later BOUND, so the event has to outlive this wait.
+     */
+    if (stat == epicsEventWaitTimeout)
         printf("\n ---- DHCP timed out!\n");
-    else
+    else if (stat != epicsEventOK)
         printf("\n ---- dhcpDone Event Unknown state %d\n", stat);
 
     const char* ifconfg_args[] = {

--- a/modules/libcom/RTEMS/score/rtems_init.c
+++ b/modules/libcom/RTEMS/score/rtems_init.c
@@ -681,11 +681,16 @@ Init (rtems_task_argument ignored)
      */
     printf ("***** Preparing EPICS application *****\n");
     iocshRegisterRTEMS ();
-    set_directory (argv[1]);
-    epicsEnvSet ("IOC_STARTUP_SCRIPT", argv[1]);
+    /* No startup script when the application declares that it needs no
+     * filesystem (epicsRtemsFSImage == NULL).
+     */
+    if (argv[1] != NULL) {
+        set_directory (argv[1]);
+        epicsEnvSet ("IOC_STARTUP_SCRIPT", argv[1]);
+    }
     atexit(exitHandler);
     printf ("***** Starting EPICS application *****\n");
-    result = main ((sizeof argv / sizeof argv[0]) - 1, argv);
+    result = main (argv[1] != NULL ? 2 : 1, argv);
     printf ("***** IOC application terminating *****\n");
     epicsThreadSleep(1.0);
     epicsExit(result);


### PR DESCRIPTION
`epicsRtemsFSImage = NULL` is documented as "no FS image provided, but none is needed", yet it is the only `initialize_local_filesystem()` success path that leaves `argv[1]` unset, so `set_directory(NULL)` faults before `main()` — reproduced on RTEMS 6.0.0 / `xilinx_zynq_a9_qemu` with unpatched 7.0.10 and a 12-line IOC, and the fixed image boots through to `iocInit`. Separately, `dhcpcd_hook_handler()` is never removed and signals `dhcpDone` on every BOUND, so a lease renewal reaches the event `POSIX_Init` destroyed on the wait-OK path — a use-after-free now that `epicsEventDestroy()` frees the OSD.