### PR TITLE
as: add explicit hostname HAG refresh

### DIFF
--- a/documentation/new-notes/PR-945.md
+++ b/documentation/new-notes/PR-945.md
@@ -1,0 +1,17 @@
+### Refresh hostname-based Host Access Groups without reloading the ACF
+
+Access Security now provides `asRefreshHag()` for applications that need
+hostname-based Host Access Groups (HAGs) to follow DNS changes at runtime.
+Applications call the function periodically from a control-plane thread.
+Successful resolutions are refreshed after 300 seconds, and failed resolutions
+are retried after 60 seconds.
+
+When the effective HAG address set changes, Access Security recomputes existing
+clients and invokes their registered change-of-access callbacks.  Resolution
+failures remove stale addresses, so affected rules fail closed until a later
+retry succeeds.  Numeric HAG entries remain static.
+
+DNS resolution is performed only by `asRefreshHag()` and during ACF loading;
+ordinary access checks do not perform DNS work.  The refresh implementation
+uses the existing portable IPv4 resolver and adds no resolver-library
+dependency to `libCom`.

--- a/modules/libcom/src/as/asLib.h
+++ b/modules/libcom/src/as/asLib.h
@@ -25,7 +25,7 @@ extern "C" {
 struct dbChannel;
 
 /* 0 - Use (unverified) client provided host name string.
- * 1 - Use actual client IP address.  HAG() are resolved to IPs at ACF load time.
+ * 1 - Use actual client IP address.  HAG() host names are resolved to IPs.
  */
 LIBCOM_API extern int asCheckClientIP;
 
@@ -103,6 +103,21 @@ LIBCOM_API long epicsStdCall asComputeAllAsg(void);
 LIBCOM_API long epicsStdCall asComputeAsg(ASG *pasg);
 */
 LIBCOM_API long epicsStdCall asCompute(ASCLIENTPVT asClientPvt);
+/**
+ * Refresh due hostname HAG entries and update existing clients.
+ *
+ * Call this periodically from a control-plane thread.  Successful hostname
+ * resolutions are refreshed after 300 seconds and failures after 60 seconds.
+ * DNS is never performed by asCheckGet() or asCheckPut().
+ *
+ * If changed is not NULL, it is set to one only when the effective HAG to
+ * IPv4 mapping changes.  Existing change-of-access callbacks are run for
+ * clients whose rights change.  DNS failures remove stale mappings and are
+ * retried later; they are not reported as API errors.
+ *
+ * Returns S_asLib_asNotActive when Access Security is not active.
+ */
+LIBCOM_API long epicsStdCall asRefreshHag(unsigned *changed);
 LIBCOM_API int epicsStdCall asDump(
     void (*memcallback)(ASMEMBERPVT,FILE *),
     void (*clientcallback)(ASCLIENTPVT,FILE *),int verbose);

--- a/modules/libcom/src/as/asLibPvt.h
+++ b/modules/libcom/src/as/asLibPvt.h
@@ -1,0 +1,27 @@
+/* asLibPvt.h - Private Access Security test interfaces */
+
+#ifndef INC_asLibPvt_H
+#define INC_asLibPvt_H
+
+#include "libComAPI.h"
+#include "epicsTime.h"
+#include "osiSock.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int (epicsStdCall *asHagResolver)(const char *name, unsigned short port,
+    struct sockaddr_in *address);
+typedef epicsUInt64 (*asHagClock)(void);
+
+/* Private deterministic test seams.  This header is not installed. */
+LIBCOM_API void asTestSetHagResolver(asHagResolver resolver);
+LIBCOM_API void asTestSetHagClock(asHagClock clock);
+LIBCOM_API void asTestResetHagHooks(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INC_asLibPvt_H */

--- a/modules/libcom/src/as/asLibRoutines.c
+++ b/modules/libcom/src/as/asLibRoutines.c
@@ -21,6 +21,7 @@
 #include "dbDefs.h"
 #include "epicsThread.h"
 #include "epicsString.h"
+#include "epicsTime.h"
 #include "cantProceed.h"
 #include "epicsMutex.h"
 #include "errlog.h"
@@ -29,12 +30,14 @@
 #include "macLib.h"
 #include "postfix.h"
 #include "asLib.h"
+#include "as/asLibPvt.h"
 
 #undef ECHO /* from termios.h */
 
 int asCheckClientIP;
 
 static epicsMutexId asLock;
+static epicsMutexId asHagRefreshLock;
 #define LOCK epicsMutexMustLock(asLock)
 #define UNLOCK epicsMutexUnlock(asLock)
 
@@ -47,6 +50,49 @@ static void         *freeListPvt = NULL;
 
 
 #define DEFAULT "DEFAULT"
+#define AS_HAG_SUCCESS_INTERVAL 300u
+#define AS_HAG_FAILURE_INTERVAL 60u
+#define AS_HAG_NSEC_PER_SEC 1000000000uLL
+#define AS_HAG_IP_BUFSIZE 24u
+#define AS_HAG_SOURCE_MAX 512u
+#define AS_HAG_UNRESOLVED "unresolved:"
+
+typedef struct asHagEntryState {
+    ELLNODE node;
+    HAG *group;
+    HAGNAME *name;
+    char *source;
+    size_t capacity;
+    epicsUInt64 due;
+    unsigned index;
+    unsigned resolved;
+} ASHAGENTRYSTATE;
+
+typedef struct asHagBaseState {
+    ELLNODE node;
+    ASBASE *base;
+    ELLLIST entries;
+    epicsUInt64 generation;
+    epicsUInt64 nextDue;
+} ASHAGBASESTATE;
+
+typedef struct asHagUpdate {
+    unsigned index;
+    char *source;
+    char address[AS_HAG_IP_BUFSIZE];
+    unsigned resolved;
+} ASHAGUPDATE;
+
+typedef struct asHagMapEntry {
+    HAG *group;
+    char address[AS_HAG_IP_BUFSIZE];
+} ASHAGMAPENTRY;
+
+static ELLLIST asHagStates;
+static epicsUInt64 asHagGeneration;
+static asHagResolver asHagResolve = aToIPAddr;
+static asHagClock asHagNow = epicsMonotonicGet;
+static epicsThreadOnceId asInitializeOnceFlag = EPICS_THREAD_ONCE_INIT;
 
 /* Defined in asLib.y */
 static int myParse(ASINPUTFUNCPTR inputfunction);
@@ -60,6 +106,9 @@ static UAG *asUagAdd(const char *uagName);
 static long asUagAddUser(UAG *puag,const char *user);
 static HAG *asHagAdd(const char *hagName);
 static long asHagAddHost(HAG *phag,const char *host);
+static ASHAGBASESTATE *asHagStateFind(ASBASE *base);
+static void asHagStateDestroy(ASBASE *base);
+static void asHashRebuild(ASBASE *base);
 static ASG *asAsgAdd(const char *asgName);
 static long asAsgAddInp(ASG *pasg,const char *inp,int inpIndex);
 static ASGRULE *asAsgAddRule(ASG *pasg,asAccessRights access,int level);
@@ -85,22 +134,302 @@ static void asInitializeOnce(void *arg)
 {
     osiSockAttach();
     asLock  = epicsMutexMustCreate();
+    asHagRefreshLock = epicsMutexMustCreate();
+    ellInit(&asHagStates);
 }
+
+static void asEnsureInitialized(void)
+{
+    epicsThreadOnce(&asInitializeOnceFlag,asInitializeOnce,NULL);
+}
+
+void asTestSetHagResolver(asHagResolver resolver)
+{
+    asEnsureInitialized();
+    epicsMutexMustLock(asHagRefreshLock);
+    asHagResolve = resolver ? resolver : aToIPAddr;
+    epicsMutexUnlock(asHagRefreshLock);
+}
+
+void asTestSetHagClock(asHagClock clock)
+{
+    asEnsureInitialized();
+    epicsMutexMustLock(asHagRefreshLock);
+    asHagNow = clock ? clock : epicsMonotonicGet;
+    epicsMutexUnlock(asHagRefreshLock);
+}
+
+void asTestResetHagHooks(void)
+{
+    asEnsureInitialized();
+    epicsMutexMustLock(asHagRefreshLock);
+    asHagResolve = aToIPAddr;
+    asHagNow = epicsMonotonicGet;
+    epicsMutexUnlock(asHagRefreshLock);
+}
+
+static ASHAGBASESTATE *asHagStateFind(ASBASE *base)
+{
+    ASHAGBASESTATE *state = (ASHAGBASESTATE *)ellFirst(&asHagStates);
+
+    while(state) {
+        if(state->base == base)
+            return state;
+        state = (ASHAGBASESTATE *)ellNext(&state->node);
+    }
+    return NULL;
+}
+
+static ASHAGBASESTATE *asHagStateCreate(ASBASE *base)
+{
+    ASHAGBASESTATE *state = asCalloc(1, sizeof(*state));
+
+    state->base = base;
+    ellInit(&state->entries);
+    ellAdd(&asHagStates, &state->node);
+    return state;
+}
+
+static void asHagStateDestroy(ASBASE *base)
+{
+    ASHAGBASESTATE *state = asHagStateFind(base);
+
+    if(state) {
+        ASHAGENTRYSTATE *entry = (ASHAGENTRYSTATE *)ellFirst(&state->entries);
+
+        while(entry) {
+            ASHAGENTRYSTATE *next = (ASHAGENTRYSTATE *)ellNext(&entry->node);
+
+            ellDelete(&state->entries, &entry->node);
+            free(entry->source);
+            free(entry);
+            entry = next;
+        }
+        ellDelete(&asHagStates, &state->node);
+        free(state);
+    }
+}
+
+static ASHAGENTRYSTATE *asHagEntryFind(ASHAGBASESTATE *state, HAGNAME *name)
+{
+    ASHAGENTRYSTATE *entry;
+
+    if(!state)
+        return NULL;
+    entry = (ASHAGENTRYSTATE *)ellFirst(&state->entries);
+    while(entry) {
+        if(entry->name == name)
+            return entry;
+        entry = (ASHAGENTRYSTATE *)ellNext(&entry->node);
+    }
+    return NULL;
+}
+
+static epicsUInt64 asHagAfter(epicsUInt64 now, unsigned seconds)
+{
+    epicsUInt64 delta = (epicsUInt64)seconds * AS_HAG_NSEC_PER_SEC;
+
+    return now > ~(epicsUInt64)0 - delta ? ~(epicsUInt64)0 : now + delta;
+}
+
+static void asHagScheduleNext(ASHAGBASESTATE *state)
+{
+    ASHAGENTRYSTATE *entry;
+    epicsUInt64 next = 0;
+
+    if(!state)
+        return;
+    entry = (ASHAGENTRYSTATE *)ellFirst(&state->entries);
+    while(entry) {
+        if(!next || entry->due < next)
+            next = entry->due;
+        entry = (ASHAGENTRYSTATE *)ellNext(&entry->node);
+    }
+    state->nextDue = next;
+}
+
+static int asHagSetIPAddr(epicsUInt32 rawAddr, struct sockaddr_in *address)
+{
+    static const struct sockaddr_in emptyAddress = {0};
+
+    *address = emptyAddress;
+    address->sin_family = AF_INET;
+    address->sin_addr.s_addr = htonl(rawAddr);
+    return 0;
+}
+
+static int asHagParseNumeric(const char *host, struct sockaddr_in *address)
+{
+    unsigned octet[4];
+    unsigned long raw;
+    unsigned port;
+    char extra[8];
+    int status;
+
+    status = sscanf(host, " %u . %u . %u . %u %7s ",
+        octet, octet+1, octet+2, octet+3, extra);
+    if(status == 4) {
+        if(octet[0] <= 0xff && octet[1] <= 0xff &&
+           octet[2] <= 0xff && octet[3] <= 0xff)
+            return asHagSetIPAddr(((epicsUInt32)octet[0] << 24) |
+                                  ((epicsUInt32)octet[1] << 16) |
+                                  ((epicsUInt32)octet[2] << 8) |
+                                  (epicsUInt32)octet[3], address);
+        return -1;
+    }
+    status = sscanf(host, " %u . %u . %u . %u : %u %7s ",
+        octet, octet+1, octet+2, octet+3, &port, extra);
+    if(status == 5 && port <= 0xffff &&
+       octet[0] <= 0xff && octet[1] <= 0xff &&
+       octet[2] <= 0xff && octet[3] <= 0xff)
+        return asHagSetIPAddr(((epicsUInt32)octet[0] << 24) |
+                              ((epicsUInt32)octet[1] << 16) |
+                              ((epicsUInt32)octet[2] << 8) |
+                              (epicsUInt32)octet[3], address);
+
+    status = sscanf(host, " %lu %7s ", &raw, extra);
+    if(status == 1 && raw <= 0xfffffffful)
+        return asHagSetIPAddr((epicsUInt32)raw, address);
+    status = sscanf(host, " %lu : %u %7s ", &raw, &port, extra);
+    if(status == 2 && raw <= 0xfffffffful && port <= 0xffff)
+        return asHagSetIPAddr((epicsUInt32)raw, address);
+    return -1;
+}
+
+static void asHagFormatAddress(const struct sockaddr_in *address,
+    char *buffer, size_t size)
+{
+    epicsUInt32 ip = ntohl(address->sin_addr.s_addr);
+
+    epicsSnprintf(buffer, size, "%u.%u.%u.%u",
+                  (ip>>24)&0xff, (ip>>16)&0xff,
+                  (ip>>8)&0xff, ip&0xff);
+}
+
+static void asHagSetEntry(ASHAGENTRYSTATE *entry, int resolved,
+    const char *address)
+{
+    if(resolved) {
+        epicsSnprintf(entry->name->host, entry->capacity, "%s", address);
+    } else {
+        epicsSnprintf(entry->name->host, entry->capacity, "%s%s",
+            AS_HAG_UNRESOLVED, entry->source);
+    }
+    entry->resolved = !!resolved;
+}
+
+static int asHagMapContains(const ASHAGMAPENTRY *map, size_t count,
+    HAG *group, const char *address)
+{
+    size_t i;
+
+    for(i = 0; i < count; i++) {
+        if(map[i].group == group && strcmp(map[i].address, address) == 0)
+            return 1;
+    }
+    return 0;
+}
+
+static ASHAGMAPENTRY *asHagCollectMap(ASBASE *base, size_t *count)
+{
+    ASHAGBASESTATE *state = asHagStateFind(base);
+    HAG *group;
+    ASHAGMAPENTRY *map;
+    size_t capacity = 0;
+
+    group = (HAG *)ellFirst(&base->hagList);
+    while(group) {
+        capacity += (size_t)ellCount(&group->list);
+        group = (HAG *)ellNext(&group->node);
+    }
+    map = capacity ? asCalloc(capacity, sizeof(*map)) : NULL;
+    *count = 0;
+    group = (HAG *)ellFirst(&base->hagList);
+    while(group) {
+        HAGNAME *name = (HAGNAME *)ellFirst(&group->list);
+
+        while(name) {
+            ASHAGENTRYSTATE *entry = asHagEntryFind(state, name);
+
+            if((!entry || entry->resolved) &&
+               !asHagMapContains(map, *count, group, name->host)) {
+                map[*count].group = group;
+                epicsSnprintf(map[*count].address,
+                    sizeof(map[*count].address), "%s", name->host);
+                (*count)++;
+            }
+            name = (HAGNAME *)ellNext(&name->node);
+        }
+        group = (HAG *)ellNext(&group->node);
+    }
+    return map;
+}
+
+static int asHagMapsEqual(const ASHAGMAPENTRY *left, size_t leftCount,
+    const ASHAGMAPENTRY *right, size_t rightCount)
+{
+    size_t i;
+
+    if(leftCount != rightCount)
+        return 0;
+    for(i = 0; i < leftCount; i++) {
+        if(!asHagMapContains(right, rightCount,
+                            left[i].group, left[i].address))
+            return 0;
+    }
+    return 1;
+}
+
+static void asHashRebuild(ASBASE *base)
+{
+    struct gphPvt *oldhash = base->phash;
+    ASHAGBASESTATE *state = asHagStateFind(base);
+    UAG *puag;
+    HAG *phag;
+
+    gphInitPvt(&base->phash, 256);
+    puag = (UAG *)ellFirst(&base->uagList);
+    while(puag) {
+        UAGNAME *name = (UAGNAME *)ellFirst(&puag->list);
+
+        while(name) {
+            if(!gphAdd(base->phash, name->user, puag))
+                errlogPrintf("Duplicated user '%s' in UAG '%s'\n",
+                    name->user, puag->name);
+            name = (UAGNAME *)ellNext(&name->node);
+        }
+        puag = (UAG *)ellNext(&puag->node);
+    }
+    phag = (HAG *)ellFirst(&base->hagList);
+    while(phag) {
+        HAGNAME *name = (HAGNAME *)ellFirst(&phag->list);
+
+        while(name) {
+            ASHAGENTRYSTATE *entry = asHagEntryFind(state, name);
+
+            if((!entry || entry->resolved) &&
+               !gphAdd(base->phash, name->host, phag))
+                errlogPrintf("Duplicated host '%s' in HAG '%s'\n",
+                    name->host, phag->name);
+            name = (HAGNAME *)ellNext(&name->node);
+        }
+        phag = (HAG *)ellNext(&phag->node);
+    }
+    if(oldhash)
+        gphFreeMem(oldhash);
+}
+
 long epicsStdCall asInitialize(ASINPUTFUNCPTR inputfunction)
 {
     ASG         *pasg;
     long        status;
     ASBASE      *pasbaseold;
-    GPHENTRY    *pgphentry;
-    UAG         *puag;
-    UAGNAME     *puagname;
-    HAG         *phag;
-    HAGNAME     *phagname;
-    static epicsThreadOnceId asInitializeOnceFlag = EPICS_THREAD_ONCE_INIT;
+    ASHAGBASESTATE *hagstate;
 
-    epicsThreadOnce(&asInitializeOnceFlag,asInitializeOnce,NULL);
+    asEnsureInitialized();
     LOCK;
     pasbasenew = asCalloc(1,sizeof(ASBASE));
+    hagstate = asHagStateCreate(pasbasenew);
     if(!freeListPvt) freeListInitPvt(&freeListPvt,sizeof(ASGCLIENT),20);
     ellInit(&pasbasenew->uagList);
     ellInit(&pasbasenew->hagList);
@@ -109,6 +438,7 @@ long epicsStdCall asInitialize(ASINPUTFUNCPTR inputfunction)
     status = myParse(inputfunction);
     if(status) {
         status = S_asLib_badConfig;
+        asHagStateDestroy(pasbasenew);
         /*Not safe to call asFreeAll */
         UNLOCK;
         return(status);
@@ -118,34 +448,8 @@ long epicsStdCall asInitialize(ASINPUTFUNCPTR inputfunction)
         pasg->pavalue = asCalloc(CALCPERFORM_NARGS, sizeof(double));
         pasg = (ASG *)ellNext(&pasg->node);
     }
-    gphInitPvt(&pasbasenew->phash, 256);
-    /*Hash each uagname and each hagname*/
-    puag = (UAG *)ellFirst(&pasbasenew->uagList);
-    while(puag) {
-        puagname = (UAGNAME *)ellFirst(&puag->list);
-        while(puagname) {
-            pgphentry = gphAdd(pasbasenew->phash,puagname->user,puag);
-            if(!pgphentry) {
-                errlogPrintf("Duplicated user '%s' in UAG '%s'\n",
-                    puagname->user, puag->name);
-            }
-            puagname = (UAGNAME *)ellNext(&puagname->node);
-        }
-        puag = (UAG *)ellNext(&puag->node);
-    }
-    phag = (HAG *)ellFirst(&pasbasenew->hagList);
-    while(phag) {
-        phagname = (HAGNAME *)ellFirst(&phag->list);
-        while(phagname) {
-            pgphentry = gphAdd(pasbasenew->phash,phagname->host,phag);
-            if(!pgphentry) {
-                errlogPrintf("Duplicated host '%s' in HAG '%s'\n",
-                    phagname->host, phag->name);
-            }
-            phagname = (HAGNAME *)ellNext(&phagname->node);
-        }
-        phag = (HAG *)ellNext(&phag->node);
-    }
+    asHashRebuild(pasbasenew);
+    hagstate->generation = ++asHagGeneration;
     pasbaseold = (ASBASE *)pasbase;
     pasbase = (ASBASE volatile *)pasbasenew;
     if(pasbaseold) {
@@ -498,6 +802,135 @@ long epicsStdCall asCompute(ASCLIENTPVT asClientPvt)
     status = asComputePvt(asClientPvt);
     UNLOCK;
     return(status);
+}
+
+long epicsStdCall asRefreshHag(unsigned *changed)
+{
+    ASHAGBASESTATE *state;
+    ASHAGENTRYSTATE *entry;
+    ASHAGUPDATE *updates = NULL;
+    ASHAGMAPENTRY *before = NULL;
+    ASHAGMAPENTRY *after = NULL;
+    epicsUInt64 generation = 0;
+    epicsUInt64 now;
+    size_t updateCount = 0;
+    size_t beforeCount = 0;
+    size_t afterCount = 0;
+    size_t i;
+    int entryChanged = 0;
+    int effectiveChanged = 0;
+    long status = 0;
+
+    if(changed)
+        *changed = 0;
+    asEnsureInitialized();
+    if(!asActive)
+        return S_asLib_asNotActive;
+
+    epicsMutexMustLock(asHagRefreshLock);
+    now = asHagNow();
+    LOCK;
+    if(!asActive) {
+        status = S_asLib_asNotActive;
+        UNLOCK;
+        goto done;
+    }
+    state = asHagStateFind((ASBASE *)pasbase);
+    if(!asCheckClientIP || !state || !state->nextDue || now < state->nextDue) {
+        UNLOCK;
+        goto done;
+    }
+    entry = (ASHAGENTRYSTATE *)ellFirst(&state->entries);
+    while(entry) {
+        if(now >= entry->due)
+            updateCount++;
+        entry = (ASHAGENTRYSTATE *)ellNext(&entry->node);
+    }
+    if(!updateCount) {
+        asHagScheduleNext(state);
+        UNLOCK;
+        goto done;
+    }
+    generation = state->generation;
+    updates = asCalloc(updateCount, sizeof(*updates));
+    entry = (ASHAGENTRYSTATE *)ellFirst(&state->entries);
+    i = 0;
+    while(entry) {
+        if(now >= entry->due) {
+            updates[i].index = entry->index;
+            updates[i].source = epicsStrDup(entry->source);
+            i++;
+        }
+        entry = (ASHAGENTRYSTATE *)ellNext(&entry->node);
+    }
+    UNLOCK;
+
+    for(i = 0; i < updateCount; i++) {
+        struct sockaddr_in address;
+
+        if(asHagResolve(updates[i].source, 0, &address) == 0) {
+            asHagFormatAddress(&address, updates[i].address,
+                               sizeof(updates[i].address));
+            updates[i].resolved = 1;
+        } else {
+            errlogPrintf("ACF: Unable to refresh host '%s'\n",
+                         updates[i].source);
+        }
+    }
+
+    now = asHagNow();
+    LOCK;
+    state = asHagStateFind((ASBASE *)pasbase);
+    if(!asActive || !state || state->generation != generation) {
+        UNLOCK;
+        goto done;
+    }
+    before = asHagCollectMap((ASBASE *)pasbase, &beforeCount);
+    entry = (ASHAGENTRYSTATE *)ellFirst(&state->entries);
+    while(entry) {
+        for(i = 0; i < updateCount; i++) {
+            int different;
+
+            if(updates[i].index != entry->index)
+                continue;
+            different = entry->resolved != updates[i].resolved ||
+                (entry->resolved &&
+                 strcmp(entry->name->host, updates[i].address) != 0);
+            if(different) {
+                asHagSetEntry(entry, updates[i].resolved,
+                              updates[i].address);
+                entryChanged = 1;
+            }
+            entry->due = asHagAfter(now,
+                updates[i].resolved ? AS_HAG_SUCCESS_INTERVAL
+                                    : AS_HAG_FAILURE_INTERVAL);
+            break;
+        }
+        entry = (ASHAGENTRYSTATE *)ellNext(&entry->node);
+    }
+    asHagScheduleNext(state);
+    if(entryChanged) {
+        after = asHagCollectMap((ASBASE *)pasbase, &afterCount);
+        effectiveChanged = !asHagMapsEqual(before, beforeCount,
+                                            after, afterCount);
+        asHashRebuild((ASBASE *)pasbase);
+        if(effectiveChanged)
+            status = asComputeAllAsgPvt();
+    }
+    UNLOCK;
+    if(changed)
+        *changed = !!effectiveChanged;
+
+done:
+    if(updates) {
+        for(i = 0; i < updateCount; i++)
+            free(updates[i].source);
+    }
+    free(updates);
+    free(before);
+    free(after);
+    epicsMutexUnlock(asHagRefreshLock);
+    return status;
 }
 
 /*The dump routines do not lock. Thus they may get inconsistent data.*/
@@ -1077,6 +1510,8 @@ void asFreeAll(ASBASE *pasbase)
     if(!pasbase)
         return;
 
+    asHagStateDestroy(pasbase);
+
     puag = (UAG *)ellFirst(&pasbase->uagList);
     while(puag) {
         puagname = (UAGNAME *)ellFirst(&puag->list);
@@ -1238,26 +1673,49 @@ static long asHagAddHost(HAG *phag,const char *host)
 
     } else {
         struct sockaddr_in addr;
-        epicsUInt32 ip;
+        char address[AS_HAG_IP_BUFSIZE];
 
-        if(aToIPAddr(host, 0, &addr)) {
-            static const char unresolved[] = "unresolved:";
-
-            errlogPrintf("ACF: Unable to resolve host '%s'\n", host);
-
-            phagname = asCalloc(1, sizeof(*phagname) + sizeof(unresolved)-1+strlen(host));
-            strcpy(phagname->host, unresolved);
-            strcat(phagname->host, host);
-
+        if(asHagParseNumeric(host, &addr) == 0) {
+            asHagFormatAddress(&addr, address, sizeof(address));
+            phagname = asCalloc(1, sizeof(*phagname) + sizeof(address) - 1u);
+            epicsSnprintf(phagname->host, sizeof(address), "%s", address);
         } else {
-            ip = ntohl(addr.sin_addr.s_addr);
-            phagname = asCalloc(1, sizeof(*phagname) + 24);
-            epicsSnprintf(phagname->host, 24,
-                          "%u.%u.%u.%u",
-                          (ip>>24)&0xff,
-                          (ip>>16)&0xff,
-                          (ip>>8)&0xff,
-                          (ip>>0)&0xff);
+            ASHAGBASESTATE *state = asHagStateFind(pasbasenew);
+            ASHAGENTRYSTATE *entry;
+            size_t hostLength = epicsStrnLen(host, AS_HAG_SOURCE_MAX);
+            size_t unresolvedSize;
+            size_t capacity;
+            epicsUInt64 now = asHagNow();
+            int resolved = asHagResolve(host, 0, &addr) == 0;
+
+            if(hostLength == AS_HAG_SOURCE_MAX) {
+                errlogPrintf("ACF: HAG host name exceeds %u bytes\n",
+                    AS_HAG_SOURCE_MAX - 1u);
+                return -1;
+            }
+            unresolvedSize = sizeof(AS_HAG_UNRESOLVED) + hostLength;
+            capacity = unresolvedSize > AS_HAG_IP_BUFSIZE
+                     ? unresolvedSize : AS_HAG_IP_BUFSIZE;
+
+            phagname = asCalloc(1, sizeof(*phagname) + capacity - 1u);
+            entry = asCalloc(1, sizeof(*entry));
+            entry->group = phag;
+            entry->name = phagname;
+            entry->source = epicsStrDup(host);
+            entry->capacity = capacity;
+            entry->index = state ? (unsigned)ellCount(&state->entries) : 0u;
+            entry->due = asHagAfter(now, resolved ? AS_HAG_SUCCESS_INTERVAL
+                                                  : AS_HAG_FAILURE_INTERVAL);
+            if(state)
+                ellAdd(&state->entries, &entry->node);
+            if(resolved) {
+                asHagFormatAddress(&addr, address, sizeof(address));
+                asHagSetEntry(entry, 1, address);
+            } else {
+                errlogPrintf("ACF: Unable to resolve host '%s'\n", host);
+                asHagSetEntry(entry, 0, NULL);
+            }
+            asHagScheduleNext(state);
         }
     }
     ellAdd(&phag->list, &phagname->node);

--- a/modules/libcom/test/aslibtest.c
+++ b/modules/libcom/test/aslibtest.c
@@ -12,15 +12,30 @@
 #include <epicsUnitTest.h>
 
 #include <errSymTbl.h>
+#include <epicsEvent.h>
 #include <epicsString.h>
+#include <epicsThread.h>
 #include <osiFileName.h>
+#include <osiSock.h>
 #include <errlog.h>
 
 #include <asLib.h>
+#include <as/asLibPvt.h>
 
 static char *asUser,
             *asHost;
 static int asAsl;
+
+static epicsUInt64 hagNow;
+static epicsUInt32 hagAddress;
+static unsigned hagResolveCount;
+static int hagResolveFailure;
+static int hagResolveBlock;
+static int hagUnexpectedName;
+static epicsEventId hagResolverEntered;
+static epicsEventId hagResolverRelease;
+
+#define TEST_NSEC_PER_SEC 1000000000uLL
 
 /**
  * @brief Test data with Host Access Groups (HAG)
@@ -47,6 +62,21 @@ static const char hostname_config[] = ""
     "        HAG(foo)\n"
     "    }\n"
     "}\n";
+
+static const char refresh_config[] = ""
+    "HAG(foo) {refresh.test}\n"
+    "ASG(DEFAULT) { RULE(0, NONE) }\n"
+    "ASG(ro) { RULE(1, READ) { HAG(foo) } }\n";
+
+static const char duplicate_config[] = ""
+    "HAG(foo) {refresh.test, 127.0.0.1}\n"
+    "ASG(DEFAULT) { RULE(0, NONE) }\n"
+    "ASG(ro) { RULE(1, READ) { HAG(foo) } }\n";
+
+static const char numeric_config[] = ""
+    "HAG(foo) {127.0.0.3}\n"
+    "ASG(DEFAULT) { RULE(0, NONE) }\n"
+    "ASG(ro) { RULE(1, READ) { HAG(foo) } }\n";
 
 /**
  * Test data with unsupported elements.
@@ -549,6 +579,55 @@ static void setHost(const char *name)
     asHost = epicsStrDup(name);
 }
 
+static epicsUInt64 testHagClock(void)
+{
+    return hagNow;
+}
+
+static int epicsStdCall testHagResolver(const char *name, unsigned short port,
+    struct sockaddr_in *address)
+{
+    static const struct sockaddr_in emptyAddress = {0};
+
+    if(strcmp(name, "refresh.test") != 0)
+        hagUnexpectedName = 1;
+    hagResolveCount++;
+    if(hagResolveBlock) {
+        epicsEventSignal(hagResolverEntered);
+        epicsEventMustWait(hagResolverRelease);
+    }
+    if(hagResolveFailure)
+        return -1;
+    *address = emptyAddress;
+    address->sin_family = AF_INET;
+    address->sin_port = htons(port);
+    address->sin_addr.s_addr = htonl(hagAddress);
+    return 0;
+}
+
+static void countAccessCallback(ASCLIENTPVT client, asClientStatus status)
+{
+    unsigned *count = asGetClientPvt(client);
+
+    if(status == asClientCOAR && count)
+        (*count)++;
+}
+
+static void addPersistentClient(ASMEMBERPVT member, ASCLIENTPVT *client,
+    char *host, unsigned *callbacks)
+{
+    long status = asAddClient(client, member, 0, "testing", host);
+
+    testOk(status == 0, "add persistent client %s -> %s",
+        host, errSymMsg(status));
+    if(status)
+        return;
+    asPutClientPvt(*client, callbacks);
+    status = asRegisterClientCallback(*client, countAccessCallback);
+    testOk(status == 0, "register callback for %s -> %s",
+        host, errSymMsg(status));
+}
+
 /**
  * Test the access control system with the given ASG, user, and hostname
  * This will test that the expected access given by mask is granted
@@ -658,6 +737,277 @@ static void testUseIP(void)
     testAccess("DEFAULT", 0);
     testAccess("ro", 0);
     testAccess("rw", 0);
+}
+
+static void testRefreshInactive(void)
+{
+    unsigned changed = 1;
+    long status = asRefreshHag(&changed);
+
+    testOk(status == S_asLib_asNotActive && changed == 0,
+        "refresh reports inactive Access Security");
+}
+
+static void testHagRefresh(void)
+{
+    ASMEMBERPVT member = NULL;
+    ASCLIENTPVT oldClient = NULL;
+    ASCLIENTPVT newClient = NULL;
+    char oldHost[] = "127.0.0.1";
+    char newHost[] = "127.0.0.2";
+    unsigned oldCallbacks = 0;
+    unsigned newCallbacks = 0;
+    unsigned changed;
+    unsigned calls;
+    long status;
+
+    testDiag("testHagRefresh()");
+    asCheckClientIP = 1;
+    hagNow = 0;
+    hagAddress = 0x7f000001u;
+    hagResolveCount = 0;
+    hagResolveFailure = 0;
+    hagResolveBlock = 0;
+    hagUnexpectedName = 0;
+    asTestSetHagClock(testHagClock);
+    asTestSetHagResolver(testHagResolver);
+
+    status = asInitMem(refresh_config, NULL);
+    testOk(status == 0, "load refreshable HAG -> %s", errSymMsg(status));
+    testOk(hagResolveCount == 1 && !hagUnexpectedName,
+        "initial load resolves the original hostname once");
+    status = asAddMember(&member, "ro");
+    testOk(status == 0, "add refresh test member -> %s", errSymMsg(status));
+    addPersistentClient(member, &oldClient, oldHost, &oldCallbacks);
+    addPersistentClient(member, &newClient, newHost, &newCallbacks);
+    testOk(asCheckGet(oldClient) && !asCheckGet(newClient),
+        "initial mapping grants only the original address");
+
+    changed = 99;
+    status = asRefreshHag(&changed);
+    testOk(status == 0 && changed == 0 && hagResolveCount == 1,
+        "poll before success interval performs no DNS work");
+
+    hagNow += 300uLL * TEST_NSEC_PER_SEC;
+    changed = 99;
+    status = asRefreshHag(&changed);
+    testOk(status == 0 && changed == 0 && hagResolveCount == 2 &&
+           oldCallbacks == 1 && newCallbacks == 1,
+        "unchanged refresh reports no effective change or callbacks");
+
+    hagAddress = 0x7f000002u;
+    hagNow += 300uLL * TEST_NSEC_PER_SEC;
+    changed = 0;
+    status = asRefreshHag(&changed);
+    testOk(status == 0 && changed == 1,
+        "changed address reports an effective mapping change");
+    testOk(!asCheckGet(oldClient) && asCheckGet(newClient),
+        "persistent client rights follow the changed address");
+    testOk(oldCallbacks == 2 && newCallbacks == 2,
+        "address change calls each affected client once");
+
+    hagResolveFailure = 1;
+    hagNow += 300uLL * TEST_NSEC_PER_SEC;
+    changed = 0;
+    eltc(0);
+    status = asRefreshHag(&changed);
+    eltc(1);
+    testOk(status == 0 && changed == 1,
+        "resolution failure removes the effective mapping");
+    testOk(!asCheckGet(oldClient) && !asCheckGet(newClient) &&
+           oldCallbacks == 2 && newCallbacks == 3,
+        "resolution failure is fail-closed for existing clients");
+
+    calls = hagResolveCount;
+    hagNow += 59uLL * TEST_NSEC_PER_SEC;
+    changed = 99;
+    status = asRefreshHag(&changed);
+    testOk(status == 0 && changed == 0 && hagResolveCount == calls,
+        "failed hostname is not retried before 60 seconds");
+
+    hagResolveFailure = 0;
+    hagAddress = 0x7f000001u;
+    hagNow += TEST_NSEC_PER_SEC;
+    changed = 0;
+    status = asRefreshHag(&changed);
+    testOk(status == 0 && changed == 1 && hagResolveCount == calls + 1,
+        "failed hostname is retried after 60 seconds");
+    testOk(asCheckGet(oldClient) && !asCheckGet(newClient) &&
+           oldCallbacks == 3 && newCallbacks == 3,
+        "successful retry restores existing client rights");
+
+    hagNow += 300uLL * TEST_NSEC_PER_SEC;
+    status = asRefreshHag(NULL);
+    testOk(status == 0, "changed output may be NULL");
+
+    if(oldClient) asRemoveClient(&oldClient);
+    if(newClient) asRemoveClient(&newClient);
+    if(member) asRemoveMember(&member);
+}
+
+static void testHagEffectiveMapping(void)
+{
+    ASMEMBERPVT member = NULL;
+    ASCLIENTPVT client = NULL;
+    char host[] = "127.0.0.1";
+    unsigned callbacks = 0;
+    unsigned changed = 99;
+    long status;
+
+    testDiag("testHagEffectiveMapping()");
+    hagNow = 0;
+    hagAddress = 0x7f000001u;
+    hagResolveFailure = 0;
+    hagResolveCount = 0;
+    eltc(0);
+    status = asInitMem(duplicate_config, NULL);
+    eltc(1);
+    testOk(status == 0, "load duplicate effective HAG mapping -> %s",
+        errSymMsg(status));
+    status = asAddMember(&member, "ro");
+    testOk(status == 0, "add duplicate mapping member -> %s",
+        errSymMsg(status));
+    addPersistentClient(member, &client, host, &callbacks);
+    testOk(asCheckGet(client) && callbacks == 1,
+        "duplicate mapping initially grants access");
+
+    hagResolveFailure = 1;
+    hagNow += 300uLL * TEST_NSEC_PER_SEC;
+    eltc(0);
+    status = asRefreshHag(&changed);
+    eltc(1);
+    testOk(status == 0 && changed == 0,
+        "entry change with identical effective set reports unchanged");
+    testOk(asCheckGet(client) && callbacks == 1,
+        "unchanged effective set avoids client recomputation");
+
+    if(client) asRemoveClient(&client);
+    if(member) asRemoveMember(&member);
+}
+
+static void testStaticHagEntries(void)
+{
+    unsigned changed = 99;
+    long status;
+
+    testDiag("testStaticHagEntries()");
+    hagResolveCount = 0;
+    hagNow = 1000uLL * TEST_NSEC_PER_SEC;
+    asCheckClientIP = 1;
+    status = asInitMem(numeric_config, NULL);
+    testOk(status == 0, "load numeric HAG -> %s", errSymMsg(status));
+    status = asRefreshHag(&changed);
+    testOk(status == 0 && changed == 0 && hagResolveCount == 0,
+        "numeric HAG entries never perform DNS refresh");
+    setUser("testing");
+    setHost("127.0.0.3");
+    asAsl = 0;
+    testAccess("ro", 1);
+
+    asCheckClientIP = 0;
+    status = asInitMem(refresh_config, NULL);
+    testOk(status == 0, "load hostname-string HAG -> %s", errSymMsg(status));
+    changed = 99;
+    status = asRefreshHag(&changed);
+    testOk(status == 0 && changed == 0 && hagResolveCount == 0,
+        "asCheckClientIP=0 keeps hostname HAG entries static");
+    setHost("refresh.test");
+    testAccess("ro", 1);
+}
+
+typedef struct RefreshThreadInfo {
+    epicsEventId done;
+    long status;
+    unsigned changed;
+} RefreshThreadInfo;
+
+static void runRefresh(void *raw)
+{
+    RefreshThreadInfo *info = raw;
+
+    info->status = asRefreshHag(&info->changed);
+    epicsEventSignal(info->done);
+}
+
+static void startRefreshThread(const char *name, RefreshThreadInfo *info)
+{
+    info->done = epicsEventMustCreate(epicsEventEmpty);
+    info->status = -1;
+    info->changed = 99;
+    epicsThreadCreate(name, epicsThreadPriorityMedium,
+        epicsThreadGetStackSize(epicsThreadStackSmall), runRefresh, info);
+}
+
+static void finishRefreshThread(RefreshThreadInfo *info)
+{
+    epicsEventMustWait(info->done);
+    epicsEventDestroy(info->done);
+}
+
+static void testHagRefreshConcurrency(void)
+{
+    RefreshThreadInfo first;
+    RefreshThreadInfo second;
+    unsigned calls;
+    long status;
+
+    testDiag("testHagRefreshConcurrency()");
+    asCheckClientIP = 1;
+    hagNow = 0;
+    hagAddress = 0x7f000001u;
+    hagResolveFailure = 0;
+    hagResolveBlock = 0;
+    status = asInitMem(refresh_config, NULL);
+    testOk(status == 0, "load policy for reload race -> %s", errSymMsg(status));
+
+    hagResolverEntered = epicsEventMustCreate(epicsEventEmpty);
+    hagResolverRelease = epicsEventMustCreate(epicsEventEmpty);
+    hagResolveBlock = 1;
+    hagNow += 300uLL * TEST_NSEC_PER_SEC;
+    startRefreshThread("hagRefreshReload", &first);
+    epicsEventMustWait(hagResolverEntered);
+    status = asInitMem(numeric_config, NULL);
+    testOk(status == 0, "policy reload completes while DNS is pending -> %s",
+        errSymMsg(status));
+    hagResolveBlock = 0;
+    epicsEventSignal(hagResolverRelease);
+    finishRefreshThread(&first);
+    testOk(first.status == 0 && first.changed == 0,
+        "stale DNS result is discarded after policy generation changes");
+    setUser("testing");
+    setHost("127.0.0.3");
+    asAsl = 0;
+    testAccess("ro", 1);
+    epicsEventDestroy(hagResolverEntered);
+    epicsEventDestroy(hagResolverRelease);
+
+    hagNow = 0;
+    status = asInitMem(refresh_config, NULL);
+    testOk(status == 0, "load policy for concurrent refresh -> %s",
+        errSymMsg(status));
+    hagResolverEntered = epicsEventMustCreate(epicsEventEmpty);
+    hagResolverRelease = epicsEventMustCreate(epicsEventEmpty);
+    hagResolveBlock = 1;
+    hagNow += 300uLL * TEST_NSEC_PER_SEC;
+    calls = hagResolveCount;
+    startRefreshThread("hagRefreshOne", &first);
+    epicsEventMustWait(hagResolverEntered);
+    startRefreshThread("hagRefreshTwo", &second);
+    epicsThreadSleep(0.02);
+    hagResolveBlock = 0;
+    epicsEventSignal(hagResolverRelease);
+    finishRefreshThread(&first);
+    finishRefreshThread(&second);
+    testOk(first.status == 0 && second.status == 0,
+        "concurrent refresh callers both complete successfully");
+    testOk(hagResolveCount == calls + 1,
+        "concurrent refresh calls serialize one due DNS lookup");
+    testOk(first.changed == 0 && second.changed == 0,
+        "serialized unchanged refreshes report no mapping change");
+    epicsEventDestroy(hagResolverEntered);
+    epicsEventDestroy(hagResolverRelease);
+    hagResolveBlock = 0;
+    asTestResetHagHooks();
 }
 
 static void testFutureProofParser(void)
@@ -783,11 +1133,16 @@ static void testFutureProofParser(void)
 
 MAIN(aslibtest)
 {
-    testPlan(64);
+    testPlan(105);
+    testRefreshInactive();
     testSyntaxErrors();
     testFutureProofParser();
     testHostNames();
     testUseIP();
+    testHagRefresh();
+    testHagEffectiveMapping();
+    testStaticHagEntries();
+    testHagRefreshConcurrency();
     errlogFlush();
     return testDone();
 }


### PR DESCRIPTION
## Summary

Add an explicit Access Security API for refreshing hostname-based Host Access
Groups (HAGs) without reloading the full ACF:

```c
LIBCOM_API long epicsStdCall asRefreshHag(unsigned *changed);
```

Applications call this periodically from a control-plane thread.  Base limits
successful lookups to once every 300 seconds and failed lookups to once every
60 seconds.  Ordinary `asCheckGet()` and `asCheckPut()` calls remain simple
cached-rights checks and never perform DNS work.

## Why this belongs in Base

With `asCheckClientIP=1`, Access Security resolves HAG hostnames when an ACF is
loaded, but the resolved address is otherwise fixed for the lifetime of that
policy.  A long-running server therefore keeps stale host membership after DNS
changes unless it reloads the entire ACF or restarts.

Applications such as `redis-pvxs-ioc` can decide when a refresh should run,
but the existing public API does not expose enough state to carry it out
safely.  `asLib` owns the original HAG hostname, its lookup hash, the Access
Security lock, active `ASCLIENTPVT` objects, cached rights, and
change-of-access callbacks.  Keeping the state transition in `asLib` lets a
server request a refresh without depending on private layouts or treating a
full ACF reload as a DNS refresh operation.

## Behavior

- Keep numeric HAG entries static and preserve existing IPv4 matching.
- Retain hostname source text in private sidecar state without changing the
  installed `ASBASE` or `HAGNAME` layouts.
- Resolve due names outside the Access Security lock, then apply the complete
  result only if the same policy generation is still active.
- Serialize refresh callers and discard stale results when an ACF reload wins
  during DNS resolution.
- Rebuild the HAG lookup state when an entry changes, but recompute clients only
  when the normalized effective HAG/address set changes.
- Invoke existing change-of-access callbacks for affected connected clients.
- Treat resolution failure as fail-closed by removing the stale mapping and
  retrying after 60 seconds.
- Report `*changed = 1` only for an effective mapping change.  DNS failures are
  policy outcomes and are not returned as API failures.

The implementation continues to use `aToIPAddr()`.  It deliberately does not
inspect DNS record TTLs or add a `libresolv` dependency to `libCom`.

## Scope

This is intended as a focused successor to #862 and is limited to Access
Security HAG refresh.  The earlier PR also included CA-client search
destination refresh.  CA-client DNS behavior is left for a separate design
that can address asynchronous resolution and event-loop requirements on its
own.

## Testing

- `aslibtest`: 105/105 on macOS and Linux, shared and
  `SHARED_LIBRARIES=NO`
- Full Linux `modules/libcom/test` suite: 52 test programs and 4605 tests
- Full shared Base builds on macOS and Linux; `SHARED_LIBRARIES=NO` Base build
  on macOS and static `libCom` build on Linux
- `redis-pvxs-ioc`: all 6 consumer test executables passed after rebuilding
  Base and PVXS against this candidate on Linux
- `git diff --check`
- Confirmed with `ldd` that `libCom` has no resolver-library dependency

The deterministic tests cover refresh/retry timing, unchanged and duplicate
effective mappings, DNS loss and restoration, persistent-client callbacks,
numeric and hostname-string modes, concurrent refresh callers, and an ACF
reload completing while DNS resolution is pending.
