### PR TITLE
Corrected copy'paste mistake in mbbiDirectRecord.dbd.pod and mbboDire…

### DIFF
--- a/modules/database/src/std/dev/devMbbiDirectSoft.c
+++ b/modules/database/src/std/dev/devMbbiDirectSoft.c
@@ -27,11 +27,11 @@
 
 /* Create the dset for devMbbiDirectSoft */
 static long init_record(dbCommon *pcommon);
-static long read_mbbi(mbbiDirectRecord *prec);
+static long read_mbbiDirect(mbbiDirectRecord *prec);
 
 mbbidirectdset devMbbiDirectSoft = {
     {5, NULL, NULL, init_record, NULL},
-    read_mbbi
+    read_mbbiDirect
 };
 epicsExportAddress(dset, devMbbiDirectSoft);
 
@@ -60,7 +60,7 @@ static long readLocked(struct link *pinp, void *dummy)
     return 2;
 }
 
-static long read_mbbi(mbbiDirectRecord *prec)
+static long read_mbbiDirect(mbbiDirectRecord *prec)
 {
     long status = dbLinkDoLocked(&prec->inp, readLocked, NULL);
 

--- a/modules/database/src/std/dev/devMbbiDirectSoftRaw.c
+++ b/modules/database/src/std/dev/devMbbiDirectSoftRaw.c
@@ -27,11 +27,11 @@
 
 /* Create the dset for devMbbiDirectSoftRaw */
 static long init_record(dbCommon *pcommon);
-static long read_mbbi(mbbiDirectRecord *prec);
+static long read_mbbiDirect(mbbiDirectRecord *prec);
 
 mbbidirectdset devMbbiDirectSoftRaw = {
     {5, NULL, NULL, init_record, NULL},
-    read_mbbi
+    read_mbbiDirect
 };
 epicsExportAddress(dset, devMbbiDirectSoftRaw);
 
@@ -49,7 +49,7 @@ static long init_record(dbCommon *pcommon)
     return 0;
 }
 
