### PR TITLE
More RSRV checks

### DIFF
--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -1087,11 +1087,16 @@ static long dbPutFieldLink(DBADDR *paddr,
     switch (dbrType) {
     case DBR_CHAR:
     case DBR_UCHAR:
-        if (pstring[nRequest - 1] != '\0')
+        if (nRequest == 0) {
+            pstring = pbuffer = ""; // treat zero bytes the same as one null byte
+        } else if (pstring[nRequest - 1] != '\0') {
             return S_db_badDbrtype;
+        }
         break;
 
     case DBR_STRING:
+        if (nRequest != 1)
+            return S_db_onlyOne;
         break;
 
     default:
@@ -1253,6 +1258,8 @@ long dbPutField(DBADDR *paddr, short dbrType,
 
     if (special == SPC_ATTRIBUTE)
         return S_db_noMod;
+    if (nRequest < 0)
+        return S_db_badChoice;
 
     /*check for putField disabled*/
     if (precord->disp && paddr->pfield != &precord->disp)
@@ -1332,6 +1339,8 @@ long dbPut(DBADDR *paddr, short dbrType,
 
     if (special == SPC_ATTRIBUTE)
         return S_db_noMod;
+    if (nRequest < 0)
+        return S_db_badChoice;
 
     if (dbrType == DBR_PUT_ACKT && field_type <= DBF_DEVICE) {
         return putAckt(paddr, pbuffer, 1, 1, 0);

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -743,7 +743,6 @@ static int write_action ( caHdrLargeArray *mp,
     int                     status;
     long                    dbStatus;
     void                    *asWritePvt;
-    unsigned                size;
 
     pciu = MPTOPCIU(mp, client);
     if(!pciu){
@@ -759,8 +758,19 @@ static int write_action ( caHdrLargeArray *mp,
         mp->m_count = dbChannelFinalElements(pciu->dbch);
     }
 
-    size = dbr_size_n (mp->m_dataType, mp->m_count);
-    if (size > mp->m_postsize) {
+    if (mp->m_dataType == DBR_STRING && mp->m_count == 1 && mp->m_postsize < MAX_STRING_SIZE
+        && (client->sssb || !!(client->sssb = malloc(MAX_STRING_SIZE)))) {
+        // client sent DBR_STRING with truncated body.  This is allowed when count==1.
+        // we copy into a temporary buffer.
+        // copy into [0, postsize)
+        memcpy(client->sssb, pPayload, mp->m_postsize);
+        // zero remaining [postsize, max_string_size)
+        memset(client->sssb + mp->m_postsize, 0, MAX_STRING_SIZE - mp->m_postsize);
+        // use instead of socket buffer
+        pPayload = client->sssb;
+
+    } else if (dbr_size_n (mp->m_dataType, mp->m_count) > mp->m_postsize) {
+        log_header ( "truncated body", client, mp, 0);
         return RSRV_ERROR;
     }
 

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -57,8 +57,8 @@
 
 static EVENTFUNC read_reply;
 
-#define logBadId(CLIENT, MP, PPL)\
-logBadIdWithFileAndLineno(CLIENT, MP, PPL, __FILE__, __LINE__)
+#define logBadId(CLIENT, MP)\
+logBadIdWithFileAndLineno(CLIENT, MP, __FILE__, __LINE__)
 
 /*
  * for tracking db put notifies
@@ -283,7 +283,6 @@ static void log_header (
     const char              *pContext,
     struct client           *client,
     const caHdrLargeArray   *mp,
-    const void              *pPayLoad,
     unsigned                mnum
 )
 {
@@ -312,12 +311,11 @@ static void log_header (
 static void logBadIdWithFileAndLineno(
 struct client       *client,
 caHdrLargeArray     *mp,
-const void          *pPayload,
 char                *pFileName,
 unsigned            lineno
 )
 {
-    log_header ( "bad resource ID", client, mp, pPayload, 0 );
+    log_header ( "bad resource ID", client, mp, 0 );
     SEND_LOCK ( client );
     send_err ( mp, ECA_INTERNAL, client, "Bad Resource ID at %s.%d",
         pFileName, lineno );
@@ -330,9 +328,10 @@ unsigned            lineno
 static int bad_udp_cmd_action ( caHdrLargeArray *mp,
                        void *pPayload, struct client *pClient )
 {
+    (void)pPayload;
     if (CASDEBUG > 0)
         log_header ("invalid (damaged?) request code from UDP",
-                    pClient, mp, pPayload, 0);
+                    pClient, mp, 0);
     return RSRV_ERROR;
 }
 
@@ -343,7 +342,8 @@ static int bad_tcp_cmd_action ( caHdrLargeArray *mp, void *pPayload,
                            struct client *client )
 {
     const char *pCtx = "invalid (damaged?) request code from TCP";
-    log_header ( pCtx, client, mp, pPayload, 0 );
+    (void)pPayload;
+    log_header ( pCtx, client, mp, 0 );
 
     /*
      *  by default, clients don't recover
@@ -611,7 +611,7 @@ static int read_action ( caHdrLargeArray *mp, void *pPayloadIn, struct client *p
     db_field_log *pfl = NULL;
 
     if ( ! pciu ) {
-        logBadId ( pClient, mp, 0 );
+        logBadId ( pClient, mp );
         return RSRV_ERROR;
     }
     readAccess = asCheckGet ( pciu->asClientPVT );
@@ -706,7 +706,7 @@ static int read_notify_action ( caHdrLargeArray *mp, void *pPayload, struct clie
 
     pciu = MPTOPCIU ( mp, client );
     if ( !pciu ) {
-        logBadId ( client, mp, pPayload );
+        logBadId ( client, mp );
         return RSRV_ERROR;
     }
 
@@ -747,12 +747,12 @@ static int write_action ( caHdrLargeArray *mp,
 
     pciu = MPTOPCIU(mp, client);
     if(!pciu){
-        logBadId(client, mp, pPayload);
+        logBadId(client, mp);
         return RSRV_ERROR;
     }
 
     if (INVALID_DB_REQ(mp->m_dataType)) {
-        log_header ("bad put data type", client, mp, pPayload, 0);
+        log_header ("bad put data type", client, mp, 0);
         return RSRV_ERROR;
     }
     if (mp->m_count > dbChannelFinalElements(pciu->dbch)) {
@@ -780,7 +780,7 @@ static int write_action ( caHdrLargeArray *mp,
         mp->m_dataType, pPayload, pPayload,
         FALSE /* net -> host format */, mp->m_count );
     if ( status != ECA_NORMAL ) {
-        log_header ("invalid data type", client, mp, pPayload, 0);
+        log_header ("invalid data type", client, mp, 0);
         SEND_LOCK(client);
         send_err(
             mp,
@@ -850,7 +850,7 @@ static int host_name_action ( caHdrLargeArray *mp, void *pPayload,
     size = epicsStrnLen(pName, mp->m_postsize)+1;
     if (size > 512 || size > mp->m_postsize) {
         log_header ( "bad (very long) host name",
-            client, mp, pPayload, 0 );
+            client, mp, 0 );
         SEND_LOCK(client);
         send_err(
             mp,
@@ -875,7 +875,7 @@ static int host_name_action ( caHdrLargeArray *mp, void *pPayload,
     pMalloc = malloc(size);
     if(!pMalloc){
         log_header ( "no space in pool for new host name",
-            client, mp, pPayload, 0 );
+            client, mp, 0 );
         SEND_LOCK(client);
         send_err(
             mp,
@@ -937,7 +937,7 @@ static int client_name_action ( caHdrLargeArray *mp, void *pPayload,
     size = epicsStrnLen(pName, mp->m_postsize)+1;
     if (size > 512 || size > mp->m_postsize) {
         log_header ("a very long user name was specified",
-            client, mp, pPayload, 0);
+            client, mp, 0);
         SEND_LOCK(client);
         send_err(
             mp,
@@ -954,7 +954,7 @@ static int client_name_action ( caHdrLargeArray *mp, void *pPayload,
     pMalloc = malloc(size);
     if(!pMalloc){
         log_header ("no memory for new user name",
-            client, mp, pPayload, 0);
+            client, mp, 0);
         SEND_LOCK(client);
         send_err(
             mp,
@@ -1229,7 +1229,7 @@ static int claim_ciu_action ( caHdrLargeArray *mp,
      */
     if (mp->m_postsize<=1) {
         log_header ( "empty PV name in UDP search request?",
-            client, mp, pPayload, 0 );
+            client, mp, 0 );
         return RSRV_OK;
     }
     pName[mp->m_postsize-1] = '\0';
@@ -1254,7 +1254,7 @@ static int claim_ciu_action ( caHdrLargeArray *mp,
             mp->m_cid);
     if (!pciu) {
         log_header ("no memory to create new channel",
-            client, mp, pPayload, 0);
+            client, mp, 0);
         SEND_LOCK(client);
         send_err(mp,
             ECA_ALLOCMEM,
@@ -1276,7 +1276,7 @@ static int claim_ciu_action ( caHdrLargeArray *mp,
             client->pHostName ? client->pHostName : "");
     if(status != 0 && status != S_asLib_asNotActive){
         log_header ("No room for security table",
-            client, mp, pPayload, 0);
+            client, mp, 0);
         SEND_LOCK(client);
         send_err(mp, ECA_ALLOCMEM, client, "No room for security table");
         SEND_UNLOCK(client);
@@ -1306,7 +1306,7 @@ static int claim_ciu_action ( caHdrLargeArray *mp,
     }
     else if (status!=0) {
         log_header ("No room for access security state change subscription",
-            client, mp, pPayload, 0);
+            client, mp, 0);
         SEND_LOCK(client);
         send_err(mp, ECA_ALLOCMEM, client,
             "No room for access security state change subscription");
@@ -1666,12 +1666,12 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
 
     pciu = MPTOPCIU(mp, client);
     if(!pciu){
-        logBadId ( client, mp, pPayload );
+        logBadId ( client, mp );
         return RSRV_ERROR;
     }
 
     if (INVALID_DB_REQ(mp->m_dataType)) {
-        log_header ("bad put notify data type", client, mp, pPayload, 0);
+        log_header ("bad put notify data type", client, mp, 0);
         putNotifyErrorReply (client, mp, ECA_BADTYPE);
         return RSRV_ERROR;
     }
@@ -1728,7 +1728,7 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
 
                 if ( busyTmp ) {
                     log_header("put call back time out", client,
-                        &pciu->pPutNotify->msg, pciu->pPutNotify->pbuffer, 0);
+                        &pciu->pPutNotify->msg, 0);
                     asTrapWriteAfter ( asWritePvtTmp );
                     putNotifyErrorReply (client, &pciu->pPutNotify->msg, ECA_PUTCBINPROG);
                 }
@@ -1745,7 +1745,7 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
              * if there isn't enough memory left
              */
             log_header ( "no memory to initiate put notify",
-                client, mp, pPayload, 0 );
+                client, mp, 0 );
             putNotifyErrorReply (client, mp, ECA_ALLOCMEM);
             return RSRV_ERROR;
         }
@@ -1753,7 +1753,7 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
 
     if ( ! rsrvExpandPutNotify ( pciu->pPutNotify, size ) ) {
         log_header ( "no memory to initiate vector put notify",
-            client, mp, pPayload, 0 );
+            client, mp, 0 );
         putNotifyErrorReply ( client, mp, ECA_ALLOCMEM );
         return RSRV_ERROR;
     }
@@ -1767,7 +1767,7 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
         mp->m_dataType, pPayload, pciu->pPutNotify->pbuffer,
         FALSE /* net -> host format */, mp->m_count );
     if ( status != ECA_NORMAL ) {
-        log_header ("invalid data type", client, mp, pPayload, 0);
+        log_header ("invalid data type", client, mp, 0);
         putNotifyErrorReply ( client, mp, status );
         return RSRV_ERROR;
     }
@@ -1804,7 +1804,7 @@ static int event_add_action (caHdrLargeArray *mp, void *pPayload, struct client 
 
     pciu = MPTOPCIU ( mp, client );
     if ( ! pciu ) {
-        logBadId ( client, mp, pPayload );
+        logBadId ( client, mp );
         return RSRV_ERROR;
     }
 
@@ -1821,7 +1821,7 @@ static int event_add_action (caHdrLargeArray *mp, void *pPayload, struct client 
 
     if (!pevext) {
         log_header ("no memory to add subscription",
-            client, mp, pPayload, 0);
+            client, mp, 0);
         SEND_LOCK(client);
         send_err(
             mp,
@@ -1849,7 +1849,7 @@ static int event_add_action (caHdrLargeArray *mp, void *pPayload, struct client 
                 read_reply, pevext, pevext->mask);
     if (pevext->pdbev == NULL) {
         log_header ("no memory to add subscription to db",
-            client, mp, pPayload, 0);
+            client, mp, 0);
         SEND_LOCK(client);
         send_err (mp, ECA_ALLOCMEM, client,
             "subscription install into record %s failed",
@@ -1918,7 +1918,7 @@ static int clear_channel_reply ( caHdrLargeArray *mp,
       */
      pciu = MPTOPCIU(mp, client);
      if(!pciu){
-         logBadId ( client, mp, pPayload );
+         logBadId ( client, mp );
          return RSRV_ERROR;
      }
 
@@ -1994,7 +1994,7 @@ static int clear_channel_reply ( caHdrLargeArray *mp,
      if(status != S_bucket_success){
          UNLOCK_CLIENTQ;
          errMessage (status, "Bad resource id during channel clear");
-         logBadId ( client, mp, pPayload );
+         logBadId ( client, mp );
          return RSRV_ERROR;
      }
      rsrvChannelCount--;
@@ -2027,7 +2027,7 @@ static int event_cancel_reply ( caHdrLargeArray *mp, void *pPayload, struct clie
       */
      pciu = MPTOPCIU(mp, client);
      if (!pciu) {
-         logBadId ( client, mp, pPayload );
+         logBadId ( client, mp );
          return RSRV_ERROR;
      }
 
@@ -2194,7 +2194,7 @@ static int search_reply_udp ( caHdrLargeArray *mp, void *pPayload, struct client
      */
     if (mp->m_postsize<=1) {
         log_header ("empty PV name in UDP search request?",
-            client, mp, pPayload, 0);
+            client, mp, 0);
         return RSRV_OK;
     }
     pName[mp->m_postsize-1] = '\0';
@@ -2281,7 +2281,7 @@ static int search_reply_tcp (
      */
     if (mp->m_postsize<=1) {
         log_header ("empty PV name in UDP search request?",
-            client, mp, pPayload, 0);
+            client, mp, 0);
         return RSRV_OK;
     }
     pName[mp->m_postsize-1] = '\0';
@@ -2478,7 +2478,7 @@ int camessage ( struct client *client )
                     "CAS: Client version %u too old", client->minor_version_number );
                 SEND_UNLOCK(client);
                 log_header ( "CAS: Client version too old",
-                    client, &msg, 0, nmsg );
+                    client, &msg, nmsg );
                 if (msgsize >= bytes_left) {
                     client->recvBytesToDrain = msgsize - bytes_left;
                     client->recv.stk = client->recv.cnt;
@@ -2506,7 +2506,7 @@ int camessage ( struct client *client )
                     "CAS: Missaligned protocol rejected" );
                 SEND_UNLOCK(client);
                 log_header ( "CAS: Missaligned protocol rejected",
-                    client, &msg, 0, nmsg );
+                    client, &msg, nmsg );
             }
             status = RSRV_ERROR;
             break;
@@ -2528,7 +2528,7 @@ int camessage ( struct client *client )
                         rsrvSizeofLargeBufTCP );
                     SEND_UNLOCK(client);
                     log_header ( "CAS: server unable to load large request message",
-                        client, &msg, 0, nmsg );
+                        client, &msg, nmsg );
                 }
                 assert ( client->recv.cnt <= client->recv.maxstk );
                 assert ( msgsize >= bytes_left );
@@ -2550,7 +2550,7 @@ int camessage ( struct client *client )
         nmsg++;
 
         if ( CASDEBUG > 2 )
-            log_header (NULL, client, &msg, pBody, nmsg);
+            log_header (NULL, client, &msg, nmsg);
 
         if ( client->proto==IPPROTO_UDP ) {
             if ( msg.m_cmmd < NELEMENTS ( udpJumpTable ) ) {

--- a/modules/database/src/ioc/rsrv/camessage.c
+++ b/modules/database/src/ioc/rsrv/camessage.c
@@ -1664,6 +1664,60 @@ void rsrvFreePutNotify ( client *pClient,
      }
 }
 
+/* Only one concurrent write_notify (aka. put with callback) is allowed for each client.
+ * If a second write_notify is attempted before the first has completed, then wait for
+ * some time for the first to complete.  Then cancel the first.
+ */
+static const double write_notify_timeout = 60.0;
+
+// wait for in-progress put notify to complete, or cancel after some time
+static void write_notify_cancel(const struct channel_in_use *pciu)
+{
+    struct client* client = pciu->client;
+    // serialize concurrent put notifies
+    epicsMutexMustLock(client->putNotifyLock);
+    while(pciu->pPutNotify->busy){
+        epicsMutexUnlock(client->putNotifyLock);
+        epicsEventStatus status = epicsEventWaitWithTimeout(client->blockSem, write_notify_timeout);
+        if ( status != epicsEventWaitOK ) { // timeout
+            char busyTmp;
+            void * asWritePvtTmp = 0;
+
+            epicsMutexMustLock(client->putNotifyLock);
+            busyTmp = pciu->pPutNotify->busy;
+            epicsMutexUnlock(client->putNotifyLock);
+
+            /* if any possibility of put notify still running
+             * then cancel it
+             */
+            if ( busyTmp ) {
+                dbNotifyCancel(&pciu->pPutNotify->dbPutNotify);
+            }
+            epicsMutexMustLock(client->putNotifyLock);
+            busyTmp = pciu->pPutNotify->busy;
+            if ( busyTmp ) {
+                if ( pciu->pPutNotify->onExtraLaborQueue ) {
+                    ellDelete ( &client->putNotifyQue,
+                              &pciu->pPutNotify->node );
+                }
+                pciu->pPutNotify->busy = FALSE;
+                asWritePvtTmp = pciu->pPutNotify->asWritePvt;
+                pciu->pPutNotify->asWritePvt = 0;
+            }
+            epicsMutexUnlock(client->putNotifyLock);
+
+            if ( busyTmp ) {
+                log_header("put call back time out", client,
+                           &pciu->pPutNotify->msg, 0);
+                asTrapWriteAfter ( asWritePvtTmp );
+                putNotifyErrorReply (client, &pciu->pPutNotify->msg, ECA_PUTCBINPROG);
+            }
+        }
+        epicsMutexMustLock(client->putNotifyLock);
+    }
+    epicsMutexUnlock(client->putNotifyLock);
+}
+
 /*
  * write_notify_action()
  */
@@ -1694,60 +1748,10 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
         return RSRV_OK;
     }
 
-    size = dbr_size_n (mp->m_dataType, mp->m_count);
-    if (size > mp->m_postsize) {
-        return RSRV_ERROR;
-    }
-
     if ( pciu->pPutNotify ) {
+        write_notify_cancel(pciu);
 
-        /*
-         * serialize concurrent put notifies
-         */
-        epicsMutexMustLock(client->putNotifyLock);
-        while(pciu->pPutNotify->busy){
-            epicsMutexUnlock(client->putNotifyLock);
-            status = epicsEventWaitWithTimeout(client->blockSem,60.0);
-            if ( status != epicsEventWaitOK ) {
-                char busyTmp;
-                void * asWritePvtTmp = 0;
-
-                epicsMutexMustLock(client->putNotifyLock);
-                busyTmp = pciu->pPutNotify->busy;
-                epicsMutexUnlock(client->putNotifyLock);
-
-                /*
-                 * if any possibility of put notify still running
-                 * then cancel it
-                 */
-                if ( busyTmp ) {
-                    dbNotifyCancel(&pciu->pPutNotify->dbPutNotify);
-                }
-                epicsMutexMustLock(client->putNotifyLock);
-                busyTmp = pciu->pPutNotify->busy;
-                if ( busyTmp ) {
-                    if ( pciu->pPutNotify->onExtraLaborQueue ) {
-                        ellDelete ( &client->putNotifyQue,
-                                    &pciu->pPutNotify->node );
-                    }
-                    pciu->pPutNotify->busy = FALSE;
-                    asWritePvtTmp = pciu->pPutNotify->asWritePvt;
-                    pciu->pPutNotify->asWritePvt = 0;
-                }
-                epicsMutexUnlock(client->putNotifyLock);
-
-                if ( busyTmp ) {
-                    log_header("put call back time out", client,
-                        &pciu->pPutNotify->msg, 0);
-                    asTrapWriteAfter ( asWritePvtTmp );
-                    putNotifyErrorReply (client, &pciu->pPutNotify->msg, ECA_PUTCBINPROG);
-                }
-            }
-            epicsMutexMustLock(client->putNotifyLock);
-        }
-        epicsMutexUnlock(client->putNotifyLock);
-    }
-    else {
+    } else {
         pciu->pPutNotify = rsrvAllocPutNotify ( pciu );
         if ( ! pciu->pPutNotify ) {
             /*
@@ -1761,6 +1765,8 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
         }
     }
 
+    size = dbr_size_n (mp->m_dataType, mp->m_count);
+
     if ( ! rsrvExpandPutNotify ( pciu->pPutNotify, size ) ) {
         log_header ( "no memory to initiate vector put notify",
             client, mp, 0 );
@@ -1768,20 +1774,33 @@ static int write_notify_action ( caHdrLargeArray *mp, void *pPayload,
         return RSRV_ERROR;
     }
 
+    if (mp->m_dataType == DBR_STRING && mp->m_count == 1 && mp->m_postsize < size) {
+        // client sent DBR_STRING with truncated body.  This is allowed when count==1.
+        // put notify buffer has sufficient capacity, so copy in directly
+        char *pPNbuf = pciu->pPutNotify->pbuffer;
+        memcpy(pPNbuf                 , pPayload, mp->m_postsize);
+        memset(pPNbuf + mp->m_postsize, 0       , size - mp->m_postsize);
+
+    } else if (mp->m_postsize < size) {
+        log_header ( "truncated body", client, mp, 0);
+        return RSRV_ERROR;
+
+    } else {
+        // copy/convert to host endian
+        status = caNetConvert (
+            mp->m_dataType, pPayload, pciu->pPutNotify->pbuffer,
+            FALSE /* net -> host format */, mp->m_count );
+        if ( status != ECA_NORMAL ) {
+            log_header ("invalid data type", client, mp, 0);
+            putNotifyErrorReply ( client, mp, status );
+            return RSRV_ERROR;
+        }
+    }
+
     pciu->pPutNotify->busy = TRUE;
     pciu->pPutNotify->onExtraLaborQueue = FALSE;
     pciu->pPutNotify->msg = *mp;
     pciu->pPutNotify->nRequest = mp->m_count;
-
-    status = caNetConvert (
-        mp->m_dataType, pPayload, pciu->pPutNotify->pbuffer,
-        FALSE /* net -> host format */, mp->m_count );
-    if ( status != ECA_NORMAL ) {
-        log_header ("invalid data type", client, mp, 0);
-        putNotifyErrorReply ( client, mp, status );
-        return RSRV_ERROR;
-    }
-
     pciu->pPutNotify->dbrType = mp->m_dataType;
 
     pciu->pPutNotify->asWritePvt = asTrapWriteWithData (

--- a/modules/database/src/ioc/rsrv/caservertask.c
+++ b/modules/database/src/ioc/rsrv/caservertask.c
@@ -1136,6 +1136,7 @@ void destroy_client ( struct client *client )
         free ( client->pHostName );
     }
 
+    free ( client->sssb );
     freeListFree ( rsrvClientFreeList, client );
 }
 

--- a/modules/database/src/ioc/rsrv/server.h
+++ b/modules/database/src/ioc/rsrv/server.h
@@ -102,6 +102,7 @@ typedef struct client {
   unsigned              recvBytesToDrain;
   unsigned              priority;
   char                  disconnect; /* disconnect detected */
+  char                  *sssb; // scalar string scratch buffer
 } client;
 
 /* Channel state shows which struct client list a


### PR DESCRIPTION
~Two~ Some RSRV related changes.

I found myself getting confused about where in `write_action()` and especially `write_notify_action()` the `pPayload` buffer was being accessed.  To clarify this I have first extended 33f4d15ff340d4af428d2b111e9d84bbaadf5087 to remove the now unused `pPayload` argument from `log_header()` and friends.  This adds a lot of churn.

A fix for #943, an alternative to #944.  Comes in two parts.

For `write_action()`.  Adds a 40 bytes "scratch" buffer to `struct client` for use in the case of a truncated PUT to a scalar string.  So downstream code will always see a buffer backed by the promised number of bytes.  Does enforce a null terminating byte, although I think this should not be necessary.

For `write_notify_action()`.  Signification rearranging to separate wait/cancel of previous PUT from handling of next PUT.  These two pieces of code are almost entirely unrelated, and having the cancel code right in the middle made it more difficult to follow the logic and usage of `pPayload`.  This adds a fair amount of churn, but I think the end result is easier to follow.

Finally, add checks on `nRequest` to `dbPut()` and `dbPutField()` code paths.  Error if negative counts get that far.  Also, handle zero count in `dbPutFieldLink()` with DBR_CHAR, and count not one in the DBR_STRING case..