### PR TITLE
db: fix dbChannel_put() for DBR_TIME_STRING

### DIFF
--- a/modules/database/src/ioc/db/db_access.c
+++ b/modules/database/src/ioc/db/db_access.c
@@ -877,7 +877,7 @@ int dbChannel_put(struct dbChannel *chan, int src_type,
         break;
 
     case(oldDBR_TIME_STRING):
-        status = dbChannelPutField(chan, DBR_TIME,
+        status = dbChannelPutField(chan, DBR_STRING,
             ((const struct dbr_time_string *)psrc)->value, no_elements);
         break;
 /*  case(oldDBR_TIME_INT): */


### PR DESCRIPTION
DBR_TIME is the option mask 0x10 from dbAccessDefs.h, not a field data type