### PR TITLE
Use sort to compare RTEMS_VERSION

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -1,6 +1,12 @@
+# CONFIG.Common.RTEMS-mvme2700
+#
+# Definitions for the RTEMS-mvme2700 target
+# Site-specific overrides go in CONFIG_SITE.Common.RTEMS-mvme2700
 #
 # Author: Matt Rippa
 #
+#-------------------------------------------------------
+
 RTEMS_TARGET_CPU = powerpc
 ARCH_DEP_CFLAGS += -DMY_DO_BOOTP=NULL
 ARCH_DEP_CFLAGS += -DHAVE_PPCBUG
@@ -23,8 +29,10 @@ endef
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS
 
-ifeq ($(shell test $(RTEMS_VERSION) -ge 5; echo $$?),0)
-RTEMS_BSP = mvme2700
+ifeq ($(sort $(RTEMS_VERSION) 5),$(RTEMS_VERSION) 5)
+  # RTEMS 4.x used this BSP name
+  RTEMS_BSP = mvme2307
 else
-RTEMS_BSP = mvme2307
+  # RTEMS 5+ support our name
+  RTEMS_BSP = mvme2700
 endif

--- a/configure/os/CONFIG.Common.RTEMS-pc386
+++ b/configure/os/CONFIG.Common.RTEMS-pc386
@@ -25,8 +25,8 @@ include $(CONFIG)/os/CONFIG.Common.RTEMS
 OP_SYS_LDFLAGS += -Wl,-Ttext,0x100000
 
 # This check must appear after the above include
-ifeq ($(shell test $(RTEMS_VERSION) -ge 5; echo $$?),0)
+ifneq ($(sort $(RTEMS_VERSION) 5),$(RTEMS_VERSION) 5)
   $(info *** This target is not compatible with the configured RTEMS version.)
-  $(info *** Build the RTEMS-pc686 (-qemu) target for RTEMS 5.x)
+  $(info *** Build the RTEMS-pc686 (-qemu) target for RTEMS 5 and later)
   $(error Can't continue)
 endif

--- a/configure/os/CONFIG.Common.RTEMS-pc686
+++ b/configure/os/CONFIG.Common.RTEMS-pc686
@@ -31,7 +31,7 @@ OP_SYS_LDFLAGS += -Wl,-Ttext,0x100000 -Wl,--gc-sections
 
 
 # This check must appear after the above include
-ifeq ($(shell test $(RTEMS_VERSION) -lt 5; echo $$?),0)
+ifeq ($(sort $(RTEMS_VERSION) 5),$(RTEMS_VERSION) 5)
   $(info *** This target is not compatible with the configured RTEMS version.)
   $(info *** Build the RTEMS-pc386 (-qemu) target for RTEMS 4.x)
   $(error Can't continue)


### PR DESCRIPTION
Fixes #950, extraneous messages in RTEMS 4.9 builds:
```
/bin/bash: line 1: test: 4.9: integer expression expected
```
