### PR TITLE
Fix for #943, ca_put(DBR_STRING,chid,"1")

### DIFF
--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -759,9 +759,18 @@ static int write_action ( caHdrLargeArray *mp,
         mp->m_count = dbChannelFinalElements(pciu->dbch);
     }
 
-    size = dbr_size_n (mp->m_dataType, mp->m_count);
-    if (size > mp->m_postsize) {
-        return RSRV_ERROR;
+    if (mp->m_dataType == DBR_STRING && mp->m_count == 1) {
+        /* Accept short scalar string payloads that are
+         * null-terminated within the message received. */
+        if (epicsStrnLen(pPayload, mp->m_postsize) >= mp->m_postsize) {
+            return RSRV_ERROR;
+        }
+    }
+    else {
+        size = dbr_size_n (mp->m_dataType, mp->m_count);
+        if (size > mp->m_postsize) {
+            return RSRV_ERROR;
+        }
     }
 
     if(!rsrvCheckPut(pciu)){
@@ -1685,7 +1694,14 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
     }
 
     size = dbr_size_n (mp->m_dataType, mp->m_count);
-    if (size > mp->m_postsize) {
+    if (mp->m_dataType == DBR_STRING && mp->m_count == 1) {
+        /* Accept short scalar string payloads that are
+         * null-terminated within the message received. */
+        if (epicsStrnLen(pPayload, mp->m_postsize) >= mp->m_postsize) {
+            return RSRV_ERROR;
+        }
+    }
+    else if (size > mp->m_postsize) {
         return RSRV_ERROR;
     }
 

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -743,7 +743,6 @@ static int write_action ( caHdrLargeArray *mp,
     int                     status;
     long                    dbStatus;
     void                    *asWritePvt;
-    unsigned                size;
 
     pciu = MPTOPCIU(mp, client);
     if(!pciu){
@@ -766,11 +765,8 @@ static int write_action ( caHdrLargeArray *mp,
             return RSRV_ERROR;
         }
     }
-    else {
-        size = dbr_size_n (mp->m_dataType, mp->m_count);
-        if (size > mp->m_postsize) {
-            return RSRV_ERROR;
-        }
+    else if (dbr_size_n (mp->m_dataType, mp->m_count) > mp->m_postsize) {
+        return RSRV_ERROR;
     }
 
     if(!rsrvCheckPut(pciu)){

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -1775,13 +1775,19 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
     pciu->pPutNotify->msg = *mp;
     pciu->pPutNotify->nRequest = mp->m_count;
 
-    status = caNetConvert (
-        mp->m_dataType, pPayload, pciu->pPutNotify->pbuffer,
-        FALSE /* net -> host format */, mp->m_count );
-    if ( status != ECA_NORMAL ) {
-        log_header ("invalid data type", client, mp, pPayload, 0);
-        putNotifyErrorReply ( client, mp, status );
-        return RSRV_ERROR;
+    if (mp->m_dataType == DBR_STRING && mp->m_count == 1) {
+        /* Scalar string, copy up to the NUL terminator and 0-pad */
+        strncpy(pciu->pPutNotify->pbuffer, pPayload, size);
+    }
+    else {
+        status = caNetConvert (
+            mp->m_dataType, pPayload, pciu->pPutNotify->pbuffer,
+            FALSE /* net -> host format */, mp->m_count );
+        if ( status != ECA_NORMAL ) {
+            log_header ("invalid data type", client, mp, pPayload, 0);
+            putNotifyErrorReply ( client, mp, status );
+            return RSRV_ERROR;
+        }
     }
 
     pciu->pPutNotify->dbrType = mp->m_dataType;


### PR DESCRIPTION
The CA client library truncates short scalar strings, RSRV must accept the result.

Fixes #943