### PR TITLE
WIP: allow *_PORT=0

### DIFF
--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -280,10 +280,6 @@ void rsrv_build_addr_lists(void)
 {
     int autobeaconlist = 1;
 
-    /* the UDP ports are known at this point, but the TCP port is not */
-    assert(ca_beacon_port!=0);
-    assert(ca_udp_port!=0);
-
     envGetBoolConfigParam(&EPICS_CAS_AUTO_BEACON_ADDR_LIST, &autobeaconlist);
 
     ellInit ( &casIntfAddrList );

--- a/modules/libcom/src/env/envSubr.c
+++ b/modules/libcom/src/env/envSubr.c
@@ -407,6 +407,7 @@ LIBCOM_API unsigned short epicsStdCall envGetInetPortConfigParam
         errlogPrintf ("setting \"%s\" = %ld\n", pEnv->name, epicsParam);
     }
 
+    if (epicsParam==0) {} else
     if (epicsParam<=IPPORT_USERRESERVED || epicsParam>USHRT_MAX) {
         errlogPrintf ("EPICS Environment \"%s\" out of range\n", pEnv->name);
         /*


### PR DESCRIPTION
Allow explicit request for a random port.  eg. for use with unit testing.

see https://github.com/epics-base/epics-base/issues/943#issuecomment-5173299708