### PR TITLE
dbChannel sanity check

### DIFF
--- a/modules/database/src/ioc/db/dbAccess.c
+++ b/modules/database/src/ioc/db/dbAccess.c
@@ -627,6 +627,7 @@ all_done:
 
 long dbEntryToAddr(const DBENTRY *pdbentry, DBADDR *paddr)
 {
+    long ret = 0;
     dbFldDes *pflddes = pdbentry->pflddes;
     short dbfType = pflddes->field_type;
 
@@ -644,10 +645,34 @@ long dbEntryToAddr(const DBENTRY *pdbentry, DBADDR *paddr)
 
         /* Let record type modify paddr */
         if (prset && prset->cvt_dbaddr) {
-            return prset->cvt_dbaddr(paddr);
+            ret = prset->cvt_dbaddr(paddr);
+        }
+        long size = dbValueSize(paddr->field_type);
+        if(ret) {
+            // oops
+
+        } else if(paddr->field_type == DBF_NOACCESS) {
+            // not directly usable, so anything goes...
+
+        } else if(paddr->no_elements == 0 || paddr->field_size == 0) {
+            // max. element count, or element stroage, of zero is unusable
+            ret = S_dbLib_badDbAddr;
+
+        } else if(paddr->field_type == DBF_STRING
+                  && (paddr->field_size <= 1
+                      || (paddr->no_elements > 1
+                          && paddr->field_size != MAX_STRING_SIZE)))
+        {
+            // A useful string needs at least 2 bytes of storage.
+            // Array of strings must provide exactly 40 bytes per element.
+            ret = S_dbLib_badDbAddr;
+
+        } else if(paddr->field_type > DBF_STRING && paddr->field_size != size) {
+            // for primative types other than STRING, provided element storage must be exact
+            ret = S_dbLib_badDbAddr;
         }
     }
-    return 0;
+    return ret;
 }
 
 /*

--- a/modules/database/src/ioc/db/dbTest.c
+++ b/modules/database/src/ioc/db/dbTest.c
@@ -22,6 +22,7 @@
 #include "epicsStdlib.h"
 #include "epicsString.h"
 #include "errlog.h"
+#include "errSymTbl.h"
 
 #include "callback.h"
 #include "dbAccessDefs.h"
@@ -789,7 +790,7 @@ static long nameToAddr(const char *pname, DBADDR *paddr)
     long status = dbNameToAddr(pname, paddr);
 
     if (status) {
-        printf("PV '%s' not found\n", pname);
+        printf("PV '%s' %s (0x%lx)\n", pname, errSymMsg(status), status);
     }
     return status;
 }

--- a/modules/database/src/ioc/dbStatic/dbLexRoutines.c
+++ b/modules/database/src/ioc/dbStatic/dbLexRoutines.c
@@ -752,14 +752,18 @@ static void dbRecordtypeBody(void)
         if(pdbFldDes->promptgroup) no_prompt++;
         field_type = pdbFldDes->field_type;
         if((field_type>=DBF_INLINK) && (field_type<=DBF_FWDLINK))no_links++;
-        if((field_type==DBF_STRING) && (pdbFldDes->size==0))
+        if((field_type==DBF_STRING) && (pdbFldDes->size<=1)) {
             fprintf(stderr, ERL_ERROR
-                ": recordtype(%s).%s size not specified\n",
-                pdbRecordType->name,pdbFldDes->name);
-        if((field_type==DBF_NOACCESS) && (pdbFldDes->extra==0))
+                ": recordtype(%s).%s size %d too small\n",
+                pdbRecordType->name,pdbFldDes->name,pdbFldDes->size);
+            yyerror("STRING field size too small");
+        }
+        if((field_type==DBF_NOACCESS) && (pdbFldDes->extra==0)) {
             fprintf(stderr, ERL_ERROR
                 ": recordtype(%s).%s extra not specified\n",
                 pdbRecordType->name,pdbFldDes->name);
+            yyerror("NOACCESS field missing extra()");
+        }
     }
     if (ellCount(&tempList))
         yyerrorAbort("dbRecordtypeBody: tempList not empty");

--- a/modules/database/src/ioc/dbStatic/dbStaticLib.h
+++ b/modules/database/src/ioc/dbStatic/dbStaticLib.h
@@ -268,6 +268,7 @@ extern int dbConvertStrict;
 #define S_dbLib_infoNotFound (M_dbLib|29)        /* Info item Not Found */
 #define S_dbLib_postInitRecRegister (M_dbLib|31) /* IOC already initialized - No new records can be added */
 #define S_dbLib_recordNameMissing (M_dbLib|33)   /* Record name is required */
+#define S_dbLib_badDbAddr (M_dbLib|34)           /* Record support cvt_dbaddr logic error */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Apply some sanity checks for newly parsed `dbFldDes` (contents of `.dbd` file), and newly created `dbChannel` (taking into `rset::cvt_dbaddr()`).

Statements which I think are always true...

* Excluding `DBF_NOACCESS`, any `dbChannel` must have non-zero field_size _and_ max. element count.
* A scalar `DBF_STRING` (max. element count of 1) must have field_size sufficient for a null and one other character.
* For an array `DBF_STRING` (max. element count > 1) must have field_size exactly 40.
* For all field types except NOACCESS and STRING, field_size must be exactly as expected (as defined by `dbValueSize()`).

Several existing "error" check in the .db parser are made fatal, and one is extended.  I see these as "semantic" errors, to be signaled by the `yyerror()` (but not immediately `yyerrorAbort()`).  cf. https://github.com/epics-base/epics-base/issues/939#issuecomment-5260070530

The errors in `dbChannelCreate()` and friends are signaled by a new error code `S_dbLib_badDbAddr`.

The iocsh `dbgf` and friends are modified to print a more specific message than "not found".  This looks like:

```
    epics> dbgf TEST:SCO.PAQ
    PV 'TEST:SCO.PAQ' Field Not Found (0x2000009)
    epics> dbgf TEST:SC
    PV 'TEST:SC' Record Not Found (0x2000005)
```