-static long read_mbbi(mbbiDirectRecord *prec)
+static long read_mbbiDirect(mbbiDirectRecord *prec)
 {
     if (!dbGetLink(&prec->inp, DBR_ULONG, &prec->rval, 0, 0)) {
         prec->rval &= prec->mask;

--- a/modules/database/src/std/dev/devMbboDirectSoft.c
+++ b/modules/database/src/std/dev/devMbboDirectSoft.c
@@ -20,7 +20,7 @@
 #include "mbboDirectRecord.h"
 #include "epicsExport.h"
 
-static long write_mbbo(mbboDirectRecord *prec)
+static long write_mbboDirect(mbboDirectRecord *prec)
 {
     dbPutLink(&prec->out, DBR_ULONG, &prec->val, 1);
     return 0;
@@ -29,6 +29,6 @@ static long write_mbbo(mbboDirectRecord *prec)
 /* Create the dset for devMbboDirectSoft */
 mbbodirectdset devMbboDirectSoft = {
     {5, NULL, NULL, NULL, NULL},
-    write_mbbo
+    write_mbboDirect
 };
 epicsExportAddress(dset, devMbboDirectSoft);

--- a/modules/database/src/std/dev/devMbboDirectSoftCallback.c
+++ b/modules/database/src/std/dev/devMbboDirectSoftCallback.c
@@ -22,7 +22,7 @@
 #include "mbboDirectRecord.h"
 #include "epicsExport.h"
 
-static long write_mbbo(mbboDirectRecord *prec)
+static long write_mbboDirect(mbboDirectRecord *prec)
 {
     struct link *plink = &prec->out;
     long status;
@@ -42,6 +42,6 @@ static long write_mbbo(mbboDirectRecord *prec)
 /* Create the dset for devMbboDirectSoftCallback */
 mbbodirectdset devMbboDirectSoftCallback = {
     {5, NULL, NULL, NULL, NULL},
-    write_mbbo
+    write_mbboDirect
 };
 epicsExportAddress(dset, devMbboDirectSoftCallback);

--- a/modules/database/src/std/dev/devMbboDirectSoftRaw.c
+++ b/modules/database/src/std/dev/devMbboDirectSoftRaw.c
@@ -33,7 +33,7 @@ static long init_record(dbCommon *pcommon)
     return 2; /* Don't convert */
 }
 
-static long write_mbbo(mbboDirectRecord *prec)
+static long write_mbboDirect(mbboDirectRecord *prec)
 {
     epicsUInt32 data;
 
@@ -45,6 +45,6 @@ static long write_mbbo(mbboDirectRecord *prec)
 /* Create the dset for devMbboDirectSoftRaw */
 mbbodirectdset devMbboDirectSoftRaw = {
     {5, NULL, NULL, init_record, NULL},
-    write_mbbo
+    write_mbboDirect
 };
 epicsExportAddress(dset, devMbboDirectSoftRaw);

--- a/modules/database/src/std/rec/mbbiDirectRecord.c
+++ b/modules/database/src/std/rec/mbbiDirectRecord.c
@@ -100,7 +100,7 @@ static long init_record(struct dbCommon *pcommon, int pass)
         return S_dev_noDSET;
     }
 
-    if ((pdset->common.number < 5) || (pdset->read_mbbi == NULL)) {
+    if ((pdset->common.number < 5) || (pdset->read_mbbiDirect == NULL)) {
         recGblRecordError(S_dev_missingSup, prec, "mbbiDirect: init_record");
         return S_dev_missingSup;
     }
@@ -137,9 +137,9 @@ static long process(struct dbCommon *pcommon)
     long status;
     int pact = prec->pact;
 
-    if ((pdset == NULL) || (pdset->read_mbbi == NULL)) {
+    if ((pdset == NULL) || (pdset->read_mbbiDirect == NULL)) {
         prec->pact = TRUE;
-        recGblRecordError(S_dev_missingSup, prec, "read_mbbi");
+        recGblRecordError(S_dev_missingSup, prec, "read_mbbiDirect");
         return S_dev_missingSup;
     }
 
@@ -250,7 +250,7 @@ static long readValue(mbbiDirectRecord *prec)
 
     switch (prec->simm) {
     case menuSimmNO:
-        status = pdset->read_mbbi(prec);
+        status = pdset->read_mbbiDirect(prec);
         break;
 
     case menuSimmYES:

--- a/modules/database/src/std/rec/mbbiDirectRecord.dbd.pod
+++ b/modules/database/src/std/rec/mbbiDirectRecord.dbd.pod
@@ -87,7 +87,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
     %struct mbbiDirectRecord;
     %typedef struct mbbidirectdset {
     %    dset common; /* init_record returns: (-1,0) => (failure, success)*/
-    %    long (*read_mbbi)(struct mbbiDirectRecord *prec); /* (0, 2) => (success, success no convert)*/
+    %    long (*read_mbbiDirect)(struct mbbiDirectRecord *prec); /* (0, 2) => (success, success no convert)*/
     %} mbbidirectdset;
     %#define HAS_mbbidirectdset
     %
@@ -591,7 +591,7 @@ read_mbbiDirect calls recGblGetLinkValue to read the current value of VAL.
 
 See L<Input Records> for a further explanation.
 
-If the return status of recGblGetLinkValue is zero, then read_mbbi sets UDF to
+If the return status of recGblGetLinkValue is zero, then read_mbbiDirect sets UDF to
 FALSE. The status of recGblGetLinkValue is returned.
 
 =head4 Raw Soft Channel

--- a/modules/database/src/std/rec/mbboDirectRecord.c
+++ b/modules/database/src/std/rec/mbboDirectRecord.c
@@ -109,7 +109,7 @@ static long init_record(struct dbCommon *pcommon, int pass)
         return S_dev_noDSET;
     }
 
-    if ((pdset->common.number < 5) || (pdset->write_mbbo == NULL)) {
+    if ((pdset->common.number < 5) || (pdset->write_mbboDirect == NULL)) {
         recGblRecordError(S_dev_missingSup, prec, "mbboDirect: init_record");
         return S_dev_missingSup;
     }
@@ -170,9 +170,9 @@ static long process(struct dbCommon *pcommon)
     long status = 0;
     int pact = prec->pact;
 
-    if ((pdset == NULL) || (pdset->write_mbbo == NULL)) {
+    if ((pdset == NULL) || (pdset->write_mbboDirect == NULL)) {
         prec->pact = TRUE;
-        recGblRecordError(S_dev_missingSup, prec, "write_mbbo");
+        recGblRecordError(S_dev_missingSup, prec, "write_mbboDirect");
         return S_dev_missingSup;
     }
 
@@ -360,7 +360,7 @@ static long writeValue(mbboDirectRecord *prec)
 
     switch (prec->simm) {
     case menuSimmNO:
-        status = pdset->write_mbbo(prec);
+        status = pdset->write_mbboDirect(prec);
         break;
 
     case menuSimmYES:

--- a/modules/database/src/std/rec/mbboDirectRecord.dbd.pod
+++ b/modules/database/src/std/rec/mbboDirectRecord.dbd.pod
@@ -130,7 +130,7 @@ Parameters> for more on the record name (NAME) and description (DESC) fields.
     %struct mbboDirectRecord;
     %typedef struct mbbodirectdset {
     %    dset common; /*init_record returns: (0, 2)=>(success, success no convert)*/
-    %    long (*write_mbbo)(struct mbboDirectRecord *prec); /*returns: (0, 2)=>(success, success no convert)*/
+    %    long (*write_mbboDirect)(struct mbboDirectRecord *prec); /*returns: (0, 2)=>(success, success no convert)*/
     %} mbbodirectdset;
     %#define HAS_mbbodirectdset
     %


### PR DESCRIPTION
…ctRecord.dbd.pod which refer to the 'normal' mbbi and mbbo access routines.

This addresses https://github.com/epics-base/epics-base/issues/